### PR TITLE
Work with no scripts in package.json

### DIFF
--- a/src/findBin.js
+++ b/src/findBin.js
@@ -7,7 +7,7 @@ module.exports = function findBin (binName, paths, config, cb) {
     * If package.json has script with binName defined
     * we want it to be executed first
     */
-    if (config.scripts[binName] !== undefined) {
+    if (config.scripts && config.scripts[binName] !== undefined) {
         // Support for scripts from package.json
         cb.call(this, null, binPath, args)
     } else {

--- a/test/findBin.spec.js
+++ b/test/findBin.spec.js
@@ -43,6 +43,16 @@ describe('findBin', () => {
         })
     })
 
+    it('should return bin from node_modules/.bin on missed scripts in package.json', done => {
+        findBin.__set__('npmWhich', npmWichMockGood)
+        findBin('eslint', 'test.js test2.js', { }, (err, bin, args) => {
+            expect(err).toBe(null)
+            expect(bin).toEqual('eslint')
+            expect(args).toEqual(['--', 'test.js test2.js'])
+            done()
+        })
+    })
+
     it('should return error if bin not found and there is no entry in scripts section', () => {
         findBin.__set__('npmWhich', npmWichMockBad)
         expect(() => {


### PR DESCRIPTION
In testing `lint-staged` for #41 and found that `lint-staged` doesn’t work if `package.json` has no `scripts` section.

This little PR fixes it.