### PR TITLE
fix: Use silent nonTTYRenderer to avoid dupl output

### DIFF
--- a/src/runAll.js
+++ b/src/runAll.js
@@ -55,6 +55,7 @@ module.exports = function runAll(config) {
         dateFormat: false,
         concurrent,
         renderer,
+        nonTTYRenderer: 'silent',
         exitOnError: !concurrent // Wait for all errors when running concurrently
       }).run()
     }


### PR DESCRIPTION
The error output, if any, was being printed thrice in non-TTY consoles. Use of the `silent` renderer for non-TTY consoles fixes the issue partially and should be helpful at least for some use-cases. If `--debug` flag is passed or if the `renderer` option is set to `verbose` in the `lint-staged` config(_option not documented?_), the output will still be duplicated. Not sure how that could be fixed.

Closes #308.
Related to #142.