### PR TITLE
 Fix duplicate error messages #142

### DIFF
--- a/src/runScript.js
+++ b/src/runScript.js
@@ -66,7 +66,7 @@ module.exports = function runScript(commands, pathsToLint, config) {
               ${errStdout}
               ${errStderr}
             `)
-          throw new Error('');
+          throw new Error('')
         })
     }
   }))

--- a/src/runScript.js
+++ b/src/runScript.js
@@ -61,7 +61,7 @@ module.exports = function runScript(commands, pathsToLint, config) {
           const errStderr = errors.map(err => err.stderr).join('')
 
           // prettier-ignore
-          console.log(dedent`
+          console.log(`
               ${logSymbols.error} ${linter} found some errors. Please fix them and try committing again.
               ${errStdout}
               ${errStderr}


### PR DESCRIPTION
Instead of throwing the error to the error method, we log it and pass an empty string to it. Hence the elimination of the 3x error messages.

See screenshots below:
[Before](https://postimg.org/image/3ly0fom07/)
[After](https://postimg.org/image/4o86y7x3r/)