### PR TITLE
ci(travis): Update `semantic-release` config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ node_js:
   - '4'
 
 before_install: yarn global add greenkeeper-lockfile@1
+install: yarn install --ignore-engines
 
 before_script: greenkeeper-lockfile-update
 after_script: greenkeeper-lockfile-upload

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ after_script: greenkeeper-lockfile-upload
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
-  - yarn global add semantic-release@11
+  - yarn global add --ignore-engines semantic-release@11
   - semantic-release
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ after_script: greenkeeper-lockfile-upload
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
-  - npm install -g semantic-release
-  - semantic-release pre && npm publish && semantic-release post
+  - yarn global add semantic-release@11
+  - semantic-release
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ environment:
 install:
   - ps: Install-Product node $env:nodejs_version
   - set CI=true
-  - yarn install
+  - yarn install --ignore-engines
 
 test_script:
   - node --version


### PR DESCRIPTION
in 2017, they have published 5 breaking changes 😰 
We need to update our `travis` config to make auto-publishing works again.

Edit: I think the most reasonable approach is to just install `semantic-release` as our devDependencies (like we did before)