### PR TITLE
feat: Verbose as CLI flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const pkg = require('./package.json')
 cmdline
   .version(pkg.version)
   .option('-c, --config [path]', 'Path to configuration file')
+  .option('-v, --verbose', 'Run in verbose mode')
   .parse(process.argv)
 
-require('./src')(console, cmdline.config)
+require('./src')(console, cmdline.config, cmdline.verbose)

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ const errConfigNotFound = new Error('Config could not be found')
 /**
  * Root lint-staged function that is called from .bin
  */
-module.exports = function lintStaged(injectedLogger, configPath) {
+module.exports = function lintStaged(injectedLogger, configPath, verbose) {
   const logger = injectedLogger || console
 
   return cosmiconfig('lint-staged', {
@@ -36,9 +36,14 @@ module.exports = function lintStaged(injectedLogger, configPath) {
     .then(result => {
       if (result == null) throw errConfigNotFound
 
+      const configResult = {
+        verbose,
+        ...result.config
+      }
+
       // result.config is the parsed configuration object
       // result.filepath is the path to the config file that was found
-      const config = validateConfig(getConfig(result.config))
+      const config = validateConfig(getConfig(configResult))
 
       if (config.verbose) {
         logger.log(`


### PR DESCRIPTION
As discussed on https://github.com/okonet/lint-staged/pull/126, I added verbose mode as CLI flag.
I am not sure about variables naming, but it works and tests pass. 
I think it need more tests, let me know if should be necessary.