### PR TITLE
Mode verbose for commands

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ cmdline
   .version(pkg.version)
   .option('-c, --config [path]', 'Path to configuration file')
   .option('-d, --debug', 'Enable debug mode')
+  .option('--verbose', 'Enable verbose mode for commands')
   .parse(process.argv)
 
 if (cmdline.debug) {
@@ -22,4 +23,4 @@ if (cmdline.debug) {
 
 debug('Running `lint-staged@%s`', pkg.version)
 
-require('./src')(console, cmdline.config, cmdline.debug)
+require('./src')(console, cmdline)

--- a/src/getConfig.js
+++ b/src/getConfig.js
@@ -16,7 +16,7 @@ const debug = require('debug')('lint-staged:cfg')
 /**
  * Default config object
  *
- * @type {{concurrent: boolean, chunkSize: number, globOptions: {matchBase: boolean, dot: boolean}, linters: {}, subTaskConcurrency: number, renderer: string}}
+ * @type {{concurrent: boolean, chunkSize: number, globOptions: {matchBase: boolean, dot: boolean}, linters: {}, subTaskConcurrency: number, renderer: string, verboseMode: Boolean}}
  */
 const defaultConfig = {
   concurrent: true,
@@ -28,7 +28,8 @@ const defaultConfig = {
   linters: {},
   ignore: [],
   subTaskConcurrency: 1,
-  renderer: 'update'
+  renderer: 'update',
+  verboseMode: false
 }
 
 /**
@@ -88,15 +89,18 @@ function unknownValidationReporter(config, example, option, options) {
  * For simple config, only the `linters` configuration is provided.
  *
  * @param {Object} sourceConfig
+ * @param {boolean} debugMode
+ * @param {Boolean} verboseMode
  * @returns {{
- *  concurrent: boolean, chunkSize: number, globOptions: {matchBase: boolean, dot: boolean}, linters: {}, subTaskConcurrency: number, renderer: string
+ *  concurrent: boolean, chunkSize: number, globOptions: {matchBase: boolean, dot: boolean}, linters: {}, subTaskConcurrency: number, renderer: string, verboseMode: Boolean
  * }}
  */
-function getConfig(sourceConfig, debugMode) {
+function getConfig(sourceConfig, debugMode, verboseMode) {
   debug('Normalizing config')
   const config = defaultsDeep(
     {}, // Do not mutate sourceConfig!!!
     isSimple(sourceConfig) ? { linters: sourceConfig } : sourceConfig,
+    { verboseMode },
     defaultConfig
   )
 

--- a/src/getConfig.js
+++ b/src/getConfig.js
@@ -89,7 +89,7 @@ function unknownValidationReporter(config, example, option, options) {
  * For simple config, only the `linters` configuration is provided.
  *
  * @param {Object} sourceConfig
- * @param {boolean} debugMode
+ * @param {Boolean} debugMode
  * @param {Boolean} verboseMode
  * @returns {{
  *  concurrent: boolean, chunkSize: number, globOptions: {matchBase: boolean, dot: boolean}, linters: {}, subTaskConcurrency: number, renderer: string, verboseMode: Boolean

--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ function loadConfig(configPath) {
  */
 module.exports = function lintStaged(
   logger = console,
-  { config: configPath, debug: debugMode, verbose: verboseMode }
+  { config: configPath, debug: debugMode, verbose: verboseMode } = {}
 ) {
   debug('Loading config using `cosmiconfig`')
 

--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,10 @@ function loadConfig(configPath) {
 /**
  * Root lint-staged function that is called from .bin
  */
-module.exports = function lintStaged(logger = console, configPath, debugMode) {
+module.exports = function lintStaged(
+  logger = console,
+  { config: configPath, debug: debugMode, verbose: verboseMode }
+) {
   debug('Loading config using `cosmiconfig`')
 
   return loadConfig(configPath)
@@ -47,7 +50,7 @@ module.exports = function lintStaged(logger = console, configPath, debugMode) {
       debug('Successfully loaded config from `%s`:\n%O', result.filepath, result.config)
       // result.config is the parsed configuration object
       // result.filepath is the path to the config file that was found
-      const config = validateConfig(getConfig(result.config, debugMode))
+      const config = validateConfig(getConfig(result.config, debugMode, verboseMode))
       if (debugMode) {
         // Log using logger to be able to test through `consolemock`.
         logger.log('Running lint-staged with the following config:')

--- a/src/makeCmdTasks.js
+++ b/src/makeCmdTasks.js
@@ -13,11 +13,12 @@ const debug = require('debug')('lint-staged:make-cmd-tasks')
  * @param {Object} [options]
  * @param {number} options.chunkSize
  * @param {number} options.subTaskConcurrency
+ * @param {Boolean} options.verboseMode
  */
 module.exports = function makeCmdTasks(
   commands,
   pathsToLint,
-  { chunkSize = Number.MAX_SAFE_INTEGER, subTaskConcurrency = 1 } = {}
+  { chunkSize = Number.MAX_SAFE_INTEGER, subTaskConcurrency = 1, verboseMode } = {}
 ) {
   debug('Creating listr tasks for commands %o', commands)
 
@@ -31,7 +32,8 @@ module.exports = function makeCmdTasks(
       gitDir,
       pathsToLint,
       chunkSize,
-      subTaskConcurrency
+      subTaskConcurrency,
+      verboseMode
     })
   }))
 }

--- a/src/resolveTaskFn.js
+++ b/src/resolveTaskFn.js
@@ -67,7 +67,7 @@ function makeErr(linter, errStdout, errStderr) {
  * @returns {function(): Promise<string>}
  */
 module.exports = function resolveTaskFn(options) {
-  const { linter, gitDir, pathsToLint } = options
+  const { linter, gitDir, pathsToLint, verboseMode } = options
   const { bin, args } = findBin(linter)
 
   const execaOptions = { reject: false }
@@ -81,6 +81,10 @@ module.exports = function resolveTaskFn(options) {
     debug('%s  OS: %s; File path chunking unnecessary', symbols.success, process.platform)
     return () =>
       execLinter(bin, args, execaOptions, pathsToLint).then(result => {
+        if (verboseMode) {
+          console.log(result.stdout)
+        }
+
         if (!result.failed) return successMsg(linter)
 
         throw makeErr(linter, result.stdout, result.stderr)

--- a/src/runAll.js
+++ b/src/runAll.js
@@ -38,7 +38,8 @@ module.exports = function runAll(config) {
         new Listr(
           makeCmdTasks(task.commands, task.fileList, {
             chunkSize,
-            subTaskConcurrency
+            subTaskConcurrency,
+            verboseMode: config.verboseMode
           }),
           {
             // In sub-tasks we don't want to run concurrently

--- a/test/__snapshots__/getConfig.spec.js.snap
+++ b/test/__snapshots__/getConfig.spec.js.snap
@@ -12,6 +12,7 @@ Object {
   "linters": Object {},
   "renderer": "update",
   "subTaskConcurrency": 1,
+  "verboseMode": false,
 }
 `;
 
@@ -27,6 +28,7 @@ Object {
   "linters": Object {},
   "renderer": "update",
   "subTaskConcurrency": 1,
+  "verboseMode": false,
 }
 `;
 
@@ -48,6 +50,7 @@ Object {
   },
   "renderer": "update",
   "subTaskConcurrency": 1,
+  "verboseMode": false,
 }
 `;
 

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -7,6 +7,7 @@ LOG {
   linters: {
     '*': 'mytask'
   },
+  verboseMode: false,
   concurrent: true,
   chunkSize: 9007199254740991,
   globOptions: {
@@ -21,6 +22,8 @@ LOG {
 
 exports[`lintStaged should not output config in normal mode 1`] = `""`;
 
+exports[`lintStaged should not output config in normal mode 2`] = `""`;
+
 exports[`lintStaged should output config in debug mode 1`] = `
 "
 LOG Running lint-staged with the following config:
@@ -28,6 +31,7 @@ LOG {
   linters: {
     '*': 'mytask'
   },
+  verboseMode: false,
   concurrent: true,
   chunkSize: 9007199254740991,
   globOptions: {
@@ -39,6 +43,28 @@ LOG {
   renderer: 'verbose'
 }"
 `;
+
+exports[`lintStaged should output config in verbose mode + debug mode 1`] = `
+"
+LOG Running lint-staged with the following config:
+LOG {
+  linters: {
+    '*': 'mytask'
+  },
+  verboseMode: true,
+  concurrent: true,
+  chunkSize: 9007199254740991,
+  globOptions: {
+    matchBase: true,
+    dot: true
+  },
+  ignore: [],
+  subTaskConcurrency: 1,
+  renderer: 'verbose'
+}"
+`;
+
+exports[`lintStaged should output config in verbose mode 1`] = `""`;
 
 exports[`lintStaged should print helpful error message when config file is not found 1`] = `
 "

--- a/test/getConfig.spec.js
+++ b/test/getConfig.spec.js
@@ -39,6 +39,20 @@ describe('getConfig', () => {
     )
   })
 
+  it('should set verboseMode', () => {
+    expect(getConfig({})).toEqual(
+      expect.objectContaining({
+        verboseMode: false
+      })
+    )
+
+    expect(getConfig({}, false, true)).toEqual(
+      expect.objectContaining({
+        verboseMode: true
+      })
+    )
+  })
+
   it('should set renderer based on debug mode', () => {
     expect(getConfig({})).toEqual(
       expect.objectContaining({
@@ -141,6 +155,7 @@ describe('getConfig', () => {
       },
       ignore: ['docs/**/*.js'],
       subTaskConcurrency: 10,
+      verboseMode: false,
       renderer: 'custom'
     }
     expect(getConfig(cloneDeep(src))).toEqual(src)

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -29,7 +29,41 @@ describe('lintStaged', () => {
       }
     }
     mockCosmiconfigWith({ config })
-    await lintStaged(logger, undefined, true)
+    await lintStaged(logger, { config: undefined, debug: true })
+    expect(logger.printHistory()).toMatchSnapshot()
+  })
+
+  it('should not output config in normal mode', async () => {
+    expect.assertions(1)
+    const config = {
+      '*': 'mytask'
+    }
+    mockCosmiconfigWith({ config })
+    await lintStaged(logger)
+    expect(logger.printHistory()).toMatchSnapshot()
+  })
+
+  it('should output config in verbose mode', async () => {
+    expect.assertions(1)
+    const config = {
+      linters: {
+        '*': 'mytask'
+      }
+    }
+    mockCosmiconfigWith({ config })
+    await lintStaged(logger, { config: undefined, verbose: true })
+    expect(logger.printHistory()).toMatchSnapshot()
+  })
+
+  it('should output config in verbose mode + debug mode', async () => {
+    expect.assertions(1)
+    const config = {
+      linters: {
+        '*': 'mytask'
+      }
+    }
+    mockCosmiconfigWith({ config })
+    await lintStaged(logger, { config: undefined, debug: true, verbose: true })
     expect(logger.printHistory()).toMatchSnapshot()
   })
 
@@ -45,14 +79,17 @@ describe('lintStaged', () => {
 
   it('should load config file when specified', async () => {
     expect.assertions(1)
-    await lintStaged(logger, path.join(__dirname, '__mocks__', 'my-config.json'), true)
+    await lintStaged(logger, {
+      config: path.join(__dirname, '__mocks__', 'my-config.json'),
+      debug: true
+    })
     expect(logger.printHistory()).toMatchSnapshot()
   })
 
   it('should print helpful error message when config file is not found', async () => {
     expect.assertions(1)
     mockCosmiconfigWith(null)
-    await lintStaged(logger)
+    await lintStaged(logger, { config: '' })
     expect(logger.printHistory()).toMatchSnapshot()
   })
 
@@ -68,7 +105,8 @@ describe('lintStaged', () => {
       )
     )
 
-    await lintStaged(logger, nonExistentConfig)
+    await lintStaged(logger, { config: nonExistentConfig })
+    process.stdout.write(logger.printHistory())
     expect(logger.printHistory()).toMatchSnapshot()
   })
 })

--- a/test/resolveTaskFn.spec.js
+++ b/test/resolveTaskFn.spec.js
@@ -25,6 +25,7 @@ describe('resolveTaskFn', () => {
 
   it('should support non npm scripts', async () => {
     expect.assertions(2)
+
     const taskFn = resolveTaskFn({
       ...defaultOpts,
       linter: 'node --arg=true ./myscript.js'
@@ -35,6 +36,41 @@ describe('resolveTaskFn', () => {
     expect(execa).lastCalledWith('node', ['--arg=true', './myscript.js', 'test.js'], {
       reject: false
     })
+  })
+
+  it('should print the output with the mode verbose', async () => {
+    expect.assertions(3)
+
+    const taskFn = resolveTaskFn({
+      ...defaultOpts,
+      verboseMode: true,
+      linter: 'echo "DEMO"'
+    })
+
+    global.console = { log: jest.fn() }
+    await taskFn()
+    expect(execa).toHaveBeenCalledTimes(1)
+    expect(execa).lastCalledWith('echo', ['DEMO', 'test.js'], {
+      reject: false
+    })
+    expect(console.log).toBeCalledWith('a-ok')
+  })
+
+  it('should not print the output without the mode verbose', async () => {
+    expect.assertions(3)
+
+    const taskFn = resolveTaskFn({
+      ...defaultOpts,
+      linter: 'echo "DEMO"'
+    })
+
+    global.console = { log: jest.fn() }
+    await taskFn()
+    expect(execa).toHaveBeenCalledTimes(1)
+    expect(execa).lastCalledWith('echo', ['DEMO', 'test.js'], {
+      reject: false
+    })
+    expect(console.log).not.toBeCalledWith('a-ok')
   })
 
   it('should pass `gitDir` as `cwd` to `execa()` gitDir !== process.cwd for git commands', async () => {


### PR DESCRIPTION
Hi, 

I added a flag `--verbose` for the command. It allows us to use some packages for metrics ex: [cqc](https://www.npmjs.com/package/cqc) to have an overview when we commit/push etc. Or any command you want to use to display a message via a hook.

This is not the same as debug, you can use them at the same time but debug is for listr-verbose, --verbose is only for commands inside the list.

## Mode debug

![modedebug](https://user-images.githubusercontent.com/713283/40718986-2fd31906-6412-11e8-8fef-559bcbff901f.jpeg)


## Mode Verbose

![modeverbose](https://user-images.githubusercontent.com/713283/40718988-352aa004-6412-11e8-8bdf-14aba69358e2.jpeg)

## Mode debug + verbose

![modedebugverbose](https://user-images.githubusercontent.com/713283/40718993-3a507f5e-6412-11e8-9e5d-c6a8d55908e1.jpeg)

I saw this PR https://github.com/okonet/lint-staged/pull/319 but didn't test it as it's closed.

Voilà