### PR TITLE
chore(scripts): replace `npm run` with `yarn`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "precommit": "node index.js",
     "cz": "git-cz",
     "lint": "eslint .",
-    "lint:fix": "npm run lint -- --fix",
-    "pretest": "npm run lint",
+    "lint:fix": "yarn lint --fix",
+    "pretest": "yarn lint",
     "test": "jest --coverage",
     "test:watch": "jest --watch"
   },


### PR DESCRIPTION
for the sake of consistency, because we're using `yarn` now