### PR TITLE
Using version instead of a link for listr-update-renderer

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
     "is-windows": "^1.0.2",
     "jest-validate": "^23.5.0",
     "listr": "^0.14.2",
-    "listr-update-renderer":
-      "https://github.com/okonet/listr-update-renderer/tarball/upgrade-log-update",
+    "listr-update-renderer": "^0.4.0",
     "lodash": "^4.17.5",
     "log-symbols": "^2.2.0",
     "micromatch": "^3.1.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3059,7 +3059,7 @@ listr-silent-renderer@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz#924b5a3757153770bf1a8e3fbf74b8bbf3f9242e"
 
-listr-update-renderer@^0.4.0, "listr-update-renderer@https://github.com/okonet/listr-update-renderer/tarball/upgrade-log-update":
+listr-update-renderer@^0.4.0:
   version "0.4.0"
   resolved "https://github.com/okonet/listr-update-renderer/tarball/upgrade-log-update#06073fa93166277607a7814f4e1f83960081414c"
   dependencies:


### PR DESCRIPTION
Hi,

For some environment that lack internet access (internal repo), this is a blocker since it is pointing directly to a github repo. 

This will use the NPM/Yarn library. Also, it is better to keep track of the version that we are using. 

Thanks!
Ignacio