### PR TITLE
adding multimatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Lint-staged supports simple and advanced config formats.
 
 ### Simple config format
 
-Should be an object where each value is a command to run and its key is a glob pattern to use for this command. This package uses [minimatch](https://github.com/isaacs/minimatch) for glob patterns.
+Should be an object where each value is a command to run and its key is a glob pattern to use for this command. This package uses [multimatch](https://github.com/sindresorhus/multimatch) which in turn uses [minimatch](https://github.com/isaacs/minimatch) for glob patterns.
 
 #### `package.json` example:
 ```json

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ It is possible to run linters for certain paths only by using [minimatch](https:
   "src/*.js": "eslint",
   // .js file anywhere within and below the src directory
   "src/**/*.js": "eslint",
+  // .js file anywhere within and below the src directory excluding src/somefolder. The %,% splits the string into an array passed to multimatch.
+  "src/**/*.js%,%!src/somefolder/*": "eslint",
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "execa": "^0.6.0",
     "listr": "^0.12.0",
     "lodash.chunk": "^4.2.0",
-    "minimatch": "^3.0.0",
+    "multimatch": "^2.1.0",
     "npm-which": "^3.0.1",
     "p-map": "^1.1.1",
     "staged-git-files": "0.0.4"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint:fix": "npm run lint -- --fix",
     "pre-commit": "node index.js",
     "test": "jest --coverage",
+    "test-watch": "jest --watch",
     "deps": "npm-check -s",
     "deps:update": "npm-check -u",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"

--- a/src/generateTasks.js
+++ b/src/generateTasks.js
@@ -9,9 +9,10 @@ module.exports = function generateTasks(config, files) {
     const resolve = file => files[file]
     return Object.keys(linters)
         .map((pattern) => {
+            let patternToUse = pattern.split('%,%')
             const commands = linters[pattern]
             const globOptions = readConfigOption(config, 'globOptions', {})
-            const fileList = multimatch(Object.keys(files), pattern, Object.assign({
+            const fileList = multimatch(Object.keys(files), patternToUse, Object.assign({
                 matchBase: true,
                 dot: true
             }, globOptions)).map(resolve)

--- a/src/generateTasks.js
+++ b/src/generateTasks.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const minimatch = require('minimatch')
+const multimatch = require('multimatch')
 
 const readConfigOption = require('./readConfigOption')
 
@@ -11,11 +11,10 @@ module.exports = function generateTasks(config, files) {
         .map((pattern) => {
             const commands = linters[pattern]
             const globOptions = readConfigOption(config, 'globOptions', {})
-            const filter = minimatch.filter(pattern, Object.assign({
+            const fileList = multimatch(Object.keys(files), pattern, Object.assign({
                 matchBase: true,
                 dot: true
-            }, globOptions))
-            const fileList = Object.keys(files).filter(filter).map(resolve)
+            }, globOptions)).map(resolve)
             return {
                 pattern,
                 commands,

--- a/test/generateTasks.spec.js
+++ b/test/generateTasks.spec.js
@@ -27,7 +27,8 @@ const linters = {
     'deeper/*.js': 'deeper-js',
     '.hidden/*.js': 'hidden-js',
     'unknown/*.js': 'unknown-js',
-    '*.{css,js}': 'root-css-or-js'
+    '*.{css,js}': 'root-css-or-js',
+    '*%,%!**/deeper/**': 'any-except-deeper'
 }
 
 describe('generateTasks', () => {
@@ -143,6 +144,23 @@ describe('generateTasks', () => {
                 '/root/deeper/test2.css',
                 '/root/even/deeper/test.css',
                 '/root/.hidden/test.css'
+            ]
+        })
+    })
+
+    it('should match multimatch pattern *%,%!**/deeper/**', () => {
+        const result = generateTasks(linters, files)
+        const linter = result.find(item => item.pattern === '*%,%!**/deeper/**')
+        expect(linter).toEqual({
+            pattern: '*%,%!**/deeper/**',
+            commands: 'any-except-deeper',
+            fileList: [
+                '/root/test.js',
+                '/root/.hidden/test.js',
+                '/root/test.css',
+                '/root/.hidden/test.css',
+                '/root/test.txt',
+                '/root/.hidden/test.txt'
             ]
         })
     })


### PR DESCRIPTION
This PR adds the ability to exclude nested subfolders by passing the glob pattern to multimatch (https://github.com/sindresorhus/multimatch):
```
// .js file anywhere within and below the src directory excluding src/somefolder. The %,% splits the string into an array passed to multimatch.
  "src/**/*.js%,%!src/somefolder/*": "eslint",
```

Normally multimatch takes an array of globs, but because lint-staged can only take string patterns, I had to add a way to split the string of globs into an array. Hence the `%,%` matching.

That's it!