### PR TITLE
ci: Whitelist build branches to avoid duplicate builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,6 @@ after_success:
   - npm install -g semantic-release
   - semantic-release pre && npm publish && semantic-release post
 branches:
-  except:
-    - /^v\d+\.\d+\.\d+$/
+  only:
+    - master
+    - /^greenkeeper/.*$/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,8 @@
+branches:
+  only:
+    - master
+    - /^greenkeeper/.*$/
+
 environment:
   matrix:
     - nodejs_version: '8'


### PR DESCRIPTION
For pull requests which are made from a branch in this repo instead of a fork, travis and appveyor run duplicate builds once for the PR and once for the branch push. See example - https://github.com/okonet/lint-staged/pull/250. By whitelisting branches, we can limit builds to master, PRs and greenkeeper branches.