### PR TITLE
Bail on fatal errors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,6 +40,7 @@ cosmiconfig('lint-staged', {
         sgf('ACM', (err, files) => {
             if (err) {
                 console.error(err)
+                process.exit(1)
             }
 
             const resolvedFiles = {}


### PR DESCRIPTION
E.g. when invoked by a `package.json` in a subdirectory:

```
$ git commit -m "Reformat-on-commit"
Found '/Users/seth/src/hotosm/osm-export-tool2/ui/.nvmrc' with version <6>
Now using node v6.11.0 (npm v3.10.10)
Found '/Users/seth/src/hotosm/osm-export-tool2/ui/.nvmrc' with version <6>
Now using node v6.11.0 (npm v3.10.10)
husky > npm run -s precommit (node v6.11.0)

Error: fatal: Not a git repository: '.git'

    at ChildProcess.<anonymous> (/Users/seth/src/hotosm/osm-export-tool2/ui/node_modules/staged-git-files/index.js:85:19)
    at emitTwo (events.js:106:13)
    at ChildProcess.emit (events.js:191:7)
    at maybeClose (internal/child_process.js:891:16)
    at Socket.<anonymous> (internal/child_process.js:342:11)
    at emitOne (events.js:96:13)
    at Socket.emit (events.js:188:7)
    at Pipe._handle.close [as _onclose] (net.js:497:12)
/Users/seth/src/hotosm/osm-export-tool2/ui/node_modules/lint-staged/src/index.js:46
            files.forEach((file) => {
                 ^

TypeError: Cannot read property 'forEach' of undefined
    at sgf (/Users/seth/src/hotosm/osm-export-tool2/ui/node_modules/lint-staged/src/index.js:46:18)
    at /Users/seth/src/hotosm/osm-export-tool2/ui/node_modules/staged-git-files/index.js:13:13
    at /Users/seth/src/hotosm/osm-export-tool2/ui/node_modules/staged-git-files/index.js:38:13
    at ChildProcess.<anonymous> (/Users/seth/src/hotosm/osm-export-tool2/ui/node_modules/staged-git-files/index.js:88:9)
    at emitTwo (events.js:106:13)
    at ChildProcess.emit (events.js:191:7)
    at maybeClose (internal/child_process.js:891:16)
    at Socket.<anonymous> (internal/child_process.js:342:11)
    at emitOne (events.js:96:13)
    at Socket.emit (events.js:188:7)

husky > pre-commit hook failed (add --no-verify to bypass)
```