### PR TITLE
docs: Add code comment for func findBin>npmArgs

### DIFF
--- a/src/findBin.js
+++ b/src/findBin.js
@@ -4,6 +4,8 @@ const npmWhich = require('npm-which')(process.cwd())
 
 module.exports = function findBin(cmd, scripts, options) {
   const npmArgs = (bin, args) =>
+    // We always add `--` even if args are not defined. This is required
+    // because we pass filenames later.
     ['run', options && options.verbose ? undefined : '--silent', bin, '--']
       // args could be undefined but we filter that out.
       .concat(args)


### PR DESCRIPTION
This adds code comment explaining why `--` is required even if args might not be defined.
