### PR TITLE
Adding logging for when no files match a pattern.

### DIFF
--- a/src/generateTasks.js
+++ b/src/generateTasks.js
@@ -13,13 +13,10 @@ module.exports = function generateTasks(config, files) {
                 dot: true
             })
             const fileList = Object.keys(files).filter(filter).map(resolve)
-            if (fileList.length) {
-                return {
-                    pattern,
-                    commands,
-                    fileList
-                }
+            return {
+                pattern,
+                commands,
+                fileList
             }
-            return undefined
-        }).filter(Boolean) // Filter undefined values
+        })
 }

--- a/src/index.js
+++ b/src/index.js
@@ -48,24 +48,33 @@ cosmiconfig('lint-staged', {
             })
 
             const tasks = generateTasks(config, resolvedFiles)
-                .map(task => ({
-                    title: `Running tasks for ${ task.pattern }`,
-                    task: () => (
-                        new Listr(
-                            runScript(
-                                task.commands,
-                                task.fileList,
-                                packageJson,
-                                { gitDir, verbose }
-                            ), {
-                                // In sub-tasks we don't want to run concurrently
-                                // and we want to abort on errors
-                                concurrent: false,
-                                exitOnError: true
-                            }
+                .map((task) => {
+                    // If no files matched the pattern, there's nothing to do.
+                    if (!task.fileList) {
+                        console.log(`✅ No staged files match ${ task.pattern }`)
+                        // Return undefined so we know to ignore this task.
+                        return undefined
+                    }
+
+                    return {
+                        title: `Running tasks for ${ task.pattern }`,
+                        task: () => (
+                            new Listr(
+                                runScript(
+                                    task.commands,
+                                    task.fileList,
+                                    packageJson,
+                                    { gitDir, verbose }
+                                ), {
+                                    // In sub-tasks we don't want to run concurrently
+                                    // and we want to abort on errors
+                                    concurrent: false,
+                                    exitOnError: true
+                                }
+                            )
                         )
-                    )
-                }))
+                    }
+                }).filter(Boolean) // Filter out tasks with no matching files.
 
 
             if (tasks.length) {

--- a/src/index.js
+++ b/src/index.js
@@ -48,33 +48,30 @@ cosmiconfig('lint-staged', {
             })
 
             const tasks = generateTasks(config, resolvedFiles)
-                .map((task) => {
-                    // If no files matched the pattern, there's nothing to do.
-                    if (task.fileList.length === 0) {
-                        console.log(`✅ No staged files match ${ task.pattern }`)
-                        // Return undefined so we know to ignore this task.
-                        return undefined
-                    }
-
-                    return {
-                        title: `Running tasks for ${ task.pattern }`,
-                        task: () => (
-                            new Listr(
-                                runScript(
-                                    task.commands,
-                                    task.fileList,
-                                    packageJson,
-                                    { gitDir, verbose }
-                                ), {
-                                    // In sub-tasks we don't want to run concurrently
-                                    // and we want to abort on errors
-                                    concurrent: false,
-                                    exitOnError: true
-                                }
-                            )
+                .map(task => ({
+                    title: `Running tasks for ${ task.pattern }`,
+                    task: () => (
+                        new Listr(
+                            runScript(
+                                task.commands,
+                                task.fileList,
+                                packageJson,
+                                { gitDir, verbose }
+                            ), {
+                                // In sub-tasks we don't want to run concurrently
+                                // and we want to abort on errors
+                                concurrent: false,
+                                exitOnError: true
+                            }
                         )
+                    ),
+                    skip: () => {
+                        if (task.fileList.length === 0) {
+                            return `No staged files match ${ task.pattern }`
+                        }
+                        return false
                     }
-                }).filter(Boolean) // Filter out tasks with no matching files.
+                }))
 
 
             if (tasks.length) {

--- a/src/index.js
+++ b/src/index.js
@@ -50,7 +50,7 @@ cosmiconfig('lint-staged', {
             const tasks = generateTasks(config, resolvedFiles)
                 .map((task) => {
                     // If no files matched the pattern, there's nothing to do.
-                    if (!task.fileList) {
+                    if (task.fileList.length === 0) {
                         console.log(`✅ No staged files match ${ task.pattern }`)
                         // Return undefined so we know to ignore this task.
                         return undefined

--- a/test/generateTasks.spec.js
+++ b/test/generateTasks.spec.js
@@ -58,17 +58,15 @@ describe('generateTasks', () => {
         ])
     })
 
-    it('should return only linters it could find files for', () => {
+    it('should return an empty file list for linters with no matches.', () => {
         const result = generateTasks(linters, files)
-        const commands = result.map(match => match.commands)
-        expect(commands).toEqual([
-            'root-js',
-            'any-js',
-            'deeper-js',
-            'hidden-js',
-            // 'unknown-js' does not match any files
-            'root-css-or-js'
-        ])
+        for (const task of result) {
+            if (task.commands === 'unknown-js') {
+                expect(task.fileList.length).toEqual(0)
+            } else {
+                expect(task.fileList.length).toNotEqual(0)
+            }
+        }
     })
 
     it('should match pattern "*.js"', () => {


### PR DESCRIPTION
This is an initial attempt at a solution for #135. In short, I'm adjusting the `generateTasks` function so it doesn't filter out patterns with no matching files, and then adding a special case for tasks with no files found.

There's another option for this that involves just adding the logging to the `generateTasks` function, which could keep the main method a little less complicated if that's preferred.

I'm also noticing that there seems to be an inconsistency between the check character that lint-staged uses, `✅`, and the one that Listr seems to use, `✔`. This isn't a new problem, but it does look a little odd now:

![screen shot 2017-03-13 at 1 26 56 pm](https://cloud.githubusercontent.com/assets/2228864/23869384/c2408e60-07f0-11e7-8148-716de6a363e0.png)
