### PR TITLE
Allow to use lint-staged on CI

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,6 +21,7 @@
         }
       }
     ],
-    "prettier/prettier": "off"
+    "prettier/prettier": "off",
+    "node/no-unsupported-features": ["error", "8.6.0"]
   }
 }

--- a/index.js
+++ b/index.js
@@ -3,7 +3,11 @@
 'use strict'
 
 const pkg = require('./package.json')
-require('please-upgrade-node')(pkg)
+require('please-upgrade-node')({
+  engines: {
+    node: '>=8.6.0'
+  }
+})
 
 const cmdline = require('commander')
 const debugLib = require('debug')

--- a/package.json
+++ b/package.json
@@ -9,9 +9,6 @@
     "Lufty Wiranda <lufty.wiranda@gmail.com>",
     "Suhas Karanth <sudo.suhas@gmail.com>"
   ],
-  "engines": {
-    "node": ">=8.6.0"
-  },
   "bin": "index.js",
   "files": ["index.js", "src"],
   "scripts": {


### PR DESCRIPTION
Closes https://github.com/okonet/lint-staged/issues/515

Right now `lint-staged` 8.0 can’t be used in big open source projects. They must test all maintained Node.js version. Node.js 6 is still LTS. So `lint-staged` failed CI with:

```
error lint-staged@8.0.0: The engine "node" is incompatible with this module. Expected version ">=8.6.0".
error Found incompatible module
```

This PR:

1. Remove `engines` from `package.json`
2. Still tests Node.js version when `lint-staged` will be executed.
3. `eslint-plugin-node` should works too