### PR TITLE
ci: Cache dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 notifications:
   email: false
+cache:
+  yarn: true
+  directories: node_modules
 node_js:
   - '8'
   - '6'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,10 @@ branches:
     - master
     - /^greenkeeper/.*$/
 
+cache:
+  - node_modules
+  - "%LOCALAPPDATA%\\Yarn"
+
 environment:
   matrix:
     - nodejs_version: '8'


### PR DESCRIPTION
To speed up CI builds,
we didn't do this before because we didn't commit lock files and wanted to run builds with fresh dependencies