### PR TITLE
chore: Remove `jsonlint-cli`

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "is-promise": "^2.1.0",
     "jest": "^20.0.1",
     "jsonlint": "^1.6.2",
-    "jsonlint-cli": "^1.0.1",
     "npm-check": "^5.2.2",
     "pre-commit": "^1.1.3",
     "prettier": "1.5.3",


### PR DESCRIPTION
We only use `jsonlint` in this project,

https://github.com/okonet/lint-staged/blob/e3b7fafa63466ab854718222795210e59338703e/.lintstagedrc#L7

So it's safe to remove the unused `jsonlint-cli`