### PR TITLE
docs(README): Add link to releases for changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ See [examples](#examples) and [configuration](#configuration) below.
 >
 > To mitigate this rename your `commit` npm script to something non git hook namespace like, for example `{ cz: git-cz }`
 
+## Changelog
+
+[releases](https://github.com/okonet/lint-staged/releases)
+
 ## Command line flags
 
 ```


### PR DESCRIPTION
This adds a link to the releases to explicitly call out that it serves as our changelog.