### PR TITLE
docs: Update inconsistent docs for filtering files

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,9 @@ To set options and keep lint-staged extensible, advanced format can be used. Thi
 
 ## Filtering files
 
-It is possible to run linters for certain paths only by using [minimatch](https://github.com/isaacs/minimatch) patterns.
-The file patterns should be specified relative to the package root (where `lint-staged` is installed).
-The paths passed to the linters are absolute to avoid confusion in case they're executed with a different working directory.
+It is possible to run linters for certain paths only using glob patterns using [minimatch](https://github.com/isaacs/minimatch) to match those patterns. File patterns should be specified _relative to the `package.json` location_ (i.e. where `lint-staged` is installed).
+
+**NOTE:** If you're using `lint-staged<5` globs have to be _relative to the git root_.
 
 ```js
 {
@@ -149,12 +149,15 @@ The paths passed to the linters are absolute to avoid confusion in case they're 
 }
 ```
 
-**NOTE:** Prior to `lint-staged@5`, when the `gitDir` option was present, file patterns used for filtering via minimatch had to be relative to the git root.
-But that's no longer necessary and the `gitDir` option is deprecated. Instead, `lint-staged` will now do the following:
+When mathcing, lint-staged will do the following
 
 * Resolve the git root automatically, no configuration needed.
 * Pick the staged files which are present inside the project directory.
 * Filter them using the specified glob patterns.
+* Resolve filtered paths relative to the git root and make them absolute.
+* Pass absolute paths to the linters as arguments
+
+**NOTE:** Lint-staged will pass _absolute_ paths to the linters commands to avoid any confusion in case they're executed in a different working directory (i.e. when your `.git` directory isn't the same as your `package.json` directory).
 
 Also see [How to use `lint-staged` in a multi package monorepo?](#how-to-use-lint-staged-in-a-multi-package-monorepo)
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ To set options and keep lint-staged extensible, advanced format can be used. Thi
 ## Filtering files
 
 It is possible to run linters for certain paths only by using [minimatch](https://github.com/isaacs/minimatch) patterns.
-The file patterns should be relative to the project root(where `lint-staged` is installed).
+The file patterns should be specified relative to the package root (where `lint-staged` is installed).
+The paths passed to the linters are absolute to avoid confusion in case they're executed with a different working directory.
 
 ```js
 {
@@ -149,8 +150,7 @@ The file patterns should be relative to the project root(where `lint-staged` is 
 ```
 
 **NOTE:** Prior to `lint-staged@5`, when the `gitDir` option was present, file patterns used for filtering via minimatch had to be relative to the git root.
-But that's no longer necessary and the `gitDir` option is deprecated.
-Instead, `lint-staged` will now do the following:
+But that's no longer necessary and the `gitDir` option is deprecated. Instead, `lint-staged` will now do the following:
 
 * Resolve the git root automatically, no configuration needed.
 * Pick the staged files which are present inside the project directory.

--- a/README.md
+++ b/README.md
@@ -132,8 +132,7 @@ To set options and keep lint-staged extensible, advanced format can be used. Thi
 
 ## Filtering files
 
-It is possible to run linters for certain paths only by using glob patterns. [minimatch](https://github.com/isaacs/minimatch) is used to filter the staged files according to these patterns.
-File patterns should be specified _relative to the `package.json` location_ (i.e. where `lint-staged` is installed).
+It is possible to run linters for certain paths only by using glob patterns. [minimatch](https://github.com/isaacs/minimatch) is used to filter the staged files according to these patterns. File patterns should be specified _relative to the `package.json` location_ (i.e. where `lint-staged` is installed).
 
 **NOTE:** If you're using `lint-staged<5` globs have to be _relative to the git root_.
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,8 @@ To set options and keep lint-staged extensible, advanced format can be used. Thi
 
 ## Filtering files
 
-It is possible to run linters for certain paths only using glob patterns using [minimatch](https://github.com/isaacs/minimatch) to match those patterns. File patterns should be specified _relative to the `package.json` location_ (i.e. where `lint-staged` is installed).
+It is possible to run linters for certain paths only by using glob patterns. [minimatch](https://github.com/isaacs/minimatch) is used to filter the staged files according to these patterns.
+File patterns should be specified _relative to the `package.json` location_ (i.e. where `lint-staged` is installed).
 
 **NOTE:** If you're using `lint-staged<5` globs have to be _relative to the git root_.
 
@@ -149,15 +150,14 @@ It is possible to run linters for certain paths only using glob patterns using [
 }
 ```
 
-When mathcing, lint-staged will do the following
+When matching, `lint-staged` will do the following
 
 * Resolve the git root automatically, no configuration needed.
 * Pick the staged files which are present inside the project directory.
 * Filter them using the specified glob patterns.
-* Resolve filtered paths relative to the git root and make them absolute.
-* Pass absolute paths to the linters as arguments
+* Pass absolute paths to the linters as arguments.
 
-**NOTE:** Lint-staged will pass _absolute_ paths to the linters commands to avoid any confusion in case they're executed in a different working directory (i.e. when your `.git` directory isn't the same as your `package.json` directory).
+**NOTE:** `lint-staged` will pass _absolute_ paths to the linters to avoid any confusion in case they're executed in a different working directory (i.e. when your `.git` directory isn't the same as your `package.json` directory).
 
 Also see [How to use `lint-staged` in a multi package monorepo?](#how-to-use-lint-staged-in-a-multi-package-monorepo)
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,8 @@ To set options and keep lint-staged extensible, advanced format can be used. Thi
 
 ## Filtering files
 
-It is possible to run linters for certain paths only by using [minimatch](https://github.com/isaacs/minimatch) patterns. The paths used for filtering via minimatch are relative to the directory that contains the `.git` directory. The paths passed to the linters are absolute to avoid confusion in case they're executed with a different working directory, as would be the case when using the `gitDir` option.
+It is possible to run linters for certain paths only by using [minimatch](https://github.com/isaacs/minimatch) patterns.
+The file patterns should be relative to the project root(where `lint-staged` is installed).
 
 ```js
 {
@@ -146,6 +147,16 @@ It is possible to run linters for certain paths only by using [minimatch](https:
   "src/**/*.js": "eslint",
 }
 ```
+
+**NOTE:** Prior to `lint-staged@5`, when the `gitDir` option was present, file patterns used for filtering via minimatch had to be relative to the git root.
+But that's no longer necessary and the `gitDir` option is deprecated.
+Instead, `lint-staged` will now do the following:
+
+* Resolve the git root automatically, no configuration needed.
+* Pick the staged files which are present inside the project directory.
+* Filter them using the specified glob patterns.
+
+Also see [How to use `lint-staged` in a multi package monorepo?](#how-to-use-lint-staged-in-a-multi-package-monorepo)
 
 ## What commands are supported?
 


### PR DESCRIPTION
The 'Filtering files' section in the readme had not been updated when the `gitDir` option was deprecated in 5.0. This updates the section explaining the changes related to how files are resolved since `lint-staged@5`.

Preview link - [/README.md@`docs/filtering`#filtering-files](https://github.com/okonet/lint-staged/blob/docs/filtering/README.md#filtering-files)

Closes #373.