### PR TITLE
test: Fix failing tests on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,17 +3,20 @@ environment:
     - nodejs_version: '8'
     - nodejs_version: '6'
     - nodejs_version: '4'
+
 install:
   - ps: Install-Product node $env:nodejs_version
   - set CI=true
   - npm install --global npm@latest
   - set PATH=%APPDATA%\npm;%PATH%
   - npm install
-matrix:
-  fast_finish: true
-build: off
-shallow_clone: true
+
+cache:
+  - node_modules
+
 test_script:
   - node --version
   - npm --version
   - npm test
+
+build: off

--- a/src/runAll.js
+++ b/src/runAll.js
@@ -26,7 +26,7 @@ module.exports = function runAll(packageJson, config) {
   return new Promise((resolve, reject) => {
     sgf('ACM', (err, files) => {
       if (err) {
-        reject(err)
+        return reject(err)
       }
 
       /* files is an Object{ filename: String, status: String } */
@@ -49,7 +49,7 @@ module.exports = function runAll(packageJson, config) {
       }))
 
       if (tasks.length) {
-        new Listr(tasks, {
+        return new Listr(tasks, {
           concurrent,
           renderer,
           exitOnError: !concurrent // Wait for all errors when running concurrently
@@ -57,9 +57,8 @@ module.exports = function runAll(packageJson, config) {
           .run()
           .then(resolve)
           .catch(reject)
-      } else {
-        resolve('No tasks to run.')
       }
+      return resolve('No tasks to run.')
     })
   })
 }

--- a/test/__mocks__/execa.js
+++ b/test/__mocks__/execa.js
@@ -1,1 +1,1 @@
-module.exports = jest.fn()
+module.exports = jest.fn(() => Promise.resolve(true))

--- a/test/generateTasks.spec.js
+++ b/test/generateTasks.spec.js
@@ -21,8 +21,10 @@ const files = [
   '.hidden/test.txt'
 ]
 
+const workDir = path.join(process.env.HOME, 'tmp-lint-staged')
+
 const config = {
-  gitDir: '/root',
+  gitDir: workDir,
   linters: {
     '*.js': 'root-js',
     '**/*.js': 'any-js',
@@ -98,7 +100,7 @@ describe('generateTasks', () => {
         `${relPath}/deeper/test2.js`,
         `${relPath}/even/deeper/test.js`,
         `${relPath}/.hidden/test.js`
-      ]
+      ].map(path.normalize)
     })
   })
 
@@ -109,12 +111,12 @@ describe('generateTasks', () => {
       pattern: '*.js',
       commands: 'root-js',
       fileList: [
-        '/root/test.js',
-        '/root/deeper/test.js',
-        '/root/deeper/test2.js',
-        '/root/even/deeper/test.js',
-        '/root/.hidden/test.js'
-      ]
+        `${workDir}/test.js`,
+        `${workDir}/deeper/test.js`,
+        `${workDir}/deeper/test2.js`,
+        `${workDir}/even/deeper/test.js`,
+        `${workDir}/.hidden/test.js`
+      ].map(path.normalize)
     })
   })
 
@@ -125,12 +127,12 @@ describe('generateTasks', () => {
       pattern: '**/*.js',
       commands: 'any-js',
       fileList: [
-        '/root/test.js',
-        '/root/deeper/test.js',
-        '/root/deeper/test2.js',
-        '/root/even/deeper/test.js',
-        '/root/.hidden/test.js'
-      ]
+        `${workDir}/test.js`,
+        `${workDir}/deeper/test.js`,
+        `${workDir}/deeper/test2.js`,
+        `${workDir}/even/deeper/test.js`,
+        `${workDir}/.hidden/test.js`
+      ].map(path.normalize)
     })
   })
 
