### PR TITLE
chore: Add eslint-node-plugin with the recommended configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "bin": {
     "lint-staged": "index.js"
   },
+  "engines": {
+    "node": ">=4.0.0"
+  },
   "files": [
     "src"
   ],
@@ -68,6 +71,7 @@
     "cz-conventional-changelog": "^2.0.0",
     "eslint": "^4.5.0",
     "eslint-config-okonet": "^5.0.1",
+    "eslint-plugin-node": "^5.1.1",
     "expect": "^1.20.2",
     "is-promise": "^2.1.0",
     "jest": "^20.0.1",

--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -1,0 +1,12 @@
+{
+  "plugins": ["node"],
+  "extends": [
+    "plugin:node/recommended"
+  ],
+  "rules": {
+    "node/exports-style": [
+      "error",
+      "module.exports"
+    ]
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-/* global process */
 /* eslint no-console: 0 */
 /* eslint no-process-exit: 0 */
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 /* global process */
 /* eslint no-console: 0 */
+/* eslint no-process-exit: 0 */
 
 'use strict'
 


### PR DESCRIPTION
In order to ensure that we don't use ES2015 features that doesn't work in Node 4.x, I've added this ESLint plugin with the set of recommended rules.