### PR TITLE
docs: Tweak appveyor badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🚫💩 lint-staged [![Build Status](https://travis-ci.org/okonet/lint-staged.svg?branch=master)](https://travis-ci.org/okonet/lint-staged) [![AppVeyor branch](https://img.shields.io/appveyor/ci/okonet/lint-staged/master.svg)](https://ci.appveyor.com/project/okonet/lint-staged) [![npm version](https://badge.fury.io/js/lint-staged.svg)](https://badge.fury.io/js/lint-staged) [![Codecov](https://codecov.io/gh/okonet/lint-staged/branch/master/graph/badge.svg)](https://codecov.io/gh/okonet/lint-staged)
+# 🚫💩 lint-staged [![Build Status for Linux](https://travis-ci.org/okonet/lint-staged.svg?branch=master)](https://travis-ci.org/okonet/lint-staged)  [![Build Status for Windows](https://ci.appveyor.com/api/projects/status/github/okonet/lint-staged?branch=master&svg=true)](https://ci.appveyor.com/project/okonet/lint-staged) [![npm version](https://badge.fury.io/js/lint-staged.svg)](https://badge.fury.io/js/lint-staged) [![Codecov](https://codecov.io/gh/okonet/lint-staged/branch/master/graph/badge.svg)](https://codecov.io/gh/okonet/lint-staged)
 
 Run linters against staged git files and don't let :poop: slip into your code base!
 


### PR DESCRIPTION
Right now, we have 2 build badges which look exactly the same:

![image](https://user-images.githubusercontent.com/22251956/31850894-c2fec0c4-b678-11e7-92db-3a7674c221ed.png)

And it bothers me just a little bit 😅. This PR tweaks the appveyor badge as shown below.

![image](https://user-images.githubusercontent.com/22251956/31850904-f0bcdffa-b678-11e7-87d3-54e681596643.png)

Appveyor docs - https://www.appveyor.com/docs/status-badges/