### PR TITLE
chore: Set jest env as node to avoid jsdom overhead

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "pre-commit": "pre-commit",
+  "jest": {
+    "testEnvironment": "node"
+  },
   "greenkeeper": {
     "ignore": [
       "cosmiconfig"


### PR DESCRIPTION
Sets jest config in `package.json`. Reference docs - https://facebook.github.io/jest/docs/en/configuration.html#testenvironment-string