### PR TITLE
feat: add fileFlag option when linter need to pass a flag before each pathFile

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Notice that the linting commands now are nested into the `linters` object. The f
 * `linters` — `Object` — keys (`String`) are glob patterns, values (`Array<String> | String`) are commands to execute.
 * `subTaskConcurrency` — `1` — Controls concurrency for processing chunks generated for each linter. This option is only applicable on Windows. Execution is **not** concurrent by default(see [#225](https://github.com/okonet/lint-staged/issues/225))
 * `relative` — `false` — if `true` it will give the relative path from your `package.json` directory to your linter arguments.
+* `fileFlag` — _empty_ — if `--files` it will give the flag `--files` for each files passed to your command line.
 
 ## Filtering files
 
@@ -293,9 +294,10 @@ The following is equivalent:
 ```json
 {
   "linters": {
-    "*.ts": "ng lint myProjectName --files"
+    "*.ts": "ng lint myProjectName"
   },
-  "relative": true
+  "relative": true,
+  "fileFlag": "--files"
 }
 ```
 

--- a/src/getConfig.js
+++ b/src/getConfig.js
@@ -16,7 +16,7 @@ const debug = require('debug')('lint-staged:cfg')
 /**
  * Default config object
  *
- * @type {{concurrent: boolean, chunkSize: number, globOptions: {matchBase: boolean, dot: boolean}, linters: {}, subTaskConcurrency: number, renderer: string}}
+ * @type {{concurrent: boolean, chunkSize: number, globOptions: {matchBase: boolean, dot: boolean}, linters: {}, subTaskConcurrency: number, renderer: string, relative: boolean, fileFlag: string}}
  */
 const defaultConfig = {
   concurrent: true,
@@ -29,7 +29,8 @@ const defaultConfig = {
   ignore: [],
   subTaskConcurrency: 1,
   renderer: 'update',
-  relative: false
+  relative: false,
+  fileFlag: ''
 }
 
 /**

--- a/src/makeCmdTasks.js
+++ b/src/makeCmdTasks.js
@@ -17,7 +17,7 @@ const debug = require('debug')('lint-staged:make-cmd-tasks')
 module.exports = function makeCmdTasks(
   commands,
   pathsToLint,
-  { chunkSize = Number.MAX_SAFE_INTEGER, subTaskConcurrency = 1 } = {}
+  { chunkSize = Number.MAX_SAFE_INTEGER, subTaskConcurrency = 1, fileFlag } = {}
 ) {
   debug('Creating listr tasks for commands %o', commands)
 
@@ -31,7 +31,8 @@ module.exports = function makeCmdTasks(
       gitDir,
       pathsToLint,
       chunkSize,
-      subTaskConcurrency
+      subTaskConcurrency,
+      fileFlag
     })
   }))
 }

--- a/src/runAll.js
+++ b/src/runAll.js
@@ -23,7 +23,7 @@ module.exports = function runAll(config) {
     throw new Error('Invalid config provided to runAll! Use getConfig instead.')
   }
 
-  const { concurrent, renderer, chunkSize, subTaskConcurrency } = config
+  const { concurrent, renderer, chunkSize, subTaskConcurrency, fileFlag } = config
   const gitDir = resolveGitDir()
   debug('Resolved git directory to be `%s`', gitDir)
 
@@ -39,7 +39,8 @@ module.exports = function runAll(config) {
         new Listr(
           makeCmdTasks(task.commands, task.fileList, {
             chunkSize,
-            subTaskConcurrency
+            subTaskConcurrency,
+            fileFlag
           }),
           {
             // In sub-tasks we don't want to run concurrently

--- a/test/__snapshots__/getConfig.spec.js.snap
+++ b/test/__snapshots__/getConfig.spec.js.snap
@@ -4,6 +4,7 @@ exports[`getConfig should return config with defaults 1`] = `
 Object {
   "chunkSize": 9007199254740991,
   "concurrent": true,
+  "fileFlag": "",
   "globOptions": Object {
     "dot": true,
     "matchBase": true,
@@ -20,6 +21,7 @@ exports[`getConfig should return config with defaults for undefined 1`] = `
 Object {
   "chunkSize": 9007199254740991,
   "concurrent": true,
+  "fileFlag": "",
   "globOptions": Object {
     "dot": true,
     "matchBase": true,
@@ -36,6 +38,7 @@ exports[`getConfig should set linters 1`] = `
 Object {
   "chunkSize": 9007199254740991,
   "concurrent": true,
+  "fileFlag": "",
   "globOptions": Object {
     "dot": true,
     "matchBase": true,

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -16,7 +16,8 @@ LOG {
   ignore: [],
   subTaskConcurrency: 1,
   renderer: 'verbose',
-  relative: false
+  relative: false,
+  fileFlag: ''
 }"
 `;
 
@@ -36,7 +37,8 @@ LOG {
   ignore: [],
   subTaskConcurrency: 1,
   renderer: 'verbose',
-  relative: false
+  relative: false,
+  fileFlag: ''
 }"
 `;
 
@@ -58,7 +60,8 @@ LOG {
   ignore: [],
   subTaskConcurrency: 1,
   renderer: 'verbose',
-  relative: false
+  relative: false,
+  fileFlag: ''
 }"
 `;
 

--- a/test/getConfig.spec.js
+++ b/test/getConfig.spec.js
@@ -142,7 +142,8 @@ describe('getConfig', () => {
       ignore: ['docs/**/*.js'],
       subTaskConcurrency: 10,
       renderer: 'custom',
-      relative: true
+      relative: true,
+      fileFlag: '--files'
     }
     expect(getConfig(cloneDeep(src))).toEqual(src)
   })

--- a/test/resolveTaskFn.spec.js
+++ b/test/resolveTaskFn.spec.js
@@ -60,6 +60,25 @@ describe('resolveTaskFn', () => {
     expect(execa).lastCalledWith('jest', ['test.js'], { reject: false })
   })
 
+  it('should use right file flag', async () => {
+    expect.assertions(2)
+    const opts = {
+      ...defaultOpts,
+      fileFlag: '--files',
+      linter: 'ng lint',
+      gitDir: '../'
+    }
+    opts.pathsToLint.push('test2.js')
+    const taskFn = resolveTaskFn(opts)
+
+    await taskFn()
+    expect(execa).toHaveBeenCalledTimes(1)
+    expect(execa).lastCalledWith('ng', ['lint', '--files', 'test.js', '--files', 'test2.js'], {
+      fileFlag: '--files',
+      reject: false
+    })
+  })
+
   it('should throw error for failed linters', async () => {
     expect.assertions(1)
     execa.mockResolvedValueOnce({


### PR DESCRIPTION
It close #547 
In fact, for multiple files the angular cli need to pass for each path a flag named `--files` not just one time. Sadly at this time all project used with angular cli >= 7 and lint-staged won't work correctly.
I'm aware that you aren't very fan of additional option. But I haven't any other idea to solve this issue. Let me know :) 

Signed-off-by: Benjamin Coenen <benjamin.coenen@corp.ovh.com>