### PR TITLE
ci: Don't cache `node_modules`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ node_js:
   - '6'
   - '4'
 before_install: if [[ `npm -v` < 3* ]]; then npm i -g npm@^3; fi
-before_script:
-  - npm prune
 after_success:
   - bash <(curl -s https://codecov.io/bash)
   - npm install -g semantic-release

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 language: node_js
-cache:
-  directories:
-    - node_modules
 node_js:
   - '8'
   - '6'


### PR DESCRIPTION
## Description

Since we don't allow committing lockfiles in this repo,
I think it's best to also not cache `node_modules` in Travis CI

## Benefit

* Grab fresh dependency trees
* This will help us to catch any regressions introduced by our dependencies
* Caching `node_modules` in Travis also causes more harm than benefit
  because in some cases we need to clear the cache to make our tests pass in Travis
  (Like what we did in #231)

## Downside

It'll take more time for Travis to finish the jobs