### PR TITLE
Use babel-register instead of babel-core/register

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint:fix": "npm run lint -- --fix",
     "pre-commit": "node index.js",
     "release": "npmpub",
-    "test": "mocha --compilers js:babel-core/register ./test/*.spec.js",
+    "test": "mocha --compilers js:babel-register ./test/*.spec.js",
     "deps": "npm-check -s",
     "deps:update": "npm-check -u"
   },
@@ -62,6 +62,7 @@
     "babel-core": "^6.10.4",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-stage-0": "^6.5.0",
+    "babel-register": "^6.16.3",
     "eslint": "^3.2.0",
     "eslint-config-standard": "^6.0.0",
     "eslint-plugin-import": "^1.14.0",


### PR DESCRIPTION
In `babel-core/register.js`:

```js
/* eslint max-len: 0 */
// TODO: eventually deprecate this console.trace("use the `babel-register` package instead of `babel-core/register`");
module.exports = require("babel-register");
```