### PR TITLE
Bug fix for issue #114

### DIFF
--- a/src/runScript.js
+++ b/src/runScript.js
@@ -5,10 +5,10 @@ const execa = require('execa')
 
 module.exports = function runScript(commands, pathsToLint, packageJson, gitDir) {
     const lintersArray = Array.isArray(commands) ? commands : [commands]
-    const execaOptions = gitDir ? { cwd: gitDir } : {}
     return lintersArray.map(linter => ({
         title: linter,
         task: () => {
+            const execaOptions = gitDir ? { cwd: gitDir } : {}
             try {
                 const res = findBin(linter, pathsToLint, packageJson)
                 return new Promise((resolve, reject) => {


### PR DESCRIPTION
On Windows, if the same `execaOptions` are re-used for running 'linters' in [runScripts.js](/okonet/lint-staged/blob/master/src/runScript.js) `windowsVerbatimArguments: true` options will be added  which breaks the `git add` command if present with following error:
```
{ Error: spawn undefined ENOENT
    at notFoundError (E:\workspace\odyssey\node_modules\cross-spawn\lib\enoent.js:11:11)
    at verifyENOENT (E:\workspace\odyssey\node_modules\cross-spawn\lib\enoent.js:46:16)
    at ChildProcess.cp.emit (E:\workspace\odyssey\node_modules\cross-spawn\lib\enoent.js:33:19)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:215:12)
  errno: 'ENOENT',
  code: 'ENOENT',
  syscall: 'spawn undefined',
  killed: false,
  stdout: '',
  stderr: 'git: \'Files\\Git\\cmd\\git.EXE\' is not a git command. See \'git --help\'.\n',
  failed: true,
  signal: null,
  cmd: 'C:\\Program Files\\Git\\cmd\\git.EXE add -- E:\\workspace\\odyssey\\build\\webpack.base.conf.js',
  timedOut: false }
```

Error is reproducible using this simple script:

```js
'use strict';

const execa = require('execa');

const res = {
    bin: 'C:\\Program Files\\Git\\cmd\\git.EXE',
    args: [
        'add',
        '--',
        'E:\\workspace\\odyssey\\build\\webpack.base.conf.js'
    ]
};

execa(res.bin, res.args, {
        cwd: 'E:\\workspace\\odyssey',
        windowsVerbatimArguments: true
    })
    .then(() => {
        console.log('worked!');
    })
    .catch(err => {
        console.log(err);
    });

```