### PR TITLE
fix to run this project behind a proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
     "is-windows": "^1.0.2",
     "jest-validate": "^23.5.0",
     "listr": "^0.14.2",
-    "listr-update-renderer":
-      "https://github.com/okonet/listr-update-renderer/tarball/upgrade-log-update",
+    "listr-update-renderer": "^0.4.0",
     "lodash": "^4.17.5",
     "log-symbols": "^2.2.0",
     "micromatch": "^3.1.8",


### PR DESCRIPTION
I've found some trouble running this package behind a corporate because of restrictions to the GitHub for the dependency package "listr-update-renderer".
Defining a version allowed me to download it direct from npmjs.org.