### PR TITLE
chore: move `semantic-release` to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache:
   directories:
     - node_modules
 node_js:
-  - '7'
+  - '8'
   - '6'
   - '4'
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ before_script:
   - npm prune
 after_success:
   - bash <(curl -s https://codecov.io/bash)
-  - npm run semantic-release
+  - npm install -g semantic-release
+  - semantic-release pre && npm publish && semantic-release post
 branches:
   except:
     - /^v\d+\.\d+\.\d+$/

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "pre-commit": "remove-lockfiles && node index.js",
     "test": "jest --coverage",
     "deps": "npm-check -s",
-    "deps:update": "npm-check -u",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    "deps:update": "npm-check -u"
   },
   "pre-commit": "pre-commit",
   "jest": {
@@ -77,8 +76,7 @@
     "jsonlint-cli": "^1.0.1",
     "npm-check": "^5.2.2",
     "pre-commit": "^1.1.3",
-    "remove-lockfiles": "^0.2.1",
-    "semantic-release": "^6.3.2"
+    "remove-lockfiles": "^0.2.1"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- We almost never run `semantic-release` manually, I see *no* benefit to have it listed in devDependencies
- We're still using the old version of `semantic-release` which produces annoying `<a name"blahblah">` in releases page. It's solved in v7
- Moving `semantic-release` to CI will reduce the time it takes to install devDependencies
- Installing `semantic-release` gives us some warnings in CLI output

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I did this to some projects such as:
- [generator-node-oss](https://github.com/luftywiranda13/generator-node-oss)
- [remove-lockfiles](https://github.com/luftywiranda13/remove-lockfiles)
- [glamorous](https://github.com/paypal/glamorous)
- [polished](https://github.com/styled-components/polished), etc.

### Screenshots:

<p align="center"><strong>Before:</strong> <em>4 warnings</em></p>

![screen shot 2017-08-24 at 13 24 11](https://user-images.githubusercontent.com/22868432/29653079-8eb0aae0-88d2-11e7-881e-c77f140b9aac.png)

<p align="center"><strong>After:</strong> <em>1 warning</em></p>

![screen shot 2017-08-24 at 13 28 38](https://user-images.githubusercontent.com/22868432/29653237-38e347a2-88d3-11e7-8e20-2c797317ced5.png)

`semantic-release` still works perfectly fine like before but with no `<a name"blahblah">` 🎉

![screen shot 2017-08-24 at 13 56 39](https://user-images.githubusercontent.com/22868432/29653877-6c4c2da0-88d5-11e7-985e-effb4698276f.png)
