### PR TITLE
Fix: Wait for all tasks to finish before showing errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "app-root-path": "^2.0.0",
     "cosmiconfig": "^1.1.0",
     "execa": "^0.6.0",
-    "listr": "^0.10.0",
+    "listr": "^0.11.0",
     "minimatch": "^3.0.0",
     "npm-which": "^3.0.1",
     "staged-git-files": "0.0.4",


### PR DESCRIPTION
When running tasks in parallel (which is by default), we want to run all linters
and display all errors after they finished their work.

Fixes #86