### PR TITLE
fix(git): Use resolveGitDir to resolve to .git for git commands

### DIFF
--- a/src/gitWorkflow.js
+++ b/src/gitWorkflow.js
@@ -5,6 +5,7 @@ const execa = require('execa')
 const gStatus = require('g-status')
 const del = require('del')
 const debug = require('debug')('lint-staged:git')
+const resolveGitDir = require('./resolveGitDir')
 
 let workingCopyTree = null
 let indexTree = null
@@ -15,7 +16,7 @@ function getAbsolutePath(dir) {
 }
 
 async function execGit(cmd, options) {
-  const cwd = options && options.cwd ? options.cwd : process.cwd()
+  const cwd = options && options.cwd ? options.cwd : resolveGitDir()
   debug('Running git command', cmd)
   try {
     const { stdout } = await execa('git', [].concat(cmd), {

--- a/test/gitWorkflow.spec.js
+++ b/test/gitWorkflow.spec.js
@@ -3,28 +3,28 @@
 import path from 'path'
 import tmp from 'tmp'
 import execa from 'execa'
-import gitflow from '../src/gitWorkflow'
+import { execGit } from '../src/gitWorkflow'
 
 tmp.setGracefulCleanup()
 
 describe('gitWorkflow', () => {
   describe('execGit', () => {
-    it('should execute git in cwd if working copy is not specified', async () => {
-      await gitflow.execGit(['init', 'param'])
+    it('should execute git in process.cwd if working copy is not specified', async () => {
+      await execGit(['init', 'param'])
       expect(execa).toHaveBeenCalledWith('git', ['init', 'param'], {
         cwd: path.resolve(process.cwd())
       })
     })
 
     it('should execute git in a given working copy', async () => {
-      await gitflow.execGit(['init', 'param'], { cwd: 'test/__fixtures__' })
+      await execGit(['init', 'param'], { cwd: 'test/__fixtures__' })
       expect(execa).toHaveBeenCalledWith('git', ['init', 'param'], {
         cwd: path.resolve(process.cwd(), 'test', '__fixtures__')
       })
     })
 
     it('should work with relative paths', async () => {
-      await gitflow.execGit(['init', 'param'], {
+      await execGit(['init', 'param'], {
         cwd: 'test/__fixtures__'
       })
       expect(execa).toHaveBeenCalledWith('git', ['init', 'param'], {


### PR DESCRIPTION
When options aren't specified, instead of using `process.cwd()`
use `resolveGitDir()`.

Fixes #514