### PR TITLE
fix(gitDir): `gitDir` should only be applied when using `git` binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "devDependencies": {
     "babel-core": "^6.10.4",
-    "babel-jest": "^19.0.0",
+    "babel-jest": "^20.0.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-stage-0": "^6.5.0",
     "babel-register": "^6.16.3",

--- a/src/runScript.js
+++ b/src/runScript.js
@@ -10,8 +10,10 @@ module.exports = function runScript(commands, pathsToLint, packageJson, options)
         task: () => {
             try {
                 const res = findBin(linter, pathsToLint, packageJson, options)
+                // Only use gitDir as CWD if we are using the git binary
+                // e.g `npm` should run tasks in the actual CWD
                 const execaOptions =
-                    res.bin !== 'npm' && options && options.gitDir ? { cwd: options.gitDir } : {}
+                    res.bin.endsWith('git') && options && options.gitDir ? { cwd: options.gitDir } : {}
                 return new Promise((resolve, reject) => {
                     execa(res.bin, res.args, execaOptions)
                         .then(() => {
@@ -29,4 +31,3 @@ ${ err.stdout }`))
         }
     }))
 }
-


### PR DESCRIPTION
Inverses logic of checking for "not equal to `npm`", instead check
that binary to run is equal to `git` (and accounting for absolute
paths). This means that commands besides `npm` will also run in CWD
instead of `gitDir`.

Closes #158
Updated PR for #162 