### PR TITLE
docs(README.md): add `imagemin-lint-staged` section

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,3 +232,22 @@ This will run `eslint --fix` and automatically add changes to the commit. Please
   ]
 }
 ```
+
+### Minify the images and add files to commit
+
+```json
+{
+  "*.{png,jpeg,jpg,gif,svg}": [
+    "imagemin-lint-staged",
+    "git add"
+  ]
+}
+```
+
+<details>
+  <summary>More about <code>imagemin-lint-staged</code></summary>
+
+  [imagemin-lint-staged](https://github.com/tomchentw/imagemin-lint-staged) is a CLI tool designed for lint-staged usage with sensible defaults.
+
+  See more on [this blog post](https://medium.com/@tomchentw/imagemin-lint-staged-in-place-minify-the-images-before-adding-to-the-git-repo-5acda0b4c57e) for benefits of this approach.
+</details>


### PR DESCRIPTION
## Description

Add section for minifying images with [imagemin-lint-staged][imagemin-lint-staged] to the `READEM.md`.

## Screenshots

<img width="934" alt="screen shot 2017-11-23 at 10 56 35 am" src="https://user-images.githubusercontent.com/922234/33157433-fdcab64e-d03c-11e7-8c8e-37b2f0793ec4.png">


[imagemin-lint-staged]: https://github.com/tomchentw/imagemin-lint-staged