### PR TITLE
Update gitStash.spec.js

### DIFF
--- a/test/gitStash.spec.js
+++ b/test/gitStash.spec.js
@@ -140,7 +140,7 @@ D  test.js"
 
       // Stashing files
       await gitflow.gitStashSave(gitOpts)
-      expect(await gitStatus()).toMatchInlineSnapshot(`"D  test.js"`)
+      expect(await gitStatus()).toMatchInlineSnapshot(`""`)
 
       // Restoring state
       await gitflow.gitStashPop(gitOpts)


### PR DESCRIPTION
That's what I thought it should be. (is `gitStashSave` not doing `git stash save 'some message'`?

If it is, then this is what I expected:

```
❯ git status --porcelain
 D saffron.js
 M src/annotator/App.tsx

❯ git stash save 'foo'
Saved working directory and index state On develop: foo

❯ git status --porcelain

❯ git stash pop
...

❯ git status --porcelain
 D saffron.js
 M src/annotator/App.tsx
```