### PR TITLE
fix: Hide err msg in private field to avoid duplicate logs

### DIFF
--- a/src/printErrors.js
+++ b/src/printErrors.js
@@ -1,11 +1,14 @@
 'use strict'
 
+// Work-around for duplicated error logs, see #142
+const errMsg = err => (err.privateMsg != null ? err.privateMsg : err.message)
+
 module.exports = function printErrors(errorInstance) {
   if (Array.isArray(errorInstance.errors)) {
     errorInstance.errors.forEach(lintError => {
-      console.error(lintError.message)
+      console.error(errMsg(lintError))
     })
   } else {
-    console.error(errorInstance.message)
+    console.error(errMsg(errorInstance))
   }
 }

--- a/src/runScript.js
+++ b/src/runScript.js
@@ -60,12 +60,19 @@ module.exports = function runScript(commands, pathsToLint, config) {
           const errStdout = errors.map(err => err.stdout).join('')
           const errStderr = errors.map(err => err.stderr).join('')
 
-          // prettier-ignore
-          throw new Error(dedent`
-              ${logSymbols.error} ${linter} found some errors. Please fix them and try committing again.
-              ${errStdout}
-              ${errStderr}
-            `)
+          // If we set the message on the error instance, it gets logged
+          // multiple times(see #142). So we set the actual error message in a
+          // private field and extract it later, log only once.
+          const err = new Error()
+          err.privateMsg = dedent`
+            ${
+              logSymbols.error
+            } "${linter}" found some errors. Please fix them and try committing again.
+            ${errStdout}
+            ${errStderr}
+          `
+
+          throw err
         })
     }
   }))

--- a/test/runScript.spec.js
+++ b/test/runScript.spec.js
@@ -133,9 +133,10 @@ describe('runScript', () => {
     try {
       await linter.task()
     } catch (err) {
-      // prettier-ignore
-      expect(err.message).toMatch(dedent`
-        ${logSymbols.error} mock-fail-linter found some errors. Please fix them and try committing again.
+      expect(err.privateMsg).toMatch(dedent`
+        ${
+          logSymbols.error
+        } "mock-fail-linter" found some errors. Please fix them and try committing again.
         Mock error
       `)
     }


### PR DESCRIPTION
This hides the error message in a private field to get around the duplicate logs issue. Most of the credit goes to @umarmw for the idea, so thank you!

Closes #142, #308, #406, #415.