### PR TITLE
Show simpler pattern for matching js/jsx

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ All examples assuming you’ve already set up lint-staged and pre-commit in the 
 
 ```json
 {
-	"*.@(js|jsx)": "eslint"
+	"*.{js,jsx}": "eslint"
 }
 ```
 


### PR DESCRIPTION
It’s simpler and probably more common. Never seen `@(js|jsx)` but something like `{js,jsx}` I use very often.