### PR TITLE
fix: update "please-upgrade-node" to version 3.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "p-map": "^1.1.1",
     "path-is-inside": "^1.0.2",
     "pify": "^3.0.0",
-    "please-upgrade-node": "^3.0.1",
+    "please-upgrade-node": "^3.0.2",
     "staged-git-files": "1.1.1",
     "string-argv": "^0.0.2",
     "stringify-object": "^3.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3753,9 +3753,11 @@ pkg-dir@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
-please-upgrade-node@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.0.1.tgz#0a681f2c18915e5433a5ca2cd94e0b8206a782db"
+please-upgrade-node@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.0.2.tgz#7b9eaeca35aa4a43d6ebdfd10616c042f9a83acc"
+  dependencies:
+    semver-compare "^1.0.0"
 
 pluralize@^7.0.0:
   version "7.0.0"
@@ -4167,6 +4169,10 @@ sane@^2.0.0:
 sax@^1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+
+semver-compare@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
 
 "semver@2 || 3 || 4 || 5", semver@^5.3.0:
   version "5.4.1"


### PR DESCRIPTION
Includes semantic version range checking that avoids incorrect flagging of Node.js version 10+. https://github.com/typicode/please-upgrade-node/issues/11

Resolves #432
Edit: Closes #433 