### PR TITLE
fix: Parse arguments with single quotes properly. Better tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "dependencies": {
     "app-root-path": "^2.0.1",
     "chalk": "^2.3.1",
-    "cli-command-parser": "^1.0.3",
     "commander": "^2.14.1",
     "cosmiconfig": "^4.0.0",
     "debug": "^3.1.0",
@@ -46,6 +45,7 @@
     "pify": "^3.0.0",
     "please-upgrade-node": "^3.0.1",
     "staged-git-files": "1.1.1",
+    "string-argv": "^0.0.2",
     "stringify-object": "^3.2.2"
   },
   "devDependencies": {

--- a/src/findBin.js
+++ b/src/findBin.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const parse = require('cli-command-parser')
+const parse = require('string-argv')
 const appRoot = require('app-root-path')
 const npmWhich = require('npm-which')(process.cwd())
 const checkPkgScripts = require('./checkPkgScripts')

--- a/test/findBin.spec.js
+++ b/test/findBin.spec.js
@@ -41,8 +41,17 @@ describe('findBin', () => {
   })
 
   it('should parse cmd and add arguments to args', () => {
-    const { bin, args } = findBin('my-linter task --fix --string "additional argument"')
+    const { bin, args } = findBin(
+      'my-linter task --fix --rule \'quotes: [2, double]\' --another "[complex:argument]"'
+    )
     expect(bin).toEqual('my-linter')
-    expect(args).toEqual(['task', '--fix', '--string', 'additional argument'])
+    expect(args).toEqual([
+      'task',
+      '--fix',
+      '--rule',
+      'quotes: [2, double]',
+      '--another',
+      '[complex:argument]'
+    ])
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -982,10 +982,6 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-cli-command-parser@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/cli-command-parser/-/cli-command-parser-1.0.3.tgz#377af3ce60ad2d8a34a7e5eae4b395d491b0d652"
-
 cli-cursor@^1.0.1, cli-cursor@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
@@ -4400,6 +4396,10 @@ stream-to-observable@^0.2.0:
   resolved "https://registry.yarnpkg.com/stream-to-observable/-/stream-to-observable-0.2.0.tgz#59d6ea393d87c2c0ddac10aa0d561bc6ba6f0e10"
   dependencies:
     any-observable "^0.2.0"
+
+string-argv@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.0.2.tgz#dac30408690c21f3c3630a3ff3a05877bdcbd736"
 
 string-length@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Switched to `string-argv` since `cli-command-parser` seems to have a bug.

Closes #419 

Note to self: next time listen to @sudo-suhas 🤦‍♂️