### PR TITLE
chore: Added commitizen conventional changelog

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-stage-0": "^6.5.0",
     "babel-register": "^6.16.3",
+    "cz-conventional-changelog": "^1.2.0",
     "eslint": "^3.9.1",
     "eslint-config-okonet": "^1.1.1",
     "expect": "^1.20.2",
@@ -67,5 +68,10 @@
     "pre-commit": "^1.1.3",
     "rewire": "^2.5.1",
     "tmp": "^0.0.29"
+  },
+  "config": {
+    "commitizen": {
+      "path": "./node_modules/cz-conventional-changelog"
+    }
   }
 }


### PR DESCRIPTION
Allows using https://github.com/commitizen/cz-cli with https://www.npmjs.com/package/cz-conventional-changelog to improve commit messages

So, instead of

```bash
git commit
```

please do

```bash
git cz
```