### PR TITLE
fix: Disable concurrent sub task execution by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ See [examples](#examples) and [configuration](#configuration) below.
 
 > I recommend using [husky](https://github.com/typicode/husky) to manage git hooks but you can use any other tool.
 
-> **NOTE:** 
+> **NOTE:**
 >
 > If you're using commitizen and having following npm-script `{ commit: git-cz }`, `precommit` hook will run twice before commitizen cli and after the commit. [This buggy behaviour is introduced by husky](https://github.com/okonet/lint-staged/issues/152#issuecomment-306046520).
 >
@@ -95,7 +95,7 @@ To set options and keep lint-staged extensible, advanced format can be used. Thi
 * `gitDir` — Sets the relative path to the `.git` root. Useful when your `package.json` is located in a subdirectory. See [working from a subdirectory](#working-from-a-subdirectory)
 * `concurrent` — *true* — runs linters for each glob pattern simultaneously. If you don’t want this, you can set `concurrent: false`
 * `chunkSize` — Max allowed chunk size based on number of files for glob pattern. This is important on windows based systems to avoid command length limitations. See [#147](https://github.com/okonet/lint-staged/issues/147)
-* `subTaskConcurrency` — `2` — Controls concurrency for processing chunks generated for each linter.
+* `subTaskConcurrency` — `1` — Controls concurrency for processing chunks generated for each linter. Execution is **not** concurrent by default(see [#225](https://github.com/okonet/lint-staged/issues/225))
 * `verbose` — *false* — runs lint-staged in verbose mode. When `true` it will use https://github.com/SamVerschueren/listr-verbose-renderer.
 * `globOptions` — `{ matchBase: true, dot: true }` — [minimatch options](https://github.com/isaacs/minimatch#options) to customize how glob patterns match files.
 

--- a/src/runScript.js
+++ b/src/runScript.js
@@ -11,7 +11,7 @@ const readConfigOption = require('./readConfigOption')
 module.exports = function runScript(commands, pathsToLint, packageJson, options) {
     const config = readConfigOption(options, 'config', {})
 
-    const concurrency = readConfigOption(config, 'subTaskConcurrency', 2)
+    const concurrency = readConfigOption(config, 'subTaskConcurrency', 1)
     const chunkSize = calcChunkSize(
         pathsToLint,
         readConfigOption(config, 'chunkSize', Number.MAX_SAFE_INTEGER)


### PR DESCRIPTION
This sets the default `subTaskConcurrency` as `1` to disable parallel execution of chunks. I have also updated the readme.

Closes #225