### PR TITLE
Add advanced option globOptions to customise how matching works

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ To set options and keep lint-staged extensible, advanced format can be used. Thi
 * `chunkSize` — Max allowed chunk size based on number of files for glob pattern. This is important on windows based systems to avoid command length limitations. See #147
 * `subTaskConcurrency` — `2` — Controls concurrency for processing chunks generated for each linter.
 * `verbose` — *false* — runs lint-staged in verbose mode. When `true` it will use https://github.com/SamVerschueren/listr-verbose-renderer.
-* `globOptions` — `{ baseMatch: true, dot: true }` — [minimatch options](https://github.com/isaacs/minimatch#options) to customize how glob patterns match files.
+* `globOptions` — `{ matchBase: true, dot: true }` — [minimatch options](https://github.com/isaacs/minimatch#options) to customize how glob patterns match files.
 
 ## Filtering files
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ To set options and keep lint-staged extensible, advanced format can be used. Thi
 * `chunkSize` — Max allowed chunk size based on number of files for glob pattern. This is important on windows based systems to avoid command length limitations. See #147
 * `subTaskConcurrency` — `2` — Controls concurrency for processing chunks generated for each linter.
 * `verbose` — *false* — runs lint-staged in verbose mode. When `true` it will use https://github.com/SamVerschueren/listr-verbose-renderer.
+* `globOptions` — `{ baseMatch: true, dot: true }` — list of [minimatch options](https://github.com/isaacs/minimatch#options) to customize how glob patterns match files.
 
 ## Filtering files
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ To set options and keep lint-staged extensible, advanced format can be used. Thi
 * `chunkSize` — Max allowed chunk size based on number of files for glob pattern. This is important on windows based systems to avoid command length limitations. See #147
 * `subTaskConcurrency` — `2` — Controls concurrency for processing chunks generated for each linter.
 * `verbose` — *false* — runs lint-staged in verbose mode. When `true` it will use https://github.com/SamVerschueren/listr-verbose-renderer.
-* `globOptions` — `{ baseMatch: true, dot: true }` — list of [minimatch options](https://github.com/isaacs/minimatch#options) to customize how glob patterns match files.
+* `globOptions` — `{ baseMatch: true, dot: true }` — [minimatch options](https://github.com/isaacs/minimatch#options) to customize how glob patterns match files.
 
 ## Filtering files
 

--- a/src/generateTasks.js
+++ b/src/generateTasks.js
@@ -14,7 +14,7 @@ module.exports = function generateTasks(config, files) {
             const filter = minimatch.filter(pattern, Object.assign({
                 matchBase: true,
                 dot: true
-            }))
+            }, globOptions))
             const fileList = Object.keys(files).filter(filter).map(resolve)
             return {
                 pattern,

--- a/src/generateTasks.js
+++ b/src/generateTasks.js
@@ -2,16 +2,19 @@
 
 const minimatch = require('minimatch')
 
+const readConfigOption = require('./readConfigOption')
+
 module.exports = function generateTasks(config, files) {
     const linters = config.linters !== undefined ? config.linters : config
     const resolve = file => files[file]
     return Object.keys(linters)
         .map((pattern) => {
             const commands = linters[pattern]
-            const filter = minimatch.filter(pattern, {
+            const globOptions = readConfigOption(config, 'globOptions', {})
+            const filter = minimatch.filter(pattern, Object.assign({
                 matchBase: true,
                 dot: true
-            })
+            }))
             const fileList = Object.keys(files).filter(filter).map(resolve)
             return {
                 pattern,

--- a/test/generateTasks.spec.js
+++ b/test/generateTasks.spec.js
@@ -146,4 +146,25 @@ describe('generateTasks', () => {
             ]
         })
     })
+
+    it('should support globOptions specified in advanced configuration', () => {
+        const result = generateTasks(
+            {
+                globOptions: {
+                    matchBase: false,
+                    nocase: true
+                },
+                linters: {
+                    'TeSt.*': 'lint'
+                }
+            },
+            files
+        )
+        const linter = result.find(item => item.pattern === 'TeSt.*')
+        expect(linter).toEqual({
+            pattern: 'TeSt.*',
+            commands: 'lint',
+            fileList: ['/root/test.js', '/root/test.css', '/root/test.txt']
+        })
+    })
 })


### PR DESCRIPTION
Adds the `globOptions` key to advanced config to allow customisation of how matching works.

Will also solve (although it is not a bug in hindsight but not ideal either): https://github.com/okonet/lint-staged/issues/173