### PR TITLE
refactor: Cleanup code and tests for gitDir

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,6 @@ const printErrors = require('./printErrors')
 const runAll = require('./runAll')
 
 // Find the right package.json at the root of the project
-// TODO: Test if it should be aware of `gitDir`
 const packageJson = require(appRoot.resolve('package.json'))
 
 // Force colors for packages that depend on https://www.npmjs.com/package/supports-color

--- a/src/runAll.js
+++ b/src/runAll.js
@@ -20,10 +20,9 @@ module.exports = function runAll(scripts, config) {
     throw new Error('Invalid config provided to runAll! Use getConfig instead.')
   }
 
-  const gitDir = config.gitDir
   const concurrent = config.concurrent
   const renderer = config.renderer
-  sgf.cwd = resolveGitDir(gitDir)
+  sgf.cwd = resolveGitDir()
 
   return pify(sgf)('ACM').then(files => {
     /* files is an Object{ filename: String, status: String } */

--- a/test/generateTasks.spec.js
+++ b/test/generateTasks.spec.js
@@ -62,7 +62,6 @@ describe('generateTasks', () => {
   it('should work with advanced configuration', () => {
     const result = generateTasks(
       {
-        gitDir: '../',
         linters: {
           '*.js': 'lint'
         }
@@ -76,7 +75,6 @@ describe('generateTasks', () => {
   it('should return absolute paths', () => {
     const [task] = generateTasks(
       {
-        gitDir: '..',
         linters: {
           '*': 'lint'
         }
@@ -188,7 +186,6 @@ describe('generateTasks', () => {
   it('should support globOptions specified in advanced configuration', () => {
     const result = generateTasks(
       {
-        gitDir: workDir,
         globOptions: {
           matchBase: false,
           nocase: true

--- a/test/runScript.spec.js
+++ b/test/runScript.spec.js
@@ -100,10 +100,13 @@ describe('runScript', () => {
   })
 
   it('should not pass `gitDir` as `cwd` to `execa()` if a non-git binary is called', async () => {
-    const [linter] = runScript(['jest'], ['test.js'], scripts, { gitDir: '../' })
+    const processCwdBkp = process.cwd
+    process.cwd = () => __dirname
+    const [linter] = runScript(['jest'], ['test.js'], scripts, {})
     await linter.task()
     expect(mockFn).toHaveBeenCalledTimes(1)
     expect(mockFn).lastCalledWith('jest', ['test.js'], {})
+    process.cwd = processCwdBkp
   })
 
   it('should use --silent in non-verbose mode', async () => {


### PR DESCRIPTION
This removes some leftover code and config options in tests for `gitDir`.