### PR TITLE
fix gitDir on windows

### DIFF
--- a/src/runScript.js
+++ b/src/runScript.js
@@ -30,7 +30,7 @@ module.exports = function runScript(commands, pathsToLint, packageJson, options)
                 // Only use gitDir as CWD if we are using the git binary
                 // e.g `npm` should run tasks in the actual CWD
                 const execaOptions =
-                    res.bin.endsWith('git') && options && options.gitDir
+                    /git(\.exe)?$/i.test(res.bin) && options && options.gitDir
                     ? { cwd: options.gitDir } : {}
 
                 const errors = []


### PR DESCRIPTION
git detection didn't take file extension into consideration which caused an error when using git task on windows
fix #117