### PR TITLE
449: Add yarn dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "husky": "^0.14.3",
     "jest": "^22.4.0",
     "jsonlint": "^1.6.2",
-    "prettier": "1.11.1"
+    "prettier": "1.11.1",
+    "yarn": "^1.6.0"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
Dev dependency missing but required to run "npm test".
Found attempting to "git commit" due to "husky" package pre-commit hook.

Fixes #449