### PR TITLE
refactor: Drop support for Node.js 4

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,7 @@
   "presets": [
     ["env", {
       "targets": {
-        "node": 4
+        "node": 6
       }
     }]
   ]

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,6 +13,19 @@
       "error",
       "global"
     ],
-    "no-console": "off"
+    "no-console": "off",
+    "prefer-destructuring": [
+      "warn",
+      {
+          "VariableDeclarator": {
+              "array": true,
+              "object": true
+          },
+          "AssignmentExpression": {
+              "array": false,
+              "object": false
+          }
+      }
+  ]
   }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,9 @@ cache:
 node_js:
   - '8'
   - '6'
-  - '4'
 
 before_install: yarn global add greenkeeper-lockfile@1
-install: yarn install --ignore-engines
+install: yarn install
 
 before_script: greenkeeper-lockfile-update
 after_script: greenkeeper-lockfile-upload

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Run linters against staged git files and don't let :poop: slip into your code base!
 
+The latest versions of `lint-staged` require Node.js v6 or newer. (Versions of `lint-staged` below v7 still work with Node.js v4.)
+
 ## Why
 
 Linting makes more sense when running before committing your code. By doing that you can ensure no errors are going into repository and enforce code style. But running a lint process on a whole project is slow and linting results can be irrelevant. Ultimately you only want to lint files that will be committed.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,12 +12,11 @@ environment:
   matrix:
     - nodejs_version: '8'
     - nodejs_version: '6'
-    - nodejs_version: '4'
 
 install:
   - ps: Install-Product node $env:nodejs_version
   - set CI=true
-  - yarn install --ignore-engines
+  - yarn install
 
 test_script:
   - node --version

--- a/index.js
+++ b/index.js
@@ -2,9 +2,11 @@
 
 'use strict'
 
+const pkg = require('./package.json')
+require('please-upgrade-node')(pkg)
+
 const cmdline = require('commander')
 const debugLib = require('debug')
-const pkg = require('./package.json')
 
 const debug = debugLib('lint-staged:bin')
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "Suhas Karanth <sudo.suhas@gmail.com>"
   ],
   "engines": {
-    "node": ">=4.2.0"
+    "node": ">=6"
   },
   "bin": "index.js",
   "files": [
@@ -45,6 +45,7 @@
     "p-map": "^1.1.1",
     "path-is-inside": "^1.0.2",
     "pify": "^3.0.0",
+    "please-upgrade-node": "^3.0.1",
     "staged-git-files": "1.0.0",
     "stringify-object": "^3.2.0"
   },

