### PR TITLE
patch: support linting parent directories

### DIFF
--- a/src/generateTasks.js
+++ b/src/generateTasks.js
@@ -25,15 +25,13 @@ module.exports = function generateTasks(config, relFiles) {
 
     const fileList = micromatch(
       files
-        // Only worry about children of the CWD
-        .filter(file => pathIsInside(file, cwd))
-        // Make the paths relative to CWD for filtering
-        .map(file => path.relative(cwd, file)),
+        // Make the paths relative to gitDir for filtering
+        .map(file => path.relative(gitDir, file)),
       patterns,
       globOptions
     )
       // Return absolute path after the filter is run
-      .map(file => path.resolve(cwd, file))
+      .map(file => path.resolve(gitDir, file))
 
     const task = { pattern, commands, fileList }
     debug('Generated task: \n%O', task)

--- a/src/generateTasks.js
+++ b/src/generateTasks.js
@@ -2,7 +2,6 @@
 
 const path = require('path')
 const micromatch = require('micromatch')
-const pathIsInside = require('path-is-inside')
 const { getConfig } = require('./getConfig')
 const resolveGitDir = require('./resolveGitDir')
 
@@ -16,7 +15,6 @@ module.exports = function generateTasks(config, relFiles) {
   const ignorePatterns = normalizedConfig.ignore.map(pattern => `!${pattern}`)
 
   const gitDir = resolveGitDir()
-  const cwd = process.cwd()
   const files = relFiles.map(file => path.resolve(gitDir, file))
 
   return Object.keys(linters).map(pattern => {

--- a/test/generateTasks.spec.js
+++ b/test/generateTasks.spec.js
@@ -86,18 +86,6 @@ describe('generateTasks', () => {
     })
   })
 
-  it('should not match non-children files', () => {
-    const relPath = path.resolve(path.join(process.cwd(), '..'))
-    resolveGitDir.mockReturnValueOnce(relPath)
-    const result = generateTasks(Object.assign({}, config), files)
-    const linter = result.find(item => item.pattern === '*.js')
-    expect(linter).toEqual({
-      pattern: '*.js',
-      commands: 'root-js',
-      fileList: []
-    })
-  })
-
   it('should return an empty file list for linters with no matches.', () => {
     const result = generateTasks(config, files)
 


### PR DESCRIPTION
I have a setup where we have backend and frontend directories. The backend contains a python-django-rest-api project and frontend is javascript-react-redux project. We wanted to use lint-staged for checking python files in the backend directory too which is under the parent directory.

So we need to remove the pathIsInside check to make it work for both frontend and backend directories.