### PR TITLE
test: Use `expect.assertions()` to test async codes

### DIFF
--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -24,6 +24,7 @@ describe('lintStaged', () => {
   })
 
   it('should output config in debug mode', async () => {
+    expect.assertions(1)
     const config = {
       linters: {
         '*': 'mytask'
@@ -35,6 +36,7 @@ describe('lintStaged', () => {
   })
 
   it('should not output config in normal mode', async () => {
+    expect.assertions(1)
     const config = {
       '*': 'mytask'
     }
@@ -44,17 +46,20 @@ describe('lintStaged', () => {
   })
 
   it('should load config file when specified', async () => {
+    expect.assertions(1)
     await lintStaged(logger, path.join(__dirname, '__mocks__', 'my-config.json'), true)
     expect(logger.printHistory()).toMatchSnapshot()
   })
 
   it('should print helpful error message when config file is not found', async () => {
+    expect.assertions(1)
     mockCosmiconfigWith(null)
     await lintStaged(logger)
     expect(logger.printHistory()).toMatchSnapshot()
   })
 
   it('should print helpful error message when explicit config file is not found', async () => {
+    expect.assertions(1)
     const nonExistentConfig = 'fake-config-file.yml'
 
     // Serialize Windows, Linux and MacOS paths consistently

--- a/test/printErrors.spec.js
+++ b/test/printErrors.spec.js
@@ -24,6 +24,7 @@ describe('printErrors', () => {
   })
 
   it('should print Listr nested errors', async () => {
+    expect.assertions(1)
     const list = new Listr(
       [
         {

--- a/test/runAll.spec.js
+++ b/test/runAll.spec.js
@@ -47,11 +47,13 @@ describe('runAll', () => {
   })
 
   it('should resolve the promise with no files', async () => {
+    expect.assertions(1)
     await runAll(scripts, getConfig({ linters: { '*.js': ['echo "sample"'] } }))
     expect(console.printHistory()).toMatchSnapshot()
   })
 
   it('should not skip tasks if there are files', async () => {
+    expect.assertions(1)
     sgfMock.mockImplementationOnce((params, callback) => {
       callback(null, [{ filename: 'sample.js', status: 'sample' }])
     })

--- a/test/runAll.spec.js
+++ b/test/runAll.spec.js
@@ -62,10 +62,10 @@ describe('runAll', () => {
   })
 
   it('should reject the promise when staged-git-files errors', () => {
+    expect.assertions(1)
     sgfMock.mockImplementationOnce((params, callback) => {
       callback('test', undefined)
     })
-    expect.assertions(1)
     return expect(runAll(scripts, getConfig({}))).rejects.toEqual('test')
   })
 })

--- a/test/runAll.spec.js
+++ b/test/runAll.spec.js
@@ -41,9 +41,11 @@ describe('runAll', () => {
     expect(runAll(scripts, getConfig({}))).toBeInstanceOf(Promise)
   })
 
-  it('should resolve the promise with no tasks', () => {
+  it('should resolve the promise with no tasks', async () => {
     expect.assertions(1)
-    return expect(runAll(scripts, getConfig({}))).resolves.toEqual('No tasks to run.')
+    const res = await runAll(scripts, getConfig({}))
+
+    expect(res).toEqual('No tasks to run.')
   })
 
   it('should resolve the promise with no files', async () => {
@@ -61,11 +63,16 @@ describe('runAll', () => {
     expect(console.printHistory()).toMatchSnapshot()
   })
 
-  it('should reject the promise when staged-git-files errors', () => {
+  it('should reject the promise when staged-git-files errors', async () => {
     expect.assertions(1)
     sgfMock.mockImplementationOnce((params, callback) => {
       callback('test', undefined)
     })
-    return expect(runAll(scripts, getConfig({}))).rejects.toEqual('test')
+
+    try {
+      await runAll(scripts, getConfig({}))
+    } catch (err) {
+      expect(err).toEqual('test')
+    }
   })
 })

--- a/test/runScript-mock-findBin.spec.js
+++ b/test/runScript-mock-findBin.spec.js
@@ -31,6 +31,7 @@ describe('runScript with absolute paths', () => {
   })
 
   it('passes `gitDir` as `cwd` to `execa()` when git is called via absolute path', async () => {
+    expect.assertions(2)
     const [linter] = runScript(['git add'], ['test.js'], packageJSON)
     await linter.task()
     expect(mockFn).toHaveBeenCalledTimes(1)

--- a/test/runScript-mock-pMap.spec.js
+++ b/test/runScript-mock-pMap.spec.js
@@ -19,6 +19,7 @@ describe('runScript', () => {
   })
 
   it('should respect concurrency', async () => {
+    expect.assertions(2)
     pMapMock.mockImplementation(() => Promise.resolve(true))
 
     const [linter] = runScript(['test'], ['test1.js', 'test2.js'], packageJSON, {
@@ -32,6 +33,7 @@ describe('runScript', () => {
   })
 
   it('should handle unexpected error', async () => {
+    expect.assertions(1)
     pMapMock.mockImplementation(() => Promise.reject(new Error('Unexpected Error')))
 
     const [linter] = runScript(['test'], ['test.js'], packageJSON)

--- a/test/runScript.spec.js
+++ b/test/runScript.spec.js
@@ -31,6 +31,7 @@ describe('runScript', () => {
   })
 
   it('should work with a single command', async () => {
+    expect.assertions(4)
     const res = runScript('test', ['test.js'], scripts)
     expect(res.length).toBe(1)
     const [linter] = res
@@ -42,6 +43,7 @@ describe('runScript', () => {
   })
 
   it('should work with multiple commands', async () => {
+    expect.assertions(9)
     const res = runScript(['test', 'test2'], ['test.js'], scripts)
     expect(res.length).toBe(2)
     const [linter1, linter2] = res
@@ -61,6 +63,7 @@ describe('runScript', () => {
   })
 
   it('should respect chunk size', async () => {
+    expect.assertions(3)
     const [linter] = runScript(['test'], ['test1.js', 'test2.js'], scripts, {
       chunkSize: 1
     })
@@ -71,6 +74,7 @@ describe('runScript', () => {
   })
 
   it('should support non npm scripts', async () => {
+    expect.assertions(7)
     const res = runScript(['node --arg=true ./myscript.js', 'git add'], ['test.js'], scripts)
     expect(res.length).toBe(2)
     const [linter1, linter2] = res
@@ -87,6 +91,7 @@ describe('runScript', () => {
   })
 
   it('should pass cwd to execa if gitDir is different than process.cwd for non-npm tasks', async () => {
+    expect.assertions(4)
     resolveGitDir.mockReturnValueOnce('../')
     const res = runScript(['test', 'git add'], ['test.js'], scripts)
     const [linter1, linter2] = res
@@ -100,6 +105,7 @@ describe('runScript', () => {
   })
 
   it('should not pass `gitDir` as `cwd` to `execa()` if a non-git binary is called', async () => {
+    expect.assertions(2)
     const processCwdBkp = process.cwd
     process.cwd = () => __dirname
     const [linter] = runScript(['jest'], ['test.js'], scripts, {})
@@ -110,6 +116,7 @@ describe('runScript', () => {
   })
 
   it('should use --silent in normal mode', async () => {
+    expect.assertions(2)
     const [linter] = runScript('test', ['test.js'], scripts, {}, false)
     await linter.task()
     expect(mockFn).toHaveBeenCalledTimes(1)
@@ -117,6 +124,7 @@ describe('runScript', () => {
   })
 
   it('should not use --silent in debug mode', async () => {
+    expect.assertions(2)
     const [linter] = runScript('test', ['test.js'], scripts, {}, true)
     await linter.task()
     expect(mockFn).toHaveBeenCalledTimes(1)
@@ -124,6 +132,7 @@ describe('runScript', () => {
   })
 
   it('should throw error for failed linters', async () => {
+    expect.assertions(1)
     const linterErr = new Error()
     linterErr.stdout = 'Mock error'
     linterErr.stderr = ''


### PR DESCRIPTION
To make sure certain numbers of assertions are called,
IMO this is important to give us more confidence in testing async codes.

We're using `expect.assertions()` already in:
https://github.com/okonet/lint-staged/blob/master/test/runAll.spec.js#L45
https://github.com/okonet/lint-staged/blob/master/test/runAll.spec.js#L66