### PR TITLE
ci: test on Node.js 6, 8, 10 and 11

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,9 +4,10 @@
 
 environment:
   matrix:
+    - nodejs_version: '11'
     - nodejs_version: '10'
-    - nodejs_version: '9'
     - nodejs_version: '8'
+    - nodejs_version: '6'
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,10 @@
 
 language: node_js
 node_js:
+  - 'node'
   - '10'
-  - '9'
   - '8'
+  - '6'
 
 before_install: yarn global add greenkeeper-lockfile@1
 install: yarn install


### PR DESCRIPTION
Node.js 9 was a short living branch and we should also test on the current LTS and stable branches.

See https://github.com/nodejs/Release/blob/master/README.md