### PR TITLE
Allow config to be provided via command-line

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Starting with v3.1 you can now use different ways of configuring it:
 * `lint-staged` object in your `package.json`
 * `.lintstagedrc` file in JSON or YML format
 * `lint-staged.config.js` file in JS format
+* Pass a configuration file using the `--config` or `-c` flag
 
 See [cosmiconfig](https://github.com/davidtheclark/cosmiconfig) for more details on what formats are supported.
 

--- a/index.js
+++ b/index.js
@@ -2,4 +2,12 @@
 
 'use strict'
 
-require('./src')()
+const cmdline = require('commander')
+const pkg = require('./package.json')
+
+cmdline
+  .version(pkg.version)
+  .option('-c, --config [path]', 'Path to configuration file')
+  .parse(process.argv)
+
+require('./src')(console, cmdline.config)

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "app-root-path": "^2.0.0",
     "chalk": "^2.1.0",
+    "commander": "^2.11.0",
     "cosmiconfig": "^1.1.0",
     "execa": "^0.8.0",
     "is-glob": "^4.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -25,8 +25,11 @@ const errConfigNotFound = new Error('Config could not be found')
 /**
  * Root lint-staged function that is called from .bin
  */
-module.exports = function lintStaged() {
+module.exports = function lintStaged(injectedLogger, configPath) {
+  const logger = injectedLogger || console
+
   return cosmiconfig('lint-staged', {
+    configPath,
     rc: '.lintstagedrc',
     rcExtensions: true
   })
@@ -38,7 +41,7 @@ module.exports = function lintStaged() {
       const config = validateConfig(getConfig(result.config))
 
       if (config.verbose) {
-        console.log(`
+        logger.log(`
 Running lint-staged with the following config:
 ${stringifyObject(config)}
 `)
@@ -59,15 +62,15 @@ ${stringifyObject(config)}
     })
     .catch(err => {
       if (err === errConfigNotFound) {
-        console.error(`${err.message}.`)
+        logger.error(`${err.message}.`)
       } else {
         // It was probably a parsing error
-        console.error(`Could not parse lint-staged config.
+        logger.error(`Could not parse lint-staged config.
 
 ${err}`)
       }
       // Print helpful message for all errors
-      console.error(`
+      logger.error(`
 Please make sure you have created it correctly.
 See https://github.com/okonet/lint-staged#configuration.
 `)

--- a/test/__mocks__/cosmiconfig.js
+++ b/test/__mocks__/cosmiconfig.js
@@ -1,0 +1,12 @@
+const actual = require.requireActual('cosmiconfig')
+const mock = jest.genMockFromModule('cosmiconfig')
+
+function cosmiconfig(name, options) {
+  if (options.configPath) {
+    return actual(name, options)
+  }
+
+  return mock(name, options)
+}
+
+module.exports = jest.fn(cosmiconfig)

--- a/test/__mocks__/my-config.json
+++ b/test/__mocks__/my-config.json
@@ -1,0 +1,6 @@
+{
+  "verbose": true,
+  "linters": {
+    "*": "mytask"
+  }
+}

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -1,8 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`lintStaged should load config file when specified 1`] = `
+"
+LOG 
+Running lint-staged with the following config:
+{
+	verbose: true,
+	linters: {
+		'*': 'mytask'
+	},
+	concurrent: true,
+	chunkSize: 9007199254740991,
+	gitDir: '.',
+	globOptions: {
+		matchBase: true,
+		dot: true
+	},
+	subTaskConcurrency: 1,
+	renderer: 'verbose'
+}
+"
+`;
+
 exports[`lintStaged should not output config in non verbose mode 1`] = `""`;
 
-exports[`lintStaged should ouput config in verbose mode 1`] = `
+exports[`lintStaged should output config in verbose mode 1`] = `
 "
 LOG 
 Running lint-staged with the following config:
@@ -31,4 +53,15 @@ ERROR
 Please make sure you have created it correctly.
 See https://github.com/okonet/lint-staged#configuration.
 "
+`;
+
+exports[`lintStaged should print helpful error message when explicit config file is not found 1`] = `
+
+ERROR Could not parse lint-staged config.
+
+Error: ENOENT: no such file or directory, open 'fake-config-file.yml'
+ERROR 
+Please make sure you have created it correctly.
+See https://github.com/okonet/lint-staged#configuration.
+
 `;

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,15 +1,23 @@
 import { makeConsoleMock } from 'consolemock'
 import cosmiconfig from 'cosmiconfig'
+import path from 'path'
 import lintStaged from '../src/index'
+
+const replaceSerializer = (from, to) => ({
+  test: val => typeof val === 'string' && from.test(val),
+  print: val => val.replace(from, to)
+})
 
 jest.mock('cosmiconfig')
 
 describe('lintStaged', () => {
+  let logger
+
   beforeEach(() => {
-    console = makeConsoleMock()
+    logger = makeConsoleMock()
   })
 
-  it('should ouput config in verbose mode', async () => {
+  it('should output config in verbose mode', async () => {
     const config = {
       verbose: true,
       linters: {
@@ -17,8 +25,8 @@ describe('lintStaged', () => {
       }
     }
     cosmiconfig.mockImplementationOnce(() => Promise.resolve({ config }))
-    await lintStaged()
-    expect(console.printHistory()).toMatchSnapshot()
+    await lintStaged(logger)
+    expect(logger.printHistory()).toMatchSnapshot()
   })
 
   it('should not output config in non verbose mode', async () => {
@@ -26,13 +34,33 @@ describe('lintStaged', () => {
       '*': 'mytask'
     }
     cosmiconfig.mockImplementationOnce(() => Promise.resolve({ config }))
-    await lintStaged()
-    expect(console.printHistory()).toMatchSnapshot()
+    await lintStaged(logger)
+    expect(logger.printHistory()).toMatchSnapshot()
+  })
+
+  it('should load config file when specified', async () => {
+    await lintStaged(logger, path.join(__dirname, '__mocks__', 'my-config.json'))
+    expect(logger.printHistory()).toMatchSnapshot()
   })
 
   it('should print helpful error message when config file is not found', async () => {
     cosmiconfig.mockImplementationOnce(() => Promise.resolve(null))
-    await lintStaged()
-    expect(console.printHistory()).toMatchSnapshot()
+    await lintStaged(logger)
+    expect(logger.printHistory()).toMatchSnapshot()
+  })
+
+  it('should print helpful error message when explicit config file is not found', async () => {
+    const nonExistentConfig = 'fake-config-file.yml'
+
+    // Serialize Windows, Linux and MacOS paths consistently
+    expect.addSnapshotSerializer(
+      replaceSerializer(
+        /Error: ENOENT: no such file or directory, open '([^']+)'/,
+        `Error: ENOENT: no such file or directory, open '${nonExistentConfig}'`
+      )
+    )
+
+    await lintStaged(logger, nonExistentConfig)
+    expect(logger.printHistory()).toMatchSnapshot()
   })
 })


### PR DESCRIPTION
### Summary
I use `lint-staged` as a pre-commit hook and would like to explicitly provide the config file location. This PR uses [`commander`](npmjs.com/package/commander) to parse the command-line argument and passes it as `cosmiconfig`'s [`configPath`](https://github.com/davidtheclark/cosmiconfig#configpath) option. This allows the config file to be any format already supported.

### Test plan
I've added tests and updated the documentation.