### PR TITLE
feat: Skip '--' argument for non-npm commands

### DIFF
--- a/src/runScript.js
+++ b/src/runScript.js
@@ -27,6 +27,9 @@ module.exports = function runScript(commands, pathsToLint, packageJson, options)
             try {
                 const res = findBin(linter, packageJson, options)
 
+                const separatorArgs = /npm(\.exe)?$/i.test(res.bin)
+                    ? ['--'] : [];
+
                 // Only use gitDir as CWD if we are using the git binary
                 // e.g `npm` should run tasks in the actual CWD
                 const execaOptions =
@@ -35,7 +38,7 @@ module.exports = function runScript(commands, pathsToLint, packageJson, options)
 
                 const errors = []
                 const mapper = (pathsChunk) => {
-                    const args = res.args.concat(['--'], pathsChunk)
+                    const args = res.args.concat(separatorArgs, pathsChunk)
 
                     return execa(res.bin, args, Object.assign({}, execaOptions))
                         /* If we don't catch, pMap will terminate on first rejection */
@@ -67,4 +70,3 @@ ${ errStderr }`)
         }
     }))
 }
-

--- a/test/runScript-mock-findBin.spec.js
+++ b/test/runScript-mock-findBin.spec.js
@@ -60,8 +60,7 @@ describe.only('runScript with absolute paths', () => {
         await taskPromise
         expect(mockFn.mock.calls.length).toEqual(1)
         expect(mockFn.mock.calls[0][0]).toMatch('/usr/local/bin/git')
-        expect(mockFn.mock.calls[0][1]).toEqual(['add', '--', 'test.js'])
+        expect(mockFn.mock.calls[0][1]).toEqual(['add', 'test.js'])
         expect(mockFn.mock.calls[0][2]).toEqual({ cwd: '../' })
     })
 })
-

--- a/test/runScript.spec.js
+++ b/test/runScript.spec.js
@@ -105,14 +105,14 @@ describe('runScript', () => {
         await taskPromise
         expect(mockFn.mock.calls.length).toEqual(1)
         expect(mockFn.mock.calls[0][0]).toContain('node')
-        expect(mockFn.mock.calls[0][1]).toEqual(['--arg=true', './myscript.js', '--', 'test.js'])
+        expect(mockFn.mock.calls[0][1]).toEqual(['--arg=true', './myscript.js', 'test.js'])
 
         taskPromise = res[1].task()
         expect(taskPromise).toBeAPromise()
         await taskPromise
         expect(mockFn.mock.calls.length).toEqual(2)
         expect(mockFn.mock.calls[1][0]).toContain('git')
-        expect(mockFn.mock.calls[1][1]).toEqual(['add', '--', 'test.js'])
+        expect(mockFn.mock.calls[1][1]).toEqual(['add', 'test.js'])
     })
 
     it('should pass cwd to execa if gitDir option is set for non-npm tasks', async () => {
@@ -135,7 +135,7 @@ describe('runScript', () => {
         await taskPromise
         expect(mockFn.mock.calls.length).toEqual(2)
         expect(mockFn.mock.calls[1][0]).toMatch(/git$/)
-        expect(mockFn.mock.calls[1][1]).toEqual(['add', '--', 'test.js'])
+        expect(mockFn.mock.calls[1][1]).toEqual(['add', 'test.js'])
         expect(mockFn.mock.calls[1][2]).toEqual({ cwd: '../' })
     })
 
@@ -151,7 +151,7 @@ describe('runScript', () => {
         await taskPromise
         expect(mockFn.mock.calls.length).toEqual(1)
         expect(mockFn.mock.calls[0]).toEqual(
-          ['jest', ['--', 'test.js'], {}]
+          ['jest', ['test.js'], {}]
         )
     })
 
@@ -204,4 +204,3 @@ ${ linteErr.stderr }`)
         }
     })
 })
-


### PR DESCRIPTION
Closes #195 

BREAKING CHANGE: This might affect existing setups which depend on the `--` argument.