### PR TITLE
fix: remove please-upgrade-node

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@
 'use strict'
 
 const pkg = require('./package.json')
-require('please-upgrade-node')(pkg)
 
 const cmdline = require('commander')
 const debugLib = require('debug')

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "p-map": "^1.1.1",
     "path-is-inside": "^1.0.2",
     "pify": "^3.0.0",
-    "please-upgrade-node": "^3.0.1",
     "staged-git-files": "1.1.1",
     "string-argv": "^0.0.2",
     "stringify-object": "^3.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3753,10 +3753,6 @@ pkg-dir@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
-please-upgrade-node@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.0.1.tgz#0a681f2c18915e5433a5ca2cd94e0b8206a782db"
-
 pluralize@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"


### PR DESCRIPTION
Closes #432.

* Removes [currently-broken `please-upgrade-node` package](https://github.com/typicode/please-upgrade-node/issues/11)
* Doesn't replace it with anything at the moment. Could add a warning using the [`semver`](https://www.npmjs.com/package/semver) package or similar, if desired.