### PR TITLE
WIP feat(trackChanged)

### DIFF
--- a/src/changedGitFiles.js
+++ b/src/changedGitFiles.js
@@ -1,0 +1,28 @@
+const { exec } = require('child_process')
+
+module.exports = function changedGitFiles(opMode, callback) {
+    const gitDiffCmd = 'git diff-tree -r --name-only --no-commit-id'
+    let revA = 'HEAD@{1}'
+    let revB = 'HEAD'
+
+    if (opMode === 'checkout') {
+        const params = process.env.GIT_PARAMS.split(' ')
+
+        if (params[2] === '0') {
+            // Exit early if this was only a file checkout, not a branch change ($3 == 1)
+            callback(null, [])
+            return
+        }
+
+        revA = params[0]
+        revB = params[1]
+    }
+
+    exec(`${ gitDiffCmd } ${ revA } ${ revB }`, (err, sources) => {
+        if (err) {
+            callback(err)
+        } else {
+            callback(null, sources.split('\n').map(filename => ({ filename })))
+        }
+    })
+}

--- a/src/index.js
+++ b/src/index.js
@@ -12,11 +12,53 @@ const cosmiconfig = require('cosmiconfig')
 const packageJson = require(appRoot.resolve('package.json')) // eslint-disable-line
 const runScript = require('./runScript')
 const generateTasks = require('./generateTasks')
+const cgf = require('./changedGitFiles')
 
 // Force colors for packages that depend on https://www.npmjs.com/package/supports-color
 // but do this only in TTY mode
 if (process.stdout.isTTY) {
     process.env.FORCE_COLOR = true
+}
+
+const gitFilesCallback = opts => (err, files) => {
+    if (err) {
+        console.error(err)
+    }
+
+    if (!files || files.length === 0) {
+        return
+    }
+
+    const { config, verbose, concurrent, renderer, gitDir } = opts
+    const resolvedFiles = {}
+    files.forEach((file) => {
+        const absolute = path.resolve(gitDir, file.filename)
+        const relative = path.relative(gitDir, absolute)
+        resolvedFiles[relative] = absolute
+    })
+
+    const tasks = generateTasks(config, resolvedFiles)
+        .map(task => ({
+            title: `Running tasks for ${ task.pattern }`,
+            task: () => (
+                new Listr(
+                    runScript(
+                        task.commands,
+                        task.fileList,
+                        packageJson,
+                        { gitDir, verbose }
+                    )
+                )
+            )
+        }))
+
+
+    if (tasks.length) {
+        new Listr(tasks, { concurrent, renderer }).run().catch((error) => {
+            console.error(error.message)
+            process.exit(1)
+        })
+    }
 }
 
 cosmiconfig('lint-staged', {
@@ -33,43 +75,18 @@ cosmiconfig('lint-staged', {
         const concurrent = typeof config.concurrent !== 'undefined' ? config.concurrent : true
         const renderer = verbose ? 'verbose' : 'update'
         const gitDir = config.gitDir ? path.resolve(config.gitDir) : process.cwd()
-        sgf.cwd = gitDir
 
-        sgf('ACM', (err, files) => {
-            if (err) {
-                console.error(err)
-            }
+        const opMode = process.argv[2] || 'commit'
+        const callback = gitFilesCallback({ config, verbose, concurrent, renderer, gitDir })
 
-            const resolvedFiles = {}
-            files.forEach((file) => {
-                const absolute = path.resolve(gitDir, file.filename)
-                const relative = path.relative(gitDir, absolute)
-                resolvedFiles[relative] = absolute
-            })
-
-            const tasks = generateTasks(config, resolvedFiles)
-                .map(task => ({
-                    title: `Running tasks for ${ task.pattern }`,
-                    task: () => (
-                        new Listr(
-                            runScript(
-                                task.commands,
-                                task.fileList,
-                                packageJson,
-                                { gitDir, verbose }
-                            )
-                        )
-                    )
-                }))
-
-
-            if (tasks.length) {
-                new Listr(tasks, { concurrent, renderer }).run().catch((error) => {
-                    console.error(error.message)
-                    process.exit(1)
-                })
-            }
-        })
+        if (['checkout', 'merge', 'rewrite'].includes(opMode)) {
+            cgf(opMode, callback)
+        } else if (opMode === 'commit') {
+            sgf.cwd = gitDir
+            sgf('ACM', callback)
+        } else {
+            console.error(`Unknown op mode ${ opMode }. Make sure your setup is correct.`)
+        }
     })
     .catch((parsingError) => {
         console.error(`Could not parse lint-staged config.


### PR DESCRIPTION
Regarding #127, initial takes.

Add different op-modes to switch between staged and diffed files handling (commit <> checkout,
merge, rewrite). Handle diffed files the same style as it would be simple staged ones. Implement git
diff tree wrapper that would parse output to files array handling different hooks correct (checkout
<> merge, rewrite).

I've tried to do non breaking changes and everything works fine. Yet have things to decide on:

1. Config file
Adding track-changed functionality would require different config for that specific case. So it should be either nested to `lint-staged` (and adding nesting would seem to break things) or separate entry like `track-changed` one
```
"lint-staged": {
  "changed": {
    "yarn.lock": "yarn",
    "npm-shrinkwrap.json": "npm prune && npm install",
    "bower.json": "bower prune && bower install",
    "Gemfile.*": "bundle install"
  },
  "staged": {
    "*.js": [
      "eslint --fix",
      "git add"
    ]
  }
}
```
vs

```
"track-changed": {
  "yarn.lock": "yarn",
  "npm-shrinkwrap.json": "npm prune && npm install",
  "bower.json": "bower prune && bower install",
  "Gemfile.*": "bundle install"
},
"lint-staged": {
  "*.js": [
    "eslint --fix",
    "git add"
  ]
}
```

2. Passing default params.
At the moment lint-staged passes list of staged files to the specific task as args. Though if we want to just run `yarn` on hook it wouldn't make sense and cause an error
I've [tried to workaround that](https://github.com/morhetz/track-changed/blob/master/src/findBin.js#L39) with bash-like `$@` placeholder. However that would be another breaking change and we possibly want to keep things clear like `"js": "eslint"` and not `"js": "eslint $@"`