### PR TITLE
[fix] update path resolution to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,13 +44,12 @@
   },
   "homepage": "https://github.com/okonet/lint-staged#readme",
   "dependencies": {
+    "app-root-path": "^1.2.1",
     "minimatch": "^3.0.0",
     "npm-which": "^2.0.0",
     "object-assign": "^4.1.0",
     "ora": "^0.2.3",
-    "staged-git-files": "0.0.4",
-    "strip-eof": "^1.0.0",
-    "which": "^1.2.9"
+    "staged-git-files": "0.0.4"
   },
   "devDependencies": {
     "eslint": "^2.9.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,12 @@
-var path = require('path');
 var cp = require('child_process');
 var sgf = require('staged-git-files');
 var minimatch = require('minimatch');
 var ora = require('ora');
-var which = require('which');
 var npmWhich = require('npm-which')(process.cwd());
-var stripEof = require('strip-eof');
 var assign = require('object-assign');
 
-var gitBin = which.sync('git');
-var root = cp.execSync(gitBin + ' rev-parse --show-toplevel', { encoding: 'utf8' });
-var config = require(path.join(stripEof(root), 'package.json'));
+var appRoot = require('app-root-path');
+var config = require(appRoot.resolve('package.json'));
 var defaultLinters = {};
 var customLinters = config['lint-staged'];
 var linters = assign(defaultLinters, customLinters);


### PR DESCRIPTION
Hi, I liked this module and would like to utilize this in some of my codebases, sending PR to enhance couple of behavior.

- resolve root path via app-root-path, provides platform compatible path
: Usually for Windows user who runs different shells will have issues by determining root via `git` can returns shell-specific path like `\c\apps\myapp...`. instead, introduced `app-root-path` (https://github.com/inxilpro/node-app-root-path) to resolve root path to application.

- fixes npm-which invocation to correctly resolves npm
one thing I noticed is this module calls `npm-which` with name of `linter` as `npmWhich(linter,...)` which causes npm-which fails all time since npm-which expects file to lookup (npm, in this case). Updated to lookup npm, leave fallback to default binPath as-is.