### PR TITLE
feat(config): add `ignore` config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,12 +124,13 @@ To set options and keep lint-staged extensible, advanced format can be used. Thi
 
 ## Options
 
-* `linters` — `Object` — keys (`String`) are glob patterns, values (`Array<String> | String`) are commands to execute.
 * `concurrent` — *true* — runs linters for each glob pattern simultaneously. If you don’t want this, you can set `concurrent: false`
 * `chunkSize` — Max allowed chunk size based on number of files for glob pattern. This is important on windows based systems to avoid command length limitations. See [#147](https://github.com/okonet/lint-staged/issues/147)
-* `subTaskConcurrency` — `1` — Controls concurrency for processing chunks generated for each linter. Execution is **not** concurrent by default(see [#225](https://github.com/okonet/lint-staged/issues/225))
-* `globOptions` — `{ matchBase: true, dot: true }` — [minimatch options](https://github.com/isaacs/minimatch#options) to customize how glob patterns match files.
+* `globOptions` — `{ matchBase: true, dot: true }` — [minimatch options](https://github.com/isaacs/minimatch#options) to 
 * `ignore` - `['**/docs/**/*.js']` - array of glob patterns to entirely ignore from any task.
+* `linters` — `Object` — keys (`String`) are glob patterns, values (`Array<String> | String`) are commands to execute.
+* `subTaskConcurrency` — `1` — Controls concurrency for processing chunks generated for each linter. Execution is **not** concurrent by default(see [#225](https://github.com/okonet/lint-staged/issues/225))
+customize how glob patterns match files.
 
 ## Filtering files
 

--- a/README.md
+++ b/README.md
@@ -127,10 +127,10 @@ To set options and keep lint-staged extensible, advanced format can be used. Thi
 * `concurrent` — *true* — runs linters for each glob pattern simultaneously. If you don’t want this, you can set `concurrent: false`
 * `chunkSize` — Max allowed chunk size based on number of files for glob pattern. This is important on windows based systems to avoid command length limitations. See [#147](https://github.com/okonet/lint-staged/issues/147)
 * `globOptions` — `{ matchBase: true, dot: true }` — [minimatch options](https://github.com/isaacs/minimatch#options) to 
+customize how glob patterns match files.
 * `ignore` - `['**/docs/**/*.js']` - array of glob patterns to entirely ignore from any task.
 * `linters` — `Object` — keys (`String`) are glob patterns, values (`Array<String> | String`) are commands to execute.
 * `subTaskConcurrency` — `1` — Controls concurrency for processing chunks generated for each linter. Execution is **not** concurrent by default(see [#225](https://github.com/okonet/lint-staged/issues/225))
-customize how glob patterns match files.
 
 ## Filtering files
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ To set options and keep lint-staged extensible, advanced format can be used. Thi
 * `chunkSize` — Max allowed chunk size based on number of files for glob pattern. This is important on windows based systems to avoid command length limitations. See [#147](https://github.com/okonet/lint-staged/issues/147)
 * `subTaskConcurrency` — `1` — Controls concurrency for processing chunks generated for each linter. Execution is **not** concurrent by default(see [#225](https://github.com/okonet/lint-staged/issues/225))
 * `globOptions` — `{ matchBase: true, dot: true }` — [minimatch options](https://github.com/isaacs/minimatch#options) to customize how glob patterns match files.
+* `ignore` - `['**/docs/**/*.js']` - array of glob patterns to entirely ignore from any task.
 
 ## Filtering files
 

--- a/src/generateTasks.js
+++ b/src/generateTasks.js
@@ -14,6 +14,12 @@ module.exports = function generateTasks(config, relFiles) {
   const normalizedConfig = getConfig(config) // Ensure we have a normalized config
   const linters = normalizedConfig.linters
   const globOptions = normalizedConfig.globOptions
+  const ignoreFilters = normalizedConfig.ignore.map(pattern => minimatch.filter(pattern))
+  // if there are filters, then return false if the input matches any
+  // if there are not, then return true for all input
+  const ignoreFilter = ignoreFilters.length
+    ? input => !ignoreFilters.some(filter => filter(input))
+    : () => true
 
   const gitDir = resolveGitDir()
   const cwd = process.cwd()
@@ -30,6 +36,7 @@ module.exports = function generateTasks(config, relFiles) {
       .map(file => path.relative(cwd, file))
       // We want to filter before resolving paths
       .filter(filter)
+      .filter(ignoreFilter)
       // Return absolute path after the filter is run
       .map(file => path.resolve(cwd, file))
 

--- a/src/getConfig.js
+++ b/src/getConfig.js
@@ -27,6 +27,7 @@ const defaultConfig = {
     dot: true
   },
   linters: {},
+  ignore: [],
   subTaskConcurrency: 1,
   renderer: 'update'
 }

--- a/test/__snapshots__/getConfig.spec.js.snap
+++ b/test/__snapshots__/getConfig.spec.js.snap
@@ -8,6 +8,7 @@ Object {
     "dot": true,
     "matchBase": true,
   },
+  "ignore": Array [],
   "linters": Object {},
   "renderer": "update",
   "subTaskConcurrency": 1,
@@ -22,6 +23,7 @@ Object {
     "dot": true,
     "matchBase": true,
   },
+  "ignore": Array [],
   "linters": Object {},
   "renderer": "update",
   "subTaskConcurrency": 1,
@@ -36,6 +38,7 @@ Object {
     "dot": true,
     "matchBase": true,
   },
+  "ignore": Array [],
   "linters": Object {
     "*.js": Array [
       "eslint --fix",

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -13,6 +13,7 @@ LOG {
     matchBase: true,
     dot: true
   },
+  ignore: [],
   subTaskConcurrency: 1,
   renderer: 'verbose'
 }"
@@ -33,6 +34,7 @@ LOG {
     matchBase: true,
     dot: true
   },
+  ignore: [],
   subTaskConcurrency: 1,
   renderer: 'verbose'
 }"

--- a/test/generateTasks.spec.js
+++ b/test/generateTasks.spec.js
@@ -205,4 +205,18 @@ describe('generateTasks', () => {
       )
     })
   })
+
+  it('should ignore patterns in the ignore array of configuration', () => {
+    const pattern = '**/*.js'
+    const commands = 'lint'
+    const result = generateTasks(
+      { ignore: ['**/ignore/**', '**/ignore.*'], linters: { [pattern]: commands } },
+      ['ignore/me.js', 'ignore.me.js', 'cool/js.js']
+    )
+    expect(result[0]).toEqual({
+      pattern,
+      commands,
+      fileList: [`${workDir}/cool/js.js`].map(path.normalize)
+    })
+  })
 })

--- a/test/getConfig.spec.js
+++ b/test/getConfig.spec.js
@@ -139,6 +139,7 @@ describe('getConfig', () => {
       linters: {
         '*.js': 'eslint'
       },
+      ignore: ['docs/**/*.js'],
       subTaskConcurrency: 10,
       renderer: 'custom'
     }


### PR DESCRIPTION
This allows users to prevent some files from being processed by lint-staged ever. This is useful if your project contains generated files that you commit to the repository, but don't want to process.

[I know it's not great to commit generated files](https://blog.kentcdodds.com/why-i-don-t-commit-generated-files-to-master-a4d76382564), but in this case it's really the best solution for me.

I didn't open an issue for this because I really need this anyway so if it's not merged then I'll just use my own fork.