### PR TITLE
fix: Handle the case when staged-git-files errors properly

### DIFF
--- a/test/runAll.spec.js
+++ b/test/runAll.spec.js
@@ -1,7 +1,14 @@
 /* eslint no-console: 0 */
 
+import sgfMock from 'staged-git-files'
 import { getConfig } from '../src/getConfig'
 import runAll from '../src/runAll'
+
+jest.mock('staged-git-files')
+
+sgfMock.mockImplementation((params, callback) => {
+  callback(null, [])
+})
 
 const packageJson = {
   scripts: {
@@ -10,6 +17,9 @@ const packageJson = {
 }
 
 describe('runAll', () => {
+  afterEach(() => {
+    sgfMock.mockClear()
+  })
   it('should throw when invalid config is provided', () => {
     expect(() => runAll(packageJson, {})).toThrowErrorMatchingSnapshot()
     expect(() => runAll(packageJson)).toThrowErrorMatchingSnapshot()
@@ -29,5 +39,13 @@ describe('runAll', () => {
   it('should resolve the promise with no tasks', () => {
     expect.assertions(1)
     return expect(runAll(packageJson, getConfig({}))).resolves.toEqual('No tasks to run.')
+  })
+
+  it('should reject the promise when staged-git-files errors', () => {
+    sgfMock.mockImplementation((params, callback) => {
+      callback('test', undefined)
+    })
+    expect.assertions(1)
+    return expect(runAll(packageJson, getConfig({}))).rejects.toEqual('test')
   })
 })


### PR DESCRIPTION
Since the implementation was already merged in #255, this PR only adds a test. It will trigger semantic-release to actually release the new version.

Closes #264