### PR TITLE
style: Use dedent for prettier multi-line template literals

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "chalk": "^2.1.0",
     "commander": "^2.11.0",
     "cosmiconfig": "^3.1.0",
+    "dedent": "^0.7.0",
     "execa": "^0.8.0",
     "is-glob": "^4.0.0",
     "jest-validate": "^21.1.0",

--- a/src/getConfig.js
+++ b/src/getConfig.js
@@ -59,9 +59,10 @@ function unknownValidationReporter(config, example, option, options) {
    * a typical mistake of mixing simple and advanced configs
    */
   if (isGlob(option)) {
+    // prettier-ignore
     const message = `  Unknown option ${chalk.bold(`"${option}"`)} with value ${chalk.bold(
-      format(config[option], { inlineCharacterLimit: Number.POSITIVE_INFINITY })
-    )} was found in the config root.
+    format(config[option], { inlineCharacterLimit: Number.POSITIVE_INFINITY })
+  )} was found in the config root.
 
   You are probably trying to mix simple and advanced config formats. Adding
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@
 'use strict'
 
 const appRoot = require('app-root-path')
+const dedent = require('dedent')
 const cosmiconfig = require('cosmiconfig')
 const stringifyObject = require('stringify-object')
 const getConfig = require('./getConfig').getConfig
@@ -44,10 +45,8 @@ module.exports = function lintStaged(injectedLogger, configPath) {
       const config = validateConfig(getConfig(result.config))
 
       if (config.verbose) {
-        logger.log(`
-Running lint-staged with the following config:
-${stringifyObject(config)}
-`)
+        logger.log('Running lint-staged with the following config:')
+        logger.log(stringifyObject(config, { indent: '  ' }))
       }
 
       const scripts = packageJson.scripts || {}
@@ -68,15 +67,18 @@ ${stringifyObject(config)}
         logger.error(`${err.message}.`)
       } else {
         // It was probably a parsing error
-        logger.error(`Could not parse lint-staged config.
+        logger.error(dedent`
+          Could not parse lint-staged config.
 
-${err}`)
+          ${err}
+        `)
       }
+      logger.error() // empty line
       // Print helpful message for all errors
-      logger.error(`
-Please make sure you have created it correctly.
-See https://github.com/okonet/lint-staged#configuration.
-`)
+      logger.error(dedent`
+        Please make sure you have created it correctly.
+        See https://github.com/okonet/lint-staged#configuration.
+      `)
       process.exitCode = 1
     })
 }

--- a/src/runScript.js
+++ b/src/runScript.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const chunk = require('lodash/chunk')
+const dedent = require('dedent')
 const execa = require('execa')
 const logSymbols = require('log-symbols')
 const pMap = require('p-map')
@@ -46,8 +47,10 @@ module.exports = function runScript(commands, pathsToLint, scripts, config) {
         return pMap(filePathChunks, mapper, { concurrency })
           .catch(err => {
             /* This will probably never be called. But just in case.. */
-            throw new Error(`${logSymbols.error} ${linter} got an unexpected error.
-${err.message}`)
+            throw new Error(dedent`
+              ${logSymbols.error} ${linter} got an unexpected error.
+              ${err.message}
+            `)
           })
           .then(() => {
             if (errors.length === 0) return `${logSymbols.success} ${linter} passed!`
@@ -55,9 +58,11 @@ ${err.message}`)
             const errStdout = errors.map(err => err.stdout).join('')
             const errStderr = errors.map(err => err.stderr).join('')
 
-            throw new Error(`${logSymbols.error} ${linter} found some errors. Please fix them and try committing again.
-${errStdout}
-${errStderr}`)
+            throw new Error(dedent`
+              ${logSymbols.error} ${linter} found some errors. Please fix them and try committing again.
+              ${errStdout}
+              ${errStderr}
+            `)
           })
       } catch (err) {
         throw err

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -2,57 +2,52 @@
 
 exports[`lintStaged should load config file when specified 1`] = `
 "
-LOG 
-Running lint-staged with the following config:
-{
-	verbose: true,
-	linters: {
-		'*': 'mytask'
-	},
-	concurrent: true,
-	chunkSize: 9007199254740991,
-	gitDir: '.',
-	globOptions: {
-		matchBase: true,
-		dot: true
-	},
-	subTaskConcurrency: 1,
-	renderer: 'verbose'
-}
-"
+LOG Running lint-staged with the following config:
+LOG {
+  verbose: true,
+  linters: {
+    '*': 'mytask'
+  },
+  concurrent: true,
+  chunkSize: 9007199254740991,
+  gitDir: '.',
+  globOptions: {
+    matchBase: true,
+    dot: true
+  },
+  subTaskConcurrency: 1,
+  renderer: 'verbose'
+}"
 `;
 
 exports[`lintStaged should not output config in non verbose mode 1`] = `""`;
 
 exports[`lintStaged should output config in verbose mode 1`] = `
 "
-LOG 
-Running lint-staged with the following config:
-{
-	verbose: true,
-	linters: {
-		'*': 'mytask'
-	},
-	concurrent: true,
-	chunkSize: 9007199254740991,
-	gitDir: '.',
-	globOptions: {
-		matchBase: true,
-		dot: true
-	},
-	subTaskConcurrency: 1,
-	renderer: 'verbose'
-}
-"
+LOG Running lint-staged with the following config:
+LOG {
+  verbose: true,
+  linters: {
+    '*': 'mytask'
+  },
+  concurrent: true,
+  chunkSize: 9007199254740991,
+  gitDir: '.',
+  globOptions: {
+    matchBase: true,
+    dot: true
+  },
+  subTaskConcurrency: 1,
+  renderer: 'verbose'
+}"
 `;
 
 exports[`lintStaged should print helpful error message when config file is not found 1`] = `
 "
 ERROR Config could not be found.
 ERROR 
-Please make sure you have created it correctly.
-See https://github.com/okonet/lint-staged#configuration.
-"
+ERROR Please make sure you have created it correctly.
+See https://github.com/okonet/lint-staged#configuration."
 `;
 
 exports[`lintStaged should print helpful error message when explicit config file is not found 1`] = `
@@ -61,7 +56,6 @@ ERROR Could not parse lint-staged config.
 
 Error: ENOENT: no such file or directory, open 'fake-config-file.yml'
 ERROR 
-Please make sure you have created it correctly.
+ERROR Please make sure you have created it correctly.
 See https://github.com/okonet/lint-staged#configuration.
-
 `;

--- a/test/runScript-mock-pMap.spec.js
+++ b/test/runScript-mock-pMap.spec.js
@@ -1,3 +1,4 @@
+import dedent from 'dedent'
 import pMapMock from 'p-map'
 import logSymbols from 'log-symbols'
 import runScript from '../src/runScript'
@@ -39,8 +40,10 @@ describe('runScript', () => {
     try {
       await res[0].task()
     } catch (err) {
-      expect(err.message).toMatch(`${logSymbols.error} test got an unexpected error.
-Unexpected Error`)
+      expect(err.message).toMatch(dedent`
+        ${logSymbols.error} test got an unexpected error.
+        Unexpected Error
+      `)
     }
   })
 })

--- a/test/runScript.spec.js
+++ b/test/runScript.spec.js
@@ -1,3 +1,4 @@
+import dedent from 'dedent'
 import mockFn from 'execa'
 import logSymbols from 'log-symbols'
 import runScript from '../src/runScript'
@@ -140,10 +141,11 @@ describe('runScript', () => {
     try {
       await taskPromise
     } catch (err) {
-      expect(err.message)
-        .toMatch(`${logSymbols.error} mock-fail-linter found some errors. Please fix them and try committing again.
-${linterErr.stdout}
-${linterErr.stderr}`)
+      expect(err.message).toMatch(dedent`
+        ${logSymbols.error} mock-fail-linter found some errors. Please fix them and try committing again.
+        ${linterErr.stdout}
+        ${linterErr.stderr}
+      `)
     }
   })
 })


### PR DESCRIPTION
This PR uses [`dedent`](https://www.npmjs.com/package/dedent) for beautifying multi-line template literals:
```js
const dedent = require('dedent');
// ...

// Before
console.log(`This is a multi-line
sentence`);

// After
console.log(dedent`
  This is a multi-line
  sentence
`)
```