### PR TITLE
feature: use unmock to avoid explicit hoist

### DIFF
--- a/test/gitStash.spec.js
+++ b/test/gitStash.spec.js
@@ -1,5 +1,3 @@
-jest.dontMock('execa') // Must be before all requires to work
-
 const execa = require('execa')
 const path = require('path')
 const tmp = require('tmp')
@@ -8,6 +6,7 @@ const pify = require('pify')
 const fsp = pify(require('fs'))
 
 tmp.setGracefulCleanup()
+jest.unmock('execa')
 
 let wcDir
 let wcDirPath


### PR DESCRIPTION
Developers have to keep `jest.dontMock('execa')` on the top as the comment says. If someone move it to somewhere else, test will fail. This PR makes it more robust.