### PR TITLE
If `gitDir` is set pass it as `cwd` option to execa

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,11 @@ cosmiconfig('lint-staged', {
             const tasks = generateTasks(config, resolvePaths(files, gitDir))
                 .map(task => ({
                     title: `Running tasks for ${ task.pattern }`,
-                    task: () => (new Listr(runScript(task.commands, task.fileList, packageJson)))
+                    task: () => (
+                        new Listr(
+                            runScript(task.commands, task.fileList, packageJson, gitDir)
+                        )
+                    )
                 }))
 
 

--- a/src/runScript.js
+++ b/src/runScript.js
@@ -3,15 +3,16 @@
 const findBin = require('./findBin')
 const execa = require('execa')
 
-module.exports = function runScript(commands, pathsToLint, packageJson) {
+module.exports = function runScript(commands, pathsToLint, packageJson, gitDir) {
     const lintersArray = Array.isArray(commands) ? commands : [commands]
+    const execaOptions = gitDir ? { cwd: gitDir } : {}
     return lintersArray.map(linter => ({
         title: linter,
         task: () => {
             try {
                 const res = findBin(linter, pathsToLint, packageJson)
                 return new Promise((resolve, reject) => {
-                    execa(res.bin, res.args)
+                    execa(res.bin, res.args, execaOptions)
                         .then(() => {
                             resolve(`${ linter } passed!`)
                         })

--- a/test/runScript.spec.js
+++ b/test/runScript.spec.js
@@ -57,13 +57,30 @@ describe('runScript', () => {
         expect(res[0].task()).toBeAPromise()
         expect(spy.calls.length).toEqual(1)
         expect(spy.calls[0].arguments).toEqual(
-            ['npm', ['run', '--silent', 'test', '--', 'test.js']]
+            ['npm', ['run', '--silent', 'test', '--', 'test.js'], {}]
         )
 
         expect(res[1].task()).toBeAPromise()
         expect(spy.calls.length).toEqual(2)
         expect(spy.calls[1].arguments).toEqual(
-            ['npm', ['run', '--silent', 'test2', '--', 'test.js']]
+            ['npm', ['run', '--silent', 'test2', '--', 'test.js'], {}]
+        )
+    })
+
+    it('should pass cwd option to execa if gitDir option is set', () => {
+        const spy = expect.createSpy()
+        runScript.__set__('execa', spy)
+        const res = runScript(['test', 'test2'], 'test.js', packageJSON, '../')
+        expect(res[0].task()).toBeAPromise()
+        expect(spy.calls.length).toEqual(1)
+        expect(spy.calls[0].arguments).toEqual(
+            ['npm', ['run', '--silent', 'test', '--', 'test.js'], { cwd: '../' }]
+        )
+
+        expect(res[1].task()).toBeAPromise()
+        expect(spy.calls.length).toEqual(2)
+        expect(spy.calls[1].arguments).toEqual(
+            ['npm', ['run', '--silent', 'test2', '--', 'test.js'], { cwd: '../' }]
         )
     })
 })


### PR DESCRIPTION
In case of running lint-stage from a sub-directory,
execa should be also run with `cwd` option set correctly to the git dir.

Closes #109