### PR TITLE
feat: add relative option to let lint-staged work with ng lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Notice that the linting commands now are nested into the `linters` object. The f
 * `ignore` - `['**/docs/**/*.js']` - array of glob patterns to entirely ignore from any task.
 * `linters` — `Object` — keys (`String`) are glob patterns, values (`Array<String> | String`) are commands to execute.
 * `subTaskConcurrency` — `1` — Controls concurrency for processing chunks generated for each linter. This option is only applicable on Windows. Execution is **not** concurrent by default(see [#225](https://github.com/okonet/lint-staged/issues/225))
+* `relative` — `false` — if `true` it will give the relative path from your `package.json` directory to your linter arguments.
 
 ## Filtering files
 
@@ -278,6 +279,17 @@ The following is equivalent:
 ```json
 {
   "*.{ts,tsx}": ["prettier --parser typescript --write", "git add"]
+}
+```
+
+### Use ng lint with angular cli >= 7.0.0
+
+```json
+{
+  "linters": {
+    "*.ts": "ng lint myProjectName --files"
+  },
+  "relative": true
 }
 ```
 

--- a/src/generateTasks.js
+++ b/src/generateTasks.js
@@ -33,9 +33,14 @@ module.exports = function generateTasks(config, stagedRelFiles) {
         .map(file => path.relative(cwd, file)),
       patterns,
       globOptions
-    )
+    ).map(file => {
+      // if you set relative option, then the file path will be relative to your package.json
+      if (config.relative) {
+        return path.normalize(file)
+      }
       // Return absolute path after the filter is run
-      .map(file => path.resolve(cwd, file))
+      return path.resolve(cwd, file)
+    })
 
     const task = { pattern, commands, fileList }
     debug('Generated task: \n%O', task)

--- a/src/getConfig.js
+++ b/src/getConfig.js
@@ -28,7 +28,8 @@ const defaultConfig = {
   linters: {},
   ignore: [],
   subTaskConcurrency: 1,
-  renderer: 'update'
+  renderer: 'update',
+  relative: false
 }
 
 /**

--- a/test/__snapshots__/getConfig.spec.js.snap
+++ b/test/__snapshots__/getConfig.spec.js.snap
@@ -10,6 +10,7 @@ Object {
   },
   "ignore": Array [],
   "linters": Object {},
+  "relative": false,
   "renderer": "update",
   "subTaskConcurrency": 1,
 }
@@ -25,6 +26,7 @@ Object {
   },
   "ignore": Array [],
   "linters": Object {},
+  "relative": false,
   "renderer": "update",
   "subTaskConcurrency": 1,
 }
@@ -46,6 +48,7 @@ Object {
     ],
     ".*rc": "jsonlint",
   },
+  "relative": false,
   "renderer": "update",
   "subTaskConcurrency": 1,
 }

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -15,7 +15,8 @@ LOG {
   },
   ignore: [],
   subTaskConcurrency: 1,
-  renderer: 'verbose'
+  renderer: 'verbose',
+  relative: false
 }"
 `;
 
@@ -34,7 +35,8 @@ LOG {
   },
   ignore: [],
   subTaskConcurrency: 1,
-  renderer: 'verbose'
+  renderer: 'verbose',
+  relative: false
 }"
 `;
 
@@ -55,7 +57,8 @@ LOG {
   },
   ignore: [],
   subTaskConcurrency: 1,
-  renderer: 'verbose'
+  renderer: 'verbose',
+  relative: false
 }"
 `;
 

--- a/test/generateTasks.spec.js
+++ b/test/generateTasks.spec.js
@@ -86,6 +86,21 @@ describe('generateTasks', () => {
     })
   })
 
+  it('should return relative paths', () => {
+    const [task] = generateTasks(
+      {
+        linters: {
+          '*': 'lint'
+        },
+        relative: true
+      },
+      files
+    )
+    task.fileList.forEach(file => {
+      expect(path.isAbsolute(file)).toBe(false)
+    })
+  })
+
   it('should not match non-children files', () => {
     const relPath = path.join(process.cwd(), '..')
     resolveGitDir.mockReturnValueOnce(relPath)
@@ -126,6 +141,22 @@ describe('generateTasks', () => {
     })
   })
 
+  it('should match pattern "*.js" and return relative path', () => {
+    const result = generateTasks(Object.assign({}, config, { relative: true }), files)
+    const linter = result.find(item => item.pattern === '*.js')
+    expect(linter).toEqual({
+      pattern: '*.js',
+      commands: 'root-js',
+      fileList: [
+        `test.js`,
+        `deeper/test.js`,
+        `deeper/test2.js`,
+        `even/deeper/test.js`,
+        `.hidden/test.js`
+      ].map(path.normalize)
+    })
+  })
+
   it('should match pattern "**/*.js"', () => {
     const result = generateTasks(config, files)
     const linter = result.find(item => item.pattern === '**/*.js')
@@ -138,6 +169,22 @@ describe('generateTasks', () => {
         `${workDir}/deeper/test2.js`,
         `${workDir}/even/deeper/test.js`,
         `${workDir}/.hidden/test.js`
+      ].map(path.normalize)
+    })
+  })
+
+  it('should match pattern "**/*.js" with relative path', () => {
+    const result = generateTasks(Object.assign({}, config, { relative: true }), files)
+    const linter = result.find(item => item.pattern === '**/*.js')
+    expect(linter).toEqual({
+      pattern: '**/*.js',
+      commands: 'any-js',
+      fileList: [
+        `test.js`,
+        `deeper/test.js`,
+        `deeper/test2.js`,
+        `even/deeper/test.js`,
+        `.hidden/test.js`
       ].map(path.normalize)
     })
   })

--- a/test/getConfig.spec.js
+++ b/test/getConfig.spec.js
@@ -141,7 +141,8 @@ describe('getConfig', () => {
       },
       ignore: ['docs/**/*.js'],
       subTaskConcurrency: 10,
-      renderer: 'custom'
+      renderer: 'custom',
+      relative: true
     }
     expect(getConfig(cloneDeep(src))).toEqual(src)
   })


### PR DESCRIPTION
In order to work with the new version of [angular-cli](https://github.com/angular/angular-cli) which is now using `--files` parameter to pass specific RELATIVE file paths to lint ([see here](https://angular.io/cli/lint)) I wasn't able to let my project working with lint-staged. I think I'm not the only one in this situation.

Signed-off-by: Benjamin Coenen <benjamin.coenen@corp.ovh.com>