### PR TITLE
Fix duplicate error messages #142

### DIFF
--- a/src/runScript.js
+++ b/src/runScript.js
@@ -27,7 +27,9 @@ module.exports = function runScript(commands, pathsToLint, scripts, config) {
         // Only use gitDir as CWD if we are using the git binary
         // e.g `npm` should run tasks in the actual CWD
         const execaOptions =
-          /git(\.exe)?$/i.test(res.bin) && config && gitDir ? { cwd: gitDir } : {}
+          /git(\.exe)?$/i.test(res.bin) && config && gitDir
+            ? { cwd: gitDir, stdio: 'inherit' }
+            : { stdio: 'inherit' }
 
         const errors = []
         const mapper = pathsChunk => {

--- a/test/runScript-mock-findBin.spec.js
+++ b/test/runScript-mock-findBin.spec.js
@@ -34,6 +34,9 @@ describe('runScript with absolute paths', () => {
     expect(taskPromise).toBeInstanceOf(Promise)
     await taskPromise
     expect(mockFn).toHaveBeenCalledTimes(1)
-    expect(mockFn).toHaveBeenCalledWith('/usr/local/bin/git', ['add', 'test.js'], { cwd: '../' })
+    expect(mockFn).toHaveBeenCalledWith('/usr/local/bin/git', ['add', 'test.js'], {
+      cwd: '../',
+      stdio: 'inherit'
+    })
   })
 })

--- a/test/runScript.spec.js
+++ b/test/runScript.spec.js
@@ -44,12 +44,20 @@ describe('runScript', () => {
     expect(taskPromise).toBeInstanceOf(Promise)
     await taskPromise
     expect(mockFn.mock.calls.length).toEqual(1)
-    expect(mockFn.mock.calls[0]).toEqual(['npm', ['run', '--silent', 'test', '--', 'test.js'], {}])
+    expect(mockFn.mock.calls[0]).toEqual([
+      'npm',
+      ['run', '--silent', 'test', '--', 'test.js'],
+      { stdio: 'inherit' }
+    ])
     taskPromise = res[1].task()
     expect(taskPromise).toBeInstanceOf(Promise)
     await taskPromise
     expect(mockFn.mock.calls.length).toEqual(2)
-    expect(mockFn.mock.calls[1]).toEqual(['npm', ['run', '--silent', 'test2', '--', 'test.js'], {}])
+    expect(mockFn.mock.calls[1]).toEqual([
+      'npm',
+      ['run', '--silent', 'test2', '--', 'test.js'],
+      { stdio: 'inherit' }
+    ])
   })
 
   it('should respect chunk size', async () => {
@@ -60,8 +68,16 @@ describe('runScript', () => {
     expect(taskPromise).toBeInstanceOf(Promise)
     await taskPromise
     expect(mockFn.mock.calls.length).toEqual(2)
-    expect(mockFn.mock.calls[0]).toEqual(['npm', ['run', '--silent', 'test', '--', 'test1.js'], {}])
-    expect(mockFn.mock.calls[1]).toEqual(['npm', ['run', '--silent', 'test', '--', 'test2.js'], {}])
+    expect(mockFn.mock.calls[0]).toEqual([
+      'npm',
+      ['run', '--silent', 'test', '--', 'test1.js'],
+      { stdio: 'inherit' }
+    ])
+    expect(mockFn.mock.calls[1]).toEqual([
+      'npm',
+      ['run', '--silent', 'test', '--', 'test2.js'],
+      { stdio: 'inherit' }
+    ])
   })
 
   it('should support non npm scripts', async () => {
@@ -91,7 +107,11 @@ describe('runScript', () => {
     expect(taskPromise).toBeInstanceOf(Promise)
     await taskPromise
     expect(mockFn.mock.calls.length).toEqual(1)
-    expect(mockFn.mock.calls[0]).toEqual(['npm', ['run', '--silent', 'test', '--', 'test.js'], {}])
+    expect(mockFn.mock.calls[0]).toEqual([
+      'npm',
+      ['run', '--silent', 'test', '--', 'test.js'],
+      { stdio: 'inherit' }
+    ])
 
     taskPromise = res[1].task()
     expect(taskPromise).toBeInstanceOf(Promise)
@@ -99,7 +119,7 @@ describe('runScript', () => {
     expect(mockFn.mock.calls.length).toEqual(2)
     expect(mockFn.mock.calls[1][0]).toMatch(/git$/)
     expect(mockFn.mock.calls[1][1]).toEqual(['add', 'test.js'])
-    expect(mockFn.mock.calls[1][2]).toEqual({ cwd: '../' })
+    expect(mockFn.mock.calls[1][2]).toEqual({ cwd: '../', stdio: 'inherit' })
   })
 
   it('should not pass `gitDir` as `cwd` to `execa()` if a non-git binary is called', async () => {
@@ -108,7 +128,7 @@ describe('runScript', () => {
     expect(taskPromise).toBeInstanceOf(Promise)
     await taskPromise
     expect(mockFn.mock.calls.length).toEqual(1)
-    expect(mockFn.mock.calls[0]).toEqual(['jest', ['test.js'], {}])
+    expect(mockFn.mock.calls[0]).toEqual(['jest', ['test.js'], { stdio: 'inherit' }])
   })
 
   it('should use --silent in non-verbose mode', async () => {
@@ -117,7 +137,11 @@ describe('runScript', () => {
     expect(taskPromise).toBeInstanceOf(Promise)
     await taskPromise
     expect(mockFn.mock.calls.length).toEqual(1)
-    expect(mockFn.mock.calls[0]).toEqual(['npm', ['run', '--silent', 'test', '--', 'test.js'], {}])
+    expect(mockFn.mock.calls[0]).toEqual([
+      'npm',
+      ['run', '--silent', 'test', '--', 'test.js'],
+      { stdio: 'inherit' }
+    ])
   })
 
   it('should not use --silent in verbose mode', async () => {
@@ -126,7 +150,11 @@ describe('runScript', () => {
     expect(taskPromise).toBeInstanceOf(Promise)
     await taskPromise
     expect(mockFn.mock.calls.length).toEqual(1)
-    expect(mockFn.mock.calls[0]).toEqual(['npm', ['run', 'test', '--', 'test.js'], {}])
+    expect(mockFn.mock.calls[0]).toEqual([
+      'npm',
+      ['run', 'test', '--', 'test.js'],
+      { stdio: 'inherit' }
+    ])
   })
 
   it('should throw error for failed linters', async () => {


### PR DESCRIPTION
### Summary

Processes spawned by `execa` do not inherit the stdio channels of their parent by default. This was causing unexpected behavior where lint-staged tasks started in some terminals would be spawned as if their input was piped, and so be considered a non-TTY (not text-input based) terminal. Because `Listr` uses different renderers for TTY/non-TTY terminals, when this happened lint-staged was unintentionally using the 'verbose' renderer, causing the duplicate error messages of #142.

### Solution

This fix just passes a `stdio: 'inherit' ` option to `execa`, so that all processes spawn with the stdin / stdout / stderr chanels of their parent.


I'm not sure why processes spawned by execa lost their TTY status only in some terminals. It happens for me with git-bash but not windows terminal or powershell. I'm curious about other fixes or thoughts on what's happening.