### PR TITLE
ci(appveyor): Switch off node modules cache

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,9 +16,6 @@ install:
   - set PATH=%APPDATA%\npm;%PATH%
   - npm install
 
-cache:
-  - node_modules
-
 test_script:
   - node --version
   - npm --version


### PR DESCRIPTION
@okonet This was a rather trivial change and a lot of issues from greenkeeper are stemming from this. So I tried to push this commit to master:
```
λ git push origin master
Counting objects: 3, done.
Delta compression using up to 4 threads.
Compressing objects: 100% (3/3), done.
Writing objects: 100% (3/3), 319 bytes | 159.00 KiB/s, done.
Total 3 (delta 2), reused 0 (delta 0)
remote: Resolving deltas: 100% (2/2), completed with 2 local objects.
remote: error: GH006: Protected branch update failed for refs/heads/master.
remote: error: 3 of 3 required status checks are expected. At least one approved review is required by reviewers with write access.
To https://github.com/okonet/lint-staged
 ! [remote rejected] master -> master (protected branch hook declined)
error: failed to push some refs to 'https://github.com/okonet/lint-staged'
```

Is this really necessary? I can assure you that I will not ever be pushing to master without good reason and always open a PR if I think the change merits discussion.