### PR TITLE
Fixed stylefmt example

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ This will run `eslint --fix` and automatically add changes to the commit. Please
 
 ```json
 {
-	"*.scss": ["stylefmt", "stylelint --syntax scss", "git add"]
+	"*.scss": ["stylefmt -r", "stylelint --syntax scss", "git add"]
 }
 ```
 


### PR DESCRIPTION
`stylefmt` doesn't take a list of files. So you have more than one matching files to be committed it will only work for the first file.

A workaround is to use the `-r` argument instead. 

This is a great little tool. Something that would have sped me up fixing this is if the `verbose: true` config showed me what actually commands are running. In this case `stylefmt file1.scss file2.scss` instead of `stylefmt file1.scss; stylefmt file2.scss`. From there it was easy to fix!

Thanks,