### PR TITLE
Chore: Upgrade semantic-release to latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ after_script: greenkeeper-lockfile-upload
 after_success:
   - bash <(curl -s https://codecov.io/bash)
   - yarn global add travis-deploy-once@4
-  - travis-deploy-once "yarn global add semantic-release@12 && semantic-release"
+  - travis-deploy-once "yarn global add semantic-release@15 && semantic-release"
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ after_script: greenkeeper-lockfile-upload
 after_success:
   - bash <(curl -s https://codecov.io/bash)
   - yarn global add travis-deploy-once@4
-  - travis-deploy-once "yarn global add semantic-release@15 && semantic-release"
+  - travis-deploy-once "yarn global add semantic-release && semantic-release"
 
 notifications:
   email: false


### PR DESCRIPTION
Should fix https://github.com/okonet/lint-staged/issues/546 and https://github.com/semantic-release/semantic-release/issues/539 where links in releases section were using git+https protocol.