### PR TITLE
chore: Bump cosmiconfig to v3, rm greenkeeper ignore

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "app-root-path": "^2.0.0",
     "chalk": "^2.1.0",
     "commander": "^2.11.0",
-    "cosmiconfig": "^1.1.0",
+    "cosmiconfig": "^3.1.0",
     "execa": "^0.8.0",
     "is-glob": "^4.0.0",
     "jest-validate": "^21.1.0",
@@ -68,11 +68,6 @@
     "testEnvironment": "node",
     "setupFiles": [
       "./testSetup.js"
-    ]
-  },
-  "greenkeeper": {
-    "ignore": [
-      "cosmiconfig"
     ]
   },
   "keywords": [

--- a/src/index.js
+++ b/src/index.js
@@ -28,11 +28,14 @@ const errConfigNotFound = new Error('Config could not be found')
 module.exports = function lintStaged(injectedLogger, configPath) {
   const logger = injectedLogger || console
 
-  return cosmiconfig('lint-staged', {
+  const explorer = cosmiconfig('lint-staged', {
     configPath,
     rc: '.lintstagedrc',
     rcExtensions: true
   })
+
+  return explorer
+    .load(process.cwd())
     .then(result => {
       if (result == null) throw errConfigNotFound
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -10,6 +10,10 @@ const replaceSerializer = (from, to) => ({
 
 jest.mock('cosmiconfig')
 
+const mockCosmiconfigWith = result => {
+  cosmiconfig.mockImplementationOnce(() => ({ load: () => Promise.resolve(result) }))
+}
+
 describe('lintStaged', () => {
   let logger
 
@@ -24,7 +28,7 @@ describe('lintStaged', () => {
         '*': 'mytask'
       }
     }
-    cosmiconfig.mockImplementationOnce(() => Promise.resolve({ config }))
+    mockCosmiconfigWith({ config })
     await lintStaged(logger)
     expect(logger.printHistory()).toMatchSnapshot()
   })
@@ -33,7 +37,7 @@ describe('lintStaged', () => {
     const config = {
       '*': 'mytask'
     }
-    cosmiconfig.mockImplementationOnce(() => Promise.resolve({ config }))
+    mockCosmiconfigWith({ config })
     await lintStaged(logger)
     expect(logger.printHistory()).toMatchSnapshot()
   })
@@ -44,7 +48,7 @@ describe('lintStaged', () => {
   })
 
   it('should print helpful error message when config file is not found', async () => {
-    cosmiconfig.mockImplementationOnce(() => Promise.resolve(null))
+    mockCosmiconfigWith(null)
     await lintStaged(logger)
     expect(logger.printHistory()).toMatchSnapshot()
   })


### PR DESCRIPTION
- Bump cosmiconfig {`1.1.0` ➡ `3.1.0`}, refactor usage.
- Remove greenkeeper directive for ignoring cosmiconfig.
- Update test mock impls for new cosmiconfig API.

Closes #282.