### PR TITLE
feat: Resolve a npm package passed as `--config`

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,12 @@ $ ./node_modules/.bin/lint-staged --help
   Options:
 
     -V, --version        output the version number
-    -c, --config [path]  Path to configuration file
+    -c, --config [path]  Configuration file path or package
     -d, --debug          Enable debug mode
     -h, --help           output usage information
 ```
 
-* **`--config [path]`**: This can be used to manually specify the `lint-staged` config file location. However, if the specified file cannot be found, it will error out instead of performing the usual search.
+* **`--config [path]`**: This can be used to manually specify the `lint-staged` config file location. However, if the specified file cannot be found, it will error out instead of performing the usual search. You may pass a npm package name for configuration also.
 * **`--debug`**: Enabling the debug mode does the following:
   * `lint-staged` uses the [debug](https://github.com/visionmedia/debug) module internally to log information about staged files, commands being executed, location of binaries etc. Debug logs, which are automatically enabled by passing the flag, can also be enabled by setting the environment variable `$DEBUG` to `lint-staged*`.
   * Use the [`verbose` renderer](https://github.com/SamVerschueren/listr-verbose-renderer) for `listr`.

--- a/__mocks__/my-lint-staged-config/index.js
+++ b/__mocks__/my-lint-staged-config/index.js
@@ -1,0 +1,5 @@
+'use strict'
+
+module.exports = {
+  '*': 'mytask'
+}

--- a/__mocks__/my-lint-staged-config/package.json
+++ b/__mocks__/my-lint-staged-config/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "my-lint-staged-config",
+  "version": "0.0.0"
+}

--- a/src/index.js
+++ b/src/index.js
@@ -18,20 +18,28 @@ if (process.stdout.isTTY) {
 
 const errConfigNotFound = new Error('Config could not be found')
 
+function resolveConfig(configPath) {
+  try {
+    return require.resolve(configPath)
+  } catch (ignore) {
+    return configPath
+  }
+}
+
 function loadConfig(configPath) {
   const explorer = cosmiconfig('lint-staged', {
     searchPlaces: [
       'package.json',
-      `.lintstagedrc`,
-      `.lintstagedrc.json`,
-      `.lintstagedrc.yaml`,
-      `.lintstagedrc.yml`,
-      `.lintstagedrc.js`,
-      `lint-staged.config.js`
+      '.lintstagedrc',
+      '.lintstagedrc.json',
+      '.lintstagedrc.yaml',
+      '.lintstagedrc.yml',
+      '.lintstagedrc.js',
+      'lint-staged.config.js'
     ]
   })
 
-  return configPath ? explorer.load(configPath) : explorer.search()
+  return configPath ? explorer.load(resolveConfig(configPath)) : explorer.search()
 }
 
 /**

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -1,5 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`lintStaged should load an npm config package when specified 1`] = `
+"
+LOG Running lint-staged with the following config:
+LOG {
+  linters: {
+    '*': 'mytask'
+  },
+  concurrent: true,
+  chunkSize: 9007199254740991,
+  globOptions: {
+    matchBase: true,
+    dot: true
+  },
+  ignore: [],
+  subTaskConcurrency: 1,
+  renderer: 'verbose'
+}"
+`;
+
 exports[`lintStaged should load config file when specified 1`] = `
 "
 LOG Running lint-staged with the following config:

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -49,6 +49,13 @@ describe('lintStaged', () => {
     expect(logger.printHistory()).toMatchSnapshot()
   })
 
+  it('should load an npm config package when specified', async () => {
+    expect.assertions(1)
+    jest.mock('my-lint-staged-config')
+    await lintStaged(logger, 'my-lint-staged-config', true)
+    expect(logger.printHistory()).toMatchSnapshot()
+  })
+
   it('should print helpful error message when config file is not found', async () => {
     expect.assertions(1)
     mockCosmiconfigWith(null)


### PR DESCRIPTION
feat: Resolve a npm package passed as `--config`

This PR enables a npm package to be passed to the command line `--config` parameter and will be resolved by lint-staged.

Example:

Say you have a npm package `my-tools-config/lint-staged`, your application can now depend on the configuration package and lint-staged allowing:

```sh
lint-staged --config my-tools-config/lint-staged
```