### PR TITLE
Allow passing an array of globs

### DIFF
--- a/src/generateTasks.js
+++ b/src/generateTasks.js
@@ -20,7 +20,10 @@ module.exports = function generateTasks(config, relFiles) {
   const files = relFiles.map(file => path.resolve(gitDir, file))
 
   return Object.keys(linters).map(pattern => {
-    const patterns = [pattern].concat(ignorePatterns)
+    const patterns = pattern.includes(', ')
+      ? pattern.split(', ').concat(ignorePatterns)
+      : [pattern].concat(ignorePatterns)
+
     const commands = linters[pattern]
 
     const fileList = micromatch(


### PR DESCRIPTION
Hello,

this is a quick win in order to leverage the advantages of [micromatch](https://github.com/micromatch/micromatch#ismatch) and multi glob support.

I use `, ` presence (it has an intentional space) for creating the multi-pattern from the JSON declaration:

```json
{
  "!nebula/**/*, *.js": [
    "xo --fix",
    "git add"
  ]
}
```

The `lint-staged` converts it into  `[ '!nebula/**/*', '*.js' ]`

The space character is intentional to avoid break other glob patterns with `,` inside, like:

```json
{
  "!(*.test).{ts,tsx}": [
    "npx jest --maxWorkers 4 --findRelatedTests",
    "npx prettier --parser typescript --write",
    "npx tslint -p tsconfig.base.json -e \"./**/__tests__/**\"",
    "git add"
  ]
}
```

Ideally, I like the config object mode explained in [this comment](https://github.com/okonet/lint-staged/issues/201#issuecomment-328263295), although I feel it adds friction with the user.

Also, I don't feel totally convinced with this solution, the user needs to know the space is required, but at least the functionality could be used (until not it's not possible).

After knowing your opinion to address it into the codebase, I can add some test to verify the change.

The same approach could be effective but using a different split character, for example, ` AND `. 🤔 

It's related to https://github.com/okonet/lint-staged/issues/201.