### PR TITLE
Fix Bug when node_modules are outside of project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Forked version where 'appRoot' is determine by `process.cwd()`
+
 # 🚫💩 lint-staged [![Build Status for Linux](https://travis-ci.org/okonet/lint-staged.svg?branch=master)](https://travis-ci.org/okonet/lint-staged) [![Build Status for Windows](https://ci.appveyor.com/api/projects/status/github/okonet/lint-staged?branch=master&svg=true)](https://ci.appveyor.com/project/okonet/lint-staged) [![npm version](https://badge.fury.io/js/lint-staged.svg)](https://badge.fury.io/js/lint-staged) [![Codecov](https://codecov.io/gh/okonet/lint-staged/branch/master/graph/badge.svg)](https://codecov.io/gh/okonet/lint-staged)
 
 Run linters against staged git files and don't let :poop: slip into your code base!
@@ -133,15 +135,10 @@ To extend and customise lint-staged, avanced options are available. To use this 
 {
   "lint-staged": {
     "linters": {
-      "*.{js,scss}": [
-        "some command",
-        "git add"
-      ]
+      "*.{js,scss}": ["some command", "git add"]
     },
-    "ignore": [
-      "**/dist/*.min.js"
-    ]
-  },
+    "ignore": ["**/dist/*.min.js"]
+  }
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "app-root-path": "^2.0.1",
     "chalk": "^2.3.1",
     "commander": "^2.14.1",
     "cosmiconfig": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "lint-staged",
+  "name": "lint-staged-outside",
   "version": "0.0.0-development",
-  "description": "Lint files staged by git",
+  "description": "Lint files staged by git forked version to work outside node_modules",
   "license": "MIT",
-  "repository": "https://github.com/okonet/lint-staged",
+  "repository": "https://github.com/ultrox/lint-staged",
   "author": "Andrey Okonetchnikov <andrey@okonet.ru>",
   "maintainers": [
     "Lufty Wiranda <lufty.wiranda@gmail.com>",

--- a/src/findBin.js
+++ b/src/findBin.js
@@ -1,12 +1,14 @@
 'use strict'
 
+const path = require('path')
 const parse = require('string-argv')
-const appRoot = require('app-root-path')
 const npmWhich = require('npm-which')(process.cwd())
 const checkPkgScripts = require('./checkPkgScripts')
 
 // Find and load the package.json at the root of the project.
-const pkg = require(appRoot.resolve('package.json')) // eslint-disable-line import/no-dynamic-require
+const packageJson = path.resolve(`${process.cwd()}/package.json`)
+const pkg = require(packageJson) // eslint-disable-line import/no-dynamic-require
+
 const debug = require('debug')('lint-staged:find-bin')
 
 const cache = new Map()


### PR DESCRIPTION
I'm not sure is this intended or not, but I think its more stable then using "app-root-path". 

Said package fails to find package json, when `node_modules` are placed outside of project in any way, including when "node_modules" are symlinked in the project.

`process.cwd()` works better because it will always be actually root project in this case.