### PR TITLE
fix(resolvePaths): return CWD-relative paths - closes #115

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,8 +70,7 @@
     "npm-check": "^5.2.2",
     "pre-commit": "^1.1.3",
     "rewire": "^2.5.1",
-    "semantic-release": "^6.3.2",
-    "tmp": "^0.0.31"
+    "semantic-release": "^6.3.2"
   },
   "config": {
     "commitizen": {

--- a/src/resolvePaths.js
+++ b/src/resolvePaths.js
@@ -3,8 +3,7 @@
 const path = require('path')
 
 module.exports = function resolvePaths(filePaths, relativeTo) {
-    return filePaths.map((file) => {
-        if (!relativeTo) relativeTo = process.cwd() // eslint-disable-line
-        return path.resolve(path.relative(process.cwd(), relativeTo), file.filename)
-    })
+    const cwd = process.cwd()
+    const base = relativeTo || cwd
+    return filePaths.map(file => path.relative(cwd, path.resolve(base, file.filename)))
 }

--- a/test/resolvePaths.spec.js
+++ b/test/resolvePaths.spec.js
@@ -3,15 +3,13 @@
 import expect from 'expect'
 import path from 'path'
 import fs from 'fs'
-import tmp from 'tmp'
 import resolvePaths from '../src/resolvePaths'
 
 const files = fs.readdirSync(path.resolve('test', '__fixtures__')).map(file => ({
     filename: file
 }))
 
-const cwd = process.cwd()
-const cwdParent = path.relative(cwd, '..')
+const cwdParent = path.resolve('..')
 
 describe('resolvePaths', () => {
     it('should return Array of filenames', () => {
@@ -22,22 +20,17 @@ describe('resolvePaths', () => {
                 'test.css',
                 'test.js',
                 'test.txt'
-            ].map(file => path.resolve(cwd, file))
+            ]
         )
     })
 
-    it('should return relative paths if second parameter is set', () => {
-        expect(resolvePaths(files, '..')).toEqual(
+    it('should return CWD-relative paths if second parameter is set', () => {
+        expect(resolvePaths(files, cwdParent)).toEqual(
             [
                 'test.css',
                 'test.js',
                 'test.txt'
-            ].map(file => path.resolve(cwdParent, file))
+            ].map(file => path.join('..', file))
         )
-    })
-
-    it('should return absolute paths if they were absolute', () => {
-        const tmpFile = tmp.fileSync()
-        expect(resolvePaths([{ filename: tmpFile.name }], '..')).toEqual([tmpFile.name])
     })
 })


### PR DESCRIPTION
Fixes #115 by making resolvePaths() return paths that are relative to CWD. Should gitDir be set to `..`, the returned path for `alpha.js` would be `../alpha.js`.

I haven't looked too closely at all of the path computations, but it feels like this could be simplified further.