### PR TITLE
ci(travis): Use `semantic-release` v12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ after_script: greenkeeper-lockfile-upload
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
-  - yarn global add --ignore-engines travis-deploy-once@4 semantic-release@12
-  - travis-deploy-once "semantic-release"
+  - yarn global add travis-deploy-once@4
+  - travis-deploy-once "yarn global add semantic-release@12 && semantic-release"
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ after_script: greenkeeper-lockfile-upload
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
-  - yarn global add --ignore-engines semantic-release@11
-  - semantic-release
+  - yarn global add --ignore-engines travis-deploy-once@4 semantic-release@12
+  - travis-deploy-once "semantic-release"
 
 branches:
   only:


### PR DESCRIPTION
v12 is now the `latest` version of `semantic-release`