@@ -140,7 +142,7 @@ describe('generateTasks', () => {
     expect(linter).toEqual({
       pattern: 'deeper/*.js',
       commands: 'deeper-js',
-      fileList: ['/root/deeper/test.js', '/root/deeper/test2.js']
+      fileList: [`${workDir}/deeper/test.js`, `${workDir}/deeper/test2.js`].map(path.normalize)
     })
   })
 
@@ -150,7 +152,7 @@ describe('generateTasks', () => {
     expect(linter).toEqual({
       pattern: '.hidden/*.js',
       commands: 'hidden-js',
-      fileList: ['/root/.hidden/test.js']
+      fileList: [path.normalize(`${workDir}/.hidden/test.js`)]
     })
   })
 
@@ -161,24 +163,24 @@ describe('generateTasks', () => {
       pattern: '*.{css,js}',
       commands: 'root-css-or-js',
       fileList: [
-        '/root/test.js',
-        '/root/deeper/test.js',
-        '/root/deeper/test2.js',
-        '/root/even/deeper/test.js',
-        '/root/.hidden/test.js',
-        '/root/test.css',
-        '/root/deeper/test.css',
-        '/root/deeper/test2.css',
-        '/root/even/deeper/test.css',
-        '/root/.hidden/test.css'
-      ]
+        `${workDir}/test.js`,
+        `${workDir}/deeper/test.js`,
+        `${workDir}/deeper/test2.js`,
+        `${workDir}/even/deeper/test.js`,
+        `${workDir}/.hidden/test.js`,
+        `${workDir}/test.css`,
+        `${workDir}/deeper/test.css`,
+        `${workDir}/deeper/test2.css`,
+        `${workDir}/even/deeper/test.css`,
+        `${workDir}/.hidden/test.css`
+      ].map(path.normalize)
     })
   })
 
   it('should support globOptions specified in advanced configuration', () => {
     const result = generateTasks(
       {
-        gitDir: '/root',
+        gitDir: workDir,
         globOptions: {
           matchBase: false,
           nocase: true
@@ -193,7 +195,9 @@ describe('generateTasks', () => {
     expect(linter).toEqual({
       pattern: 'TeSt.*',
       commands: 'lint',
-      fileList: ['/root/test.js', '/root/test.css', '/root/test.txt']
+      fileList: [`${workDir}/test.js`, `${workDir}/test.css`, `${workDir}/test.txt`].map(
+        path.normalize
+      )
     })
   })
 })

--- a/test/resolveGitDir.spec.js
+++ b/test/resolveGitDir.spec.js
@@ -18,7 +18,8 @@ describe('resolveGitDir', () => {
     expect(path.isAbsolute(resolveGitDir('..'))).toBe(true)
   })
   it('should resolve to absolute dir from config', () => {
-    expect(resolveGitDir('/path/to/some/dir')).toEqual('/path/to/some/dir')
-    expect(path.isAbsolute(resolveGitDir('/path/to/some/dir'))).toBe(true)
+    const workDir = path.join(process.env.HOME, 'tmp-lint-staged')
+    expect(resolveGitDir(workDir)).toEqual(workDir)
+    expect(path.isAbsolute(resolveGitDir(workDir))).toBe(true)
   })
 })

--- a/test/runScript-mock-findBin.spec.js
+++ b/test/runScript-mock-findBin.spec.js
@@ -6,20 +6,15 @@ import mockFn from 'execa'
 import runScript from '../src/runScript'
 
 jest.mock('execa')
-
 // Mock findBin to return an absolute path
-jest.mock(
-  '../src/findBin',
-  () => commands => {
-    const [bin, ...otherArgs] = commands.split(' ')
+jest.mock('../src/findBin', () => commands => {
+  const [bin, ...otherArgs] = commands.split(' ')
 
-    return {
-      bin: `/usr/local/bin/${bin}`,
-      args: otherArgs
-    }
-  },
-  { virtual: true }
-)
+  return {
+    bin: `/usr/local/bin/${bin}`,
+    args: otherArgs
+  }
+})
 
 const packageJSON = {
   scripts: {
@@ -30,9 +25,8 @@ const packageJSON = {
 }
 
 describe('runScript with absolute paths', () => {
-  beforeEach(() => {
-    mockFn.mockReset()
-    mockFn.mockImplementation(() => Promise.resolve(true))
+  afterEach(() => {
+    mockFn.mockClear()
   })
 
   it('can pass `gitDir` as `cwd` to `execa()` when git is called via absolute path', async () => {

--- a/test/runScript-mock-pMap.spec.js
+++ b/test/runScript-mock-pMap.spec.js
@@ -1,7 +1,7 @@
-import pMap from 'p-map'
+import pMapMock from 'p-map'
 import runScript from '../src/runScript'
 
-jest.mock('p-map', () => jest.fn(() => Promise.resolve(true)))
+jest.mock('p-map')
 
 const packageJSON = {
   scripts: {
@@ -12,21 +12,27 @@ const packageJSON = {
 }
 
 describe('runScript', () => {
+  afterEach(() => {
+    pMapMock.mockClear()
+  })
+
   it('should respect concurrency', () => {
+    pMapMock.mockImplementation(() => Promise.resolve(true))
+
     const res = runScript(['test'], ['test1.js', 'test2.js'], packageJSON, {
       chunkSize: 1,
       subTaskConcurrency: 1
     })
     res[0].task()
-    expect(pMap.mock.calls.length).toEqual(1)
-    const pMapArgs = pMap.mock.calls[0]
+    expect(pMapMock.mock.calls.length).toEqual(1)
+    const pMapArgs = pMapMock.mock.calls[0]
     expect(pMapArgs[0]).toEqual([['test1.js'], ['test2.js']])
     expect(pMapArgs[1]).toBeInstanceOf(Function)
     expect(pMapArgs[2]).toEqual({ concurrency: 1 })
   })
 
   it('should handle unexpected error', async () => {
-    pMap.mockImplementation(() => Promise.reject(new Error('Unexpected Error')))
+    pMapMock.mockImplementation(() => Promise.reject(new Error('Unexpected Error')))
 
     const res = runScript(['test'], ['test.js'], packageJSON)
     try {

--- a/test/runScript.spec.js
+++ b/test/runScript.spec.js
@@ -14,9 +14,8 @@ const packageJSON = {
 }
 
 describe('runScript', () => {
-  beforeEach(() => {
-    mockFn.mockReset()
-    mockFn.mockImplementation(() => Promise.resolve(true))
+  afterEach(() => {
+    mockFn.mockClear()
   })
 
   it('should return an array', () => {
@@ -135,10 +134,10 @@ describe('runScript', () => {
   })
 
   it('should throw error for failed linters', async () => {
-    const linteErr = new Error()
-    linteErr.stdout = 'Mock error'
-    linteErr.stderr = ''
-    mockFn.mockImplementation(() => Promise.reject(linteErr))
+    const linterErr = new Error()
+    linterErr.stdout = 'Mock error'
+    linterErr.stderr = ''
+    mockFn.mockImplementationOnce(() => Promise.reject(linterErr))
 
     const res = runScript('mock-fail-linter', ['test.js'], packageJSON)
     const taskPromise = res[0].task()
@@ -147,8 +146,8 @@ describe('runScript', () => {
     } catch (err) {
       expect(err.message)
         .toMatch(`🚫 mock-fail-linter found some errors. Please fix them and try committing again.
-${linteErr.stdout}
-${linteErr.stderr}`)
+${linterErr.stdout}
+${linterErr.stderr}`)
     }
   })
 })


### PR DESCRIPTION
This PR does the following:
- Fixes test failures due to path comparison by using a test-work directory and `path.normalize`. The test-work directory is set to `path.join(process.env.HOME, 'tmp-lint-staged')`. `process.env.HOME`, or `$HOME` is `C:\\Users\\username` on windows and `/home/username` on *nix.
- Fixes a bug in `runAll` caused by not returning from function when `staged-git-files` returns an error. 
- Fixes an issue with the appveyor config due to shallow clone which results in error `fatal: Not a git repository`.
- Fixes the blinking test by refactoring jest mocks. Now all tests pass on appveyor 🎉

### Error details:
```
Test Suites: 2 failed, 9 passed, 11 total
Tests:       8 failed, 50 passed, 58 total
Snapshots:   13 passed, 13 total
Time:        2.534s
Ran all test suites.
```

<details>
<summary>Detailed error report</summary>

```
$ jest --coverage
 FAIL  test\generateTasks.spec.js
  ● generateTasks › should match pattern "*.js" for relative path

    expect(received).toEqual(expected)

    Expected value to equal:
      {"commands": "root-js", "fileList": ["E:\\Projects\\repos/test.js", "E:\\Projects\\repos/deeper/test.js", "E:\\Projects\\repos/deeper/test2.js", "E:\\Projects\\repos/even/deeper/test.js", "E:\\Projects\\repos/.hidden/test.js"], "pattern": "*.js"}
    Received:
      {"commands": "root-js", "fileList": ["E:\\Projects\\repos\\test.js", "E:\\Projects\\repos\\deeper\\test.js", "E:\\Projects\\repos\\deeper\\test2.js", "E:\\Projects\\repos\\even\\deeper\\test.js", "E:\\Projects\\repos\\.hidden\\test.js"], "pattern": "*.js"}

    Difference:

    - Expected
    + Received

    Object {
       "commands": "root-js",
       "fileList": Array [
    -    "E:\\Projects\\repos/test.js",
    -    "E:\\Projects\\repos/deeper/test.js",
    -    "E:\\Projects\\repos/deeper/test2.js",
    -    "E:\\Projects\\repos/even/deeper/test.js",
    -    "E:\\Projects\\repos/.hidden/test.js",
    +    "E:\\Projects\\repos\\test.js",
    +    "E:\\Projects\\repos\\deeper\\test.js",
    +    "E:\\Projects\\repos\\deeper\\test2.js",
    +    "E:\\Projects\\repos\\even\\deeper\\test.js",
    +    "E:\\Projects\\repos\\.hidden\\test.js",
       ],
       "pattern": "*.js",
     }

      at Object.<anonymous> (test/generateTasks.spec.js:92:20)
          at Promise (<anonymous>)
      at Promise.resolve.then.el (node_modules/p-map/index.js:42:16)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

  ● generateTasks › should match pattern "*.js"

    expect(received).toEqual(expected)

    Expected value to equal:
      {"commands": "root-js", "fileList": ["/root/test.js", "/root/deeper/test.js", "/root/deeper/test2.js", "/root/even/deeper/test.js", "/root/.hidden/test.js"], "pattern": "*.js"}
    Received:
      {"commands": "root-js", "fileList": ["E:\\root\\test.js", "E:\\root\\deeper\\test.js", "E:\\root\\deeper\\test2.js", "E:\\root\\even\\deeper\\test.js", "E:\\root\\.hidden\\test.js"], "pattern": "*.js"}

    Difference:

    - Expected
    + Received

    Object {
       "commands": "root-js",
       "fileList": Array [
    -    "/root/test.js",
    -    "/root/deeper/test.js",
    -    "/root/deeper/test2.js",
    -    "/root/even/deeper/test.js",
    -    "/root/.hidden/test.js",
    +    "E:\\root\\test.js",
    +    "E:\\root\\deeper\\test.js",
    +    "E:\\root\\deeper\\test2.js",
    +    "E:\\root\\even\\deeper\\test.js",
    +    "E:\\root\\.hidden\\test.js",
       ],
       "pattern": "*.js",
     }

      at Object.<anonymous> (test/generateTasks.spec.js:108:20)
          at Promise (<anonymous>)
      at Promise.resolve.then.el (node_modules/p-map/index.js:42:16)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

  ● generateTasks › should match pattern "**/*.js"

    expect(received).toEqual(expected)

    Expected value to equal:
      {"commands": "any-js", "fileList": ["/root/test.js", "/root/deeper/test.js", "/root/deeper/test2.js", "/root/even/deeper/test.js", "/root/.hidden/test.js"], "pattern": "**/*.js"}
    Received:
      {"commands": "any-js", "fileList": ["E:\\root\\test.js", "E:\\root\\deeper\\test.js", "E:\\root\\deeper\\test2.js", "E:\\root\\even\\deeper\\test.js", "E:\\root\\.hidden\\test.js"], "pattern": "**/*.js"}

    Difference:

    - Expected
    + Received

    Object {
       "commands": "any-js",
       "fileList": Array [
    -    "/root/test.js",
    -    "/root/deeper/test.js",
    -    "/root/deeper/test2.js",
    -    "/root/even/deeper/test.js",
    -    "/root/.hidden/test.js",
    +    "E:\\root\\test.js",
    +    "E:\\root\\deeper\\test.js",
    +    "E:\\root\\deeper\\test2.js",
    +    "E:\\root\\even\\deeper\\test.js",
    +    "E:\\root\\.hidden\\test.js",
       ],
       "pattern": "**/*.js",
     }

      at Object.<anonymous> (test/generateTasks.spec.js:124:20)
          at Promise (<anonymous>)
      at Promise.resolve.then.el (node_modules/p-map/index.js:42:16)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

  ● generateTasks › should match pattern "deeper/*.js"

    expect(received).toEqual(expected)

    Expected value to equal:
      {"commands": "deeper-js", "fileList": ["/root/deeper/test.js", "/root/deeper/test2.js"], "pattern": "deeper/*.js"}
    Received:
      {"commands": "deeper-js", "fileList": ["E:\\root\\deeper\\test.js", "E:\\root\\deeper\\test2.js"], "pattern": "deeper/*.js"}

    Difference:

    - Expected
    + Received

    Object {
       "commands": "deeper-js",
       "fileList": Array [
    -    "/root/deeper/test.js",
    -    "/root/deeper/test2.js",
    +    "E:\\root\\deeper\\test.js",
    +    "E:\\root\\deeper\\test2.js",
       ],
       "pattern": "deeper/*.js",
     }

      at Object.<anonymous> (test/generateTasks.spec.js:140:20)
          at Promise (<anonymous>)
      at Promise.resolve.then.el (node_modules/p-map/index.js:42:16)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

  ● generateTasks › should match pattern ".hidden/*.js"

    expect(received).toEqual(expected)

    Expected value to equal:
      {"commands": "hidden-js", "fileList": ["/root/.hidden/test.js"], "pattern": ".hidden/*.js"}
    Received:
      {"commands": "hidden-js", "fileList": ["E:\\root\\.hidden\\test.js"], "pattern": ".hidden/*.js"}

    Difference:

    - Expected
    + Received

    Object {
       "commands": "hidden-js",
       "fileList": Array [
    -    "/root/.hidden/test.js",
    +    "E:\\root\\.hidden\\test.js",
       ],
       "pattern": ".hidden/*.js",
     }

      at Object.<anonymous> (test/generateTasks.spec.js:150:20)
          at Promise (<anonymous>)
      at Promise.resolve.then.el (node_modules/p-map/index.js:42:16)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

  ● generateTasks › should match pattern "*.{css,js}"

    expect(received).toEqual(expected)

    Expected value to equal:
      {"commands": "root-css-or-js", "fileList": ["/root/test.js", "/root/deeper/test.js", "/root/deeper/test2.js", "/root/even/deeper/test.js", "/root/.hidden/test.js", "/root/test.css", "/root/deeper/test.css", "/root/deeper/test2.css", "/root/even/deeper/test.css", "/root/.hidden/test.css"], "pattern": "*.{css,js}"}
    Received:
      {"commands": "root-css-or-js", "fileList": ["E:\\root\\test.js", "E:\\root\\deeper\\test.js", "E:\\root\\deeper\\test2.js", "E:\\root\\even\\deeper\\test.js", "E:\\root\\.hidden\\test.js", "E:\\root\\test.css", "E:\\root\\deeper\\test.css", "E:\\root\\deeper\\test2.css", "E:\\root\\even\\deeper\\test.css", "E:\\root\\.hidden\\test.css"], "pattern": "*.{css,js}"}

    Difference:

    - Expected
    + Received

    Object {
       "commands": "root-css-or-js",
       "fileList": Array [
    -    "/root/test.js",
    -    "/root/deeper/test.js",
    -    "/root/deeper/test2.js",
    -    "/root/even/deeper/test.js",
    -    "/root/.hidden/test.js",
    -    "/root/test.css",
    -    "/root/deeper/test.css",
    -    "/root/deeper/test2.css",
    -    "/root/even/deeper/test.css",
    -    "/root/.hidden/test.css",
    +    "E:\\root\\test.js",
    +    "E:\\root\\deeper\\test.js",
    +    "E:\\root\\deeper\\test2.js",
    +    "E:\\root\\even\\deeper\\test.js",
    +    "E:\\root\\.hidden\\test.js",
    +    "E:\\root\\test.css",
    +    "E:\\root\\deeper\\test.css",
    +    "E:\\root\\deeper\\test2.css",
    +    "E:\\root\\even\\deeper\\test.css",
    +    "E:\\root\\.hidden\\test.css",
       ],
       "pattern": "*.{css,js}",
     }

      at Object.<anonymous> (test/generateTasks.spec.js:160:20)
          at Promise (<anonymous>)
      at Promise.resolve.then.el (node_modules/p-map/index.js:42:16)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

  ● generateTasks › should support globOptions specified in advanced configuration

    expect(received).toEqual(expected)

    Expected value to equal:
      {"commands": "lint", "fileList": ["/root/test.js", "/root/test.css", "/root/test.txt"], "pattern": "TeSt.*"}
    Received:
      {"commands": "lint", "fileList": ["E:\\root\\test.js", "E:\\root\\test.css", "E:\\root\\test.txt"], "pattern": "TeSt.*"}

    Difference:

    - Expected
    + Received

    Object {
       "commands": "lint",
       "fileList": Array [
    -    "/root/test.js",
    -    "/root/test.css",
    -    "/root/test.txt",
    +    "E:\\root\\test.js",
    +    "E:\\root\\test.css",
    +    "E:\\root\\test.txt",
       ],
       "pattern": "TeSt.*",
     }

      at Object.<anonymous> (test/generateTasks.spec.js:193:20)
          at Promise (<anonymous>)
      at Promise.resolve.then.el (node_modules/p-map/index.js:42:16)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

 PASS  test\runScript-mock-findBin.spec.js
 FAIL  test\resolveGitDir.spec.js
  ● resolveGitDir › should resolve to absolute dir from config

    expect(received).toEqual(expected)

    Expected value to equal:
      "/path/to/some/dir"
    Received:
      "E:\\path\\to\\some\\dir"

      at Object.<anonymous> (test/resolveGitDir.spec.js:21:63)
          at Promise (<anonymous>)
      at Promise.resolve.then.el (node_modules/p-map/index.js:42:16)
          at <anonymous>

 PASS  test\runAll.spec.js
 PASS  test\index.spec.js
 PASS  test\getConfig.spec.js
 PASS  test\runScript.spec.js
 PASS  test\runScript-mock-pMap.spec.js
 PASS  test\printErrors.spec.js
 PASS  test\findBin.spec.js
 PASS  test\calcChunkSize.spec.js
```

</details>

<br>

Closes #245
Closes #257 
Closes #264