### PR TITLE
Add flag to generate tasks for files in parent directories

### DIFF
--- a/src/generateTasks.js
+++ b/src/generateTasks.js
@@ -17,16 +17,19 @@ module.exports = function generateTasks(config, relFiles) {
 
   const gitDir = resolveGitDir()
   const cwd = process.cwd()
-  const files = relFiles.map(file => path.resolve(gitDir, file))
+  let files = relFiles.map(file => path.resolve(gitDir, file))
 
   return Object.keys(linters).map(pattern => {
     const patterns = [pattern].concat(ignorePatterns)
     const commands = linters[pattern]
 
+    if (!normalizedConfig.matchAllFiles) {
+      // Only worry about children of the CWD
+      files = files.filter(file => pathIsInside(file, cwd))
+    }
+
     const fileList = micromatch(
       files
-        // Only worry about children of the CWD
-        .filter(file => pathIsInside(file, cwd))
         // Make the paths relative to CWD for filtering
         .map(file => path.relative(cwd, file)),
       patterns,

--- a/src/getConfig.js
+++ b/src/getConfig.js
@@ -16,7 +16,7 @@ const debug = require('debug')('lint-staged:cfg')
 /**
  * Default config object
  *
- * @type {{concurrent: boolean, chunkSize: number, globOptions: {matchBase: boolean, dot: boolean}, linters: {}, subTaskConcurrency: number, renderer: string}}
+ * @type {{concurrent: boolean, chunkSize: number, globOptions: {matchBase: boolean, dot: boolean}, linters: {}, subTaskConcurrency: number, renderer: string, matchAllFiles: boolean}}
  */
 const defaultConfig = {
   concurrent: true,
@@ -28,7 +28,8 @@ const defaultConfig = {
   linters: {},
   ignore: [],
   subTaskConcurrency: 1,
-  renderer: 'update'
+  renderer: 'update',
+  matchAllFiles: false
 }
 
 /**

--- a/test/__snapshots__/getConfig.spec.js.snap
+++ b/test/__snapshots__/getConfig.spec.js.snap
@@ -10,6 +10,7 @@ Object {
   },
   "ignore": Array [],
   "linters": Object {},
+  "matchAllFiles": false,
   "renderer": "update",
   "subTaskConcurrency": 1,
 }
@@ -25,6 +26,7 @@ Object {
   },
   "ignore": Array [],
   "linters": Object {},
+  "matchAllFiles": false,
   "renderer": "update",
   "subTaskConcurrency": 1,
 }
@@ -46,6 +48,7 @@ Object {
     ],
     ".*rc": "jsonlint",
   },
+  "matchAllFiles": false,
   "renderer": "update",
   "subTaskConcurrency": 1,
 }

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -15,7 +15,8 @@ LOG {
   },
   ignore: [],
   subTaskConcurrency: 1,
-  renderer: 'verbose'
+  renderer: 'verbose',
+  matchAllFiles: false
 }"
 `;
 
@@ -34,7 +35,8 @@ LOG {
   },
   ignore: [],
   subTaskConcurrency: 1,
-  renderer: 'verbose'
+  renderer: 'verbose',
+  matchAllFiles: false
 }"
 `;
 
@@ -55,7 +57,8 @@ LOG {
   },
   ignore: [],
   subTaskConcurrency: 1,
-  renderer: 'verbose'
+  renderer: 'verbose',
+  matchAllFiles: false
 }"
 `;
 

--- a/test/generateTasks.spec.js
+++ b/test/generateTasks.spec.js
@@ -98,6 +98,24 @@ describe('generateTasks', () => {
     })
   })
 
+  it('should match non-children files with matchAllFiles', () => {
+    const relPath = path.resolve(path.join(process.cwd(), '..'))
+    resolveGitDir.mockReturnValueOnce(relPath)
+    const result = generateTasks(Object.assign({ matchAllFiles: true }, config), files)
+    const linter = result.find(item => item.pattern === '*.js')
+    expect(linter).toEqual({
+      pattern: '*.js',
+      commands: 'root-js',
+      fileList: [
+        `${relPath}/test.js`,
+        `${relPath}/deeper/test.js`,
+        `${relPath}/deeper/test2.js`,
+        `${relPath}/even/deeper/test.js`,
+        `${relPath}/.hidden/test.js`
+      ].map(path.normalize)
+    })
+  })
+
   it('should return an empty file list for linters with no matches.', () => {
     const result = generateTasks(config, files)
 

--- a/test/getConfig.spec.js
+++ b/test/getConfig.spec.js
@@ -141,7 +141,8 @@ describe('getConfig', () => {
       },
       ignore: ['docs/**/*.js'],
       subTaskConcurrency: 10,
-      renderer: 'custom'
+      renderer: 'custom',
+      matchAllFiles: false
     }
     expect(getConfig(cloneDeep(src))).toEqual(src)
   })


### PR DESCRIPTION
Added a flag `matchAllFiles` to be able to generate tasks on files outside of package root.

This flag defaults to `false` when not defined.

See https://github.com/okonet/lint-staged/pull/425 and https://github.com/okonet/lint-staged/issues/487