### PR TITLE
chore: Remove unnecessary `babel` packages

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,12 +5,5 @@
         "node": "current"
       }
     }]
-  ],
-  "plugins": [
-    ["transform-runtime", {
-      "helpers": false,
-      "polyfill": false,
-      "regenerator": true
-    }]
   ]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,7 @@
   "presets": [
     ["env", {
       "targets": {
-        "node": "current"
+        "node": 4
       }
     }]
   ]

--- a/package.json
+++ b/package.json
@@ -61,12 +61,8 @@
     "staged-git-files": "0.0.4"
   },
   "devDependencies": {
-    "babel-core": "^6.10.4",
     "babel-jest": "^20.0.0",
-    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.4.0",
-    "babel-register": "^6.16.3",
-    "babel-runtime": "^6.23.0",
     "cz-conventional-changelog": "^1.2.0",
     "eslint": "^4.5.0",
     "eslint-config-okonet": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.0",
-    "babel-preset-env": "^1.4.0",
+    "babel-preset-env": "^1.6.0",
     "cz-conventional-changelog": "^1.2.0",
     "eslint": "^4.5.0",
     "eslint-config-okonet": "^5.0.1",


### PR DESCRIPTION
Hi it's me cleaning up again 😂

## Description

I notice that we're using some unnecessary babel packages as devDependencies.

https://github.com/okonet/lint-staged/blob/a28463d86aab05e0e00d1bd5b1b3985cbe0f4c26/package.json#L64-L69

I think the reason why we have them is to make it easier to write our tests (async/await, promise, etc.)

## What I did

We can safely remove some of them. 

By submitting this PR, I propose to remove some babel packages so we'll only have two babel packages left.

```js
{
    "babel-jest": "^20.0.0",
    "babel-preset-env": "^1.4.0",
     // other deps
}
```

## How has this been tested?

- I uninstalled the packages
- I ran our tests `npm test`  🎉

![screen shot 2017-08-25 at 19 23 38](https://user-images.githubusercontent.com/22868432/29713900-ef5352d2-89ca-11e7-8890-b8b838b5359a.png)

