### PR TITLE
Add logLevel config and log verbose task output after task has finished

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "listr": "^0.12.0",
     "minimatch": "^3.0.0",
     "npm-which": "^3.0.1",
+    "npmlog": "^4.1.0",
     "staged-git-files": "0.0.4"
   },
   "devDependencies": {

--- a/src/runScript.js
+++ b/src/runScript.js
@@ -13,15 +13,19 @@ module.exports = function runScript(commands, pathsToLint, packageJson, options)
                 const execaOptions =
                     res.bin !== 'npm' && options && options.gitDir ? { cwd: options.gitDir } : {}
                 return new Promise((resolve, reject) => {
-                    execa(res.bin, res.args, execaOptions)
-                        .then(() => {
-                            resolve(`✅ ${ linter } passed!`)
-                        })
-                        .catch((err) => {
-                            reject(new Error(`🚫 ${ linter } found some errors. Please fix them and try committing again.
+                    const task = execa(res.bin, res.args, execaOptions)
+                    task.then((result) => {
+                        const output = options.verbose
+                            ? `✅ ${ linter } passed!
+${ result.stderr }
+${ result.stdout }`
+                            : `✅ ${ linter } passed!`
+                        resolve(output)
+                    }).catch((err) => {
+                        reject(new Error(`🚫 ${ linter } found some errors. Please fix them and try committing again.
 ${ err.stderr }
 ${ err.stdout }`))
-                        })
+                    })
                 })
             } catch (err) {
                 throw err


### PR DESCRIPTION
Putting this here for validation of early direction. This is part 1 of https://github.com/okonet/lint-staged/issues/161 it will later be followed up with part 2 which is streaming output rather than just dumping at the end of a task run.

### Highlights

- Use `npmlog` for logging. Gives us log levels out the box. 
- Deprecation notice for `config.verbose` so we don't have to do a major version.

### Todo

- [ ] Workout why we get double output sometimes
- [ ] Tests
- [ ] Tidy up