--- a/src/checkPkgScripts.js
+++ b/src/checkPkgScripts.js
@@ -20,14 +20,15 @@ const warn = msg => {
  */
 module.exports = function checkPkgScripts(pkg, cmd, binName, args) {
   if (pkg && pkg.scripts) {
+    const { scripts } = pkg
     let scriptName
     let script
-    if (has(pkg.scripts, cmd)) {
+    if (has(scripts, cmd)) {
       scriptName = cmd
-      script = pkg.scripts[cmd]
-    } else if (has(pkg.scripts, binName)) {
+      script = scripts[cmd]
+    } else if (has(scripts, binName)) {
       scriptName = binName
-      script = pkg.scripts[binName]
+      script = scripts[binName]
     } else {
       return
     }

--- a/src/findBin.js
+++ b/src/findBin.js
@@ -23,9 +23,7 @@ module.exports = function findBin(cmd) {
    *    "*.js": "eslint"
    *  }
    */
-  const parts = cmd.split(' ')
-  const binName = parts[0]
-  const args = parts.splice(1)
+  const [binName, ...args] = cmd.split(' ')
 
   if (cache.has(binName)) {
     debug('Resolving binary for `%s` from cache', binName)

--- a/src/generateTasks.js
+++ b/src/generateTasks.js
@@ -3,7 +3,7 @@
 const path = require('path')
 const micromatch = require('micromatch')
 const pathIsInside = require('path-is-inside')
-const getConfig = require('./getConfig').getConfig
+const { getConfig } = require('./getConfig')
 const resolveGitDir = require('./resolveGitDir')
 
 const debug = require('debug')('lint-staged:gen-tasks')
@@ -12,8 +12,7 @@ module.exports = function generateTasks(config, relFiles) {
   debug('Generating linter tasks')
 
   const normalizedConfig = getConfig(config) // Ensure we have a normalized config
-  const linters = normalizedConfig.linters
-  const globOptions = normalizedConfig.globOptions
+  const { linters, globOptions } = normalizedConfig
   const ignorePatterns = normalizedConfig.ignore.map(pattern => `!${pattern}`)
 
   const gitDir = resolveGitDir()

--- a/src/getConfig.js
+++ b/src/getConfig.js
@@ -7,9 +7,8 @@ const format = require('stringify-object')
 const intersection = require('lodash/intersection')
 const defaultsDeep = require('lodash/defaultsDeep')
 const isObject = require('lodash/isObject')
-const validate = require('jest-validate').validate
-const logValidationWarning = require('jest-validate').logValidationWarning
-const unknownOptionWarning = require('jest-validate/build/warnings').unknownOptionWarning
+const { validate, logValidationWarning } = require('jest-validate')
+const { unknownOptionWarning } = require('jest-validate/build/warnings')
 const isGlob = require('is-glob')
 
 const debug = require('debug')('lint-staged:cfg')
@@ -73,7 +72,7 @@ function unknownValidationReporter(config, example, option, options) {
 
   will fix it and remove this message.`
 
-    const comment = options.comment
+    const { comment } = options
     const name = options.title.warning
     return logValidationWarning(name, message, comment)
   }

--- a/src/index.js
+++ b/src/index.js
@@ -5,8 +5,7 @@
 const dedent = require('dedent')
 const cosmiconfig = require('cosmiconfig')
 const stringifyObject = require('stringify-object')
-const getConfig = require('./getConfig').getConfig
-const validateConfig = require('./getConfig').validateConfig
+const { getConfig, validateConfig } = require('./getConfig')
 const printErrors = require('./printErrors')
 const runAll = require('./runAll')
 
@@ -23,9 +22,8 @@ const errConfigNotFound = new Error('Config could not be found')
 /**
  * Root lint-staged function that is called from .bin
  */
-module.exports = function lintStaged(injectedLogger, configPath, debugMode) {
+module.exports = function lintStaged(logger = console, configPath, debugMode) {
   debug('Loading config using `cosmiconfig`')
-  const logger = injectedLogger || console
 
   const explorer = cosmiconfig('lint-staged', {
     configPath,

--- a/src/runAll.js
+++ b/src/runAll.js
@@ -22,8 +22,7 @@ module.exports = function runAll(config) {
     throw new Error('Invalid config provided to runAll! Use getConfig instead.')
   }
 
-  const concurrent = config.concurrent
-  const renderer = config.renderer
+  const { concurrent, renderer } = config
   const gitDir = resolveGitDir()
   debug('Resolved git directory to be `%s`', gitDir)
 

--- a/src/runScript.js
+++ b/src/runScript.js
@@ -5,7 +5,7 @@ const dedent = require('dedent')
 const execa = require('execa')
 const logSymbols = require('log-symbols')
 const pMap = require('p-map')
-const getConfig = require('./getConfig').getConfig
+const { getConfig } = require('./getConfig')
 const calcChunkSize = require('./calcChunkSize')
 const findBin = require('./findBin')
 const resolveGitDir = require('./resolveGitDir')
@@ -16,8 +16,7 @@ module.exports = function runScript(commands, pathsToLint, config) {
   debug('Running script with commands %o', commands)
 
   const normalizedConfig = getConfig(config)
-  const chunkSize = normalizedConfig.chunkSize
-  const concurrency = normalizedConfig.subTaskConcurrency
+  const { chunkSize, subTaskConcurrency: concurrency } = normalizedConfig
   const gitDir = resolveGitDir()
 
   const filePathChunks = chunk(pathsToLint, calcChunkSize(pathsToLint, chunkSize))

--- a/yarn.lock
+++ b/yarn.lock
@@ -3699,6 +3699,10 @@ pkg-dir@^1.0.0:
   dependencies:
     find-up "^1.0.0"
 
+please-upgrade-node@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.0.1.tgz#0a681f2c18915e5433a5ca2cd94e0b8206a782db"
+
 pluralize@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"


### PR DESCRIPTION
This sets the minimum required  Node.js version to `>=6` and does the relevant config, code and docs update.

### Code Changelog

- Change Node.js requirement in `engines.node` to `>=6`. Use `please-upgrade-node` to give helpful error message on older versions.
- Remove node 4 from list of Node.js versions to test on CI. Also remove `--ignore-engines` flag for `yarn install`, not required with node 6.
- Add note to readme for Node.js version requirement.
- Target node 6 for `babel-preset-env` (relevant only for tests).
- Add eslint rule for `prefer-destructuring`, do relevant code changes.
- Use default argument for `logger` passed to `src/index.js`

Closes #372. 