### PR TITLE
Improve configuration validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "please-upgrade-node": "^3.0.2",
     "staged-git-files": "1.1.2",
     "string-argv": "^0.0.2",
-    "stringify-object": "^3.2.2"
+    "stringify-object": "^3.2.2",
+    "yup": "^0.26.10"
   },
   "devDependencies": {
     "babel-core": "^6.26.3",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "g-status": "^2.0.2",
     "is-glob": "^4.0.0",
     "is-windows": "^1.0.2",
-    "jest-validate": "^23.5.0",
     "listr": "^0.14.2",
     "lodash": "^4.17.5",
     "log-symbols": "^2.2.0",

--- a/src/getConfig.js
+++ b/src/getConfig.js
@@ -6,9 +6,12 @@ const chalk = require('chalk')
 const format = require('stringify-object')
 const intersection = require('lodash/intersection')
 const defaultsDeep = require('lodash/defaultsDeep')
+const isArray = require('lodash/isArray')
+const isBoolean = require('lodash/isBoolean')
+const isFunction = require('lodash/isFunction')
+const isInteger = require('lodash/isNumber')
 const isObject = require('lodash/isObject')
-const { validate, logValidationWarning } = require('jest-validate')
-const { unknownOptionWarning } = require('jest-validate/build/warnings')
+const isString = require('lodash/isString')
 const isGlob = require('is-glob')
 
 const debug = require('debug')('lint-staged:cfg')
@@ -46,26 +49,52 @@ function isSimple(config) {
   )
 }
 
+const logDeprecation = (opt, helpMsg) => `● Deprecation Warning:
+
+  Option ${chalk.bold(opt)} was removed.
+
+  ${helpMsg}
+
+  Please remove ${chalk.bold(opt)} from your configuration.
+
+Please refer to https://github.com/okonet/lint-staged#configuration for more information...`
+
+const logUnknown = (opt, helpMsg, value) => `● Validation Warning:
+
+  Unknown option ${chalk.bold(`"${opt}"`)} with value ${chalk.bold(
+  format(value, { inlineCharacterLimit: Number.POSITIVE_INFINITY })
+)} was found in the config root.
+
+  ${helpMsg}
+
+Please refer to https://github.com/okonet/lint-staged#configuration for more information...`
+
+const logError = (opt, helpMsg, value) => `● Validation Error:
+
+  Invalid value for '${chalk.bold(opt)}'.
+
+  ${helpMsg}.
+ 
+  Configured value is: ${chalk.bold(
+    format(value, { inlineCharacterLimit: Number.POSITIVE_INFINITY })
+  )}
+
+Please refer to https://github.com/okonet/lint-staged#configuration for more information...`
+
 /**
- * Custom jest-validate reporter for unknown options
+ * Reporter for unknown options
  * @param config
- * @param example
  * @param option
- * @param options
  * @returns {void}
  */
-function unknownValidationReporter(config, example, option, options) {
+function unknownValidationReporter(config, option) {
   /**
    * If the unkonwn property is a glob this is probably
    * a typical mistake of mixing simple and advanced configs
    */
   if (isGlob(option)) {
     // prettier-ignore
-    const message = `  Unknown option ${chalk.bold(`"${option}"`)} with value ${chalk.bold(
-    format(config[option], { inlineCharacterLimit: Number.POSITIVE_INFINITY })
-  )} was found in the config root.
-
-  You are probably trying to mix simple and advanced config formats. Adding
+    const message = `You are probably trying to mix simple and advanced config formats. Adding
 
   ${chalk.bold(`"linters": {
     "${option}": ${JSON.stringify(config[option])}
@@ -73,12 +102,11 @@ function unknownValidationReporter(config, example, option, options) {
 
   will fix it and remove this message.`
 
-    const { comment } = options
-    const name = options.title.warning
-    return logValidationWarning(name, message, comment)
+    return logUnknown(option, message, config[option])
   }
-  // If it is not glob pattern, use default jest-validate reporter
-  return unknownOptionWarning(config, example, option, options)
+
+  // If it is not glob pattern, simply notify of unknown value
+  return logUnknown(option, '', config[option])
 }
 
 /**
@@ -109,12 +137,6 @@ function getConfig(sourceConfig, debugMode) {
   return config
 }
 
-const optRmMsg = (opt, helpMsg) => `  Option ${chalk.bold(opt)} was removed.
-
-  ${helpMsg}
-
-  Please remove ${chalk.bold(opt)} from your configuration.`
-
 /**
  * Runs config validation. Throws error if the config is not valid.
  * @param config {Object}
@@ -122,28 +144,98 @@ const optRmMsg = (opt, helpMsg) => `  Option ${chalk.bold(opt)} was removed.
  */
 function validateConfig(config) {
   debug('Validating config')
-  const exampleConfig = {
-    ...defaultConfig,
-    linters: {
-      '*.js': ['eslint --fix', 'git add'],
-      '*.css': 'stylelint'
+
+  const errors = []
+  const warnings = []
+
+  if (!isBoolean(config.concurrent)) {
+    errors.push(logError('concurrent', 'Should be true or false', config.concurrent))
+  }
+
+  if (!isInteger(config.chunkSize)) {
+    errors.push(logError('chunkSize', 'Should be a number', config.chunkSize))
+  }
+
+  if (isObject(config.globOptions)) {
+    if (!isBoolean(config.globOptions.matchBase)) {
+      errors.push(
+        logError('globOptions.matchBase', 'Should be true or false', config.globOptions.matchBase)
+      )
     }
+
+    if (!isBoolean(config.globOptions.dot)) {
+      errors.push(logError('globOptions.dot', 'Should be true or false', config.globOptions.dot))
+    }
+  } else {
+    errors.push(logError('chunkSize', 'Should be a number', config.chunkSize))
   }
 
-  const deprecatedConfig = {
-    gitDir: () => optRmMsg('gitDir', "lint-staged now automatically resolves '.git' directory."),
-    verbose: () =>
-      optRmMsg('verbose', `Use the command line flag ${chalk.bold('--debug')} instead.`)
+  if (isObject(config.linters)) {
+    Object.keys(config.linters).forEach(key => {
+      if (!isGlob(key)) {
+        errors.push(logError(`linters[${key}]`, 'Key should be a glob pattern', key))
+      }
+
+      if (
+        (!isArray(config.linters[key]) || config.linters[key].some(item => !isString(item))) &&
+        !isString(config.linters[key])
+      ) {
+        errors.push(logError(`linters[${key}]`, 'Should be a string or an array of strings', key))
+      }
+    })
+  } else {
+    errors.push(logError('linters', 'Should be an object', config.linters))
   }
 
-  validate(config, {
-    exampleConfig,
-    deprecatedConfig,
-    unknown: unknownValidationReporter,
-    recursive: false,
-    comment:
-      'Please refer to https://github.com/okonet/lint-staged#configuration for more information...'
+  if (!isArray(config.ignore) || config.ignore.some(item => !isString(item))) {
+    errors.push(logError('ignore', 'Should be an array of strings', config.ignore))
+  }
+
+  if (!isInteger(config.subTaskConcurrency)) {
+    errors.push(logError('subTaskConcurrency', 'Should be a number', config.subTaskConcurrency))
+  }
+
+  if (
+    config.renderer !== 'update' &&
+    config.renderer !== 'verbose' &&
+    !isFunction(config.renderer)
+  ) {
+    errors.push(
+      logError('renderer', "Should be 'update', 'verbose' or a function.", config.renderer)
+    )
+  }
+
+  if (!isBoolean(config.relative)) {
+    errors.push(logError('relative', 'Should be true or false', config.relative))
+  }
+
+  Object.keys(config)
+    .filter(key => !defaultConfig.hasOwnProperty(key))
+    .forEach(option => {
+      if (option === 'gitDir') {
+        warnings.push(
+          logDeprecation('gitDir', "lint-staged now automatically resolves '.git' directory.")
+        )
+        return
+      }
+
+      if (option === 'verbose') {
+        warnings.push(
+          logDeprecation('verbose', `Use the command line flag ${chalk.bold('--debug')} instead.`)
+        )
+        return
+      }
+
+      warnings.push(unknownValidationReporter(config, option))
+    })
+
+  warnings.forEach(message => {
+    console.warn(message)
   })
+
+  if (errors.length) {
+    throw new Error(errors.join('\n'))
+  }
 
   return config
 }

--- a/test/__snapshots__/getConfig.spec.js.snap
+++ b/test/__snapshots__/getConfig.spec.js.snap
@@ -100,15 +100,11 @@ Please refer to https://github.com/okonet/lint-staged#configuration for more inf
 exports[`validateConfig should throw and should print validation errors for invalid config 1`] = `
 "● Validation Error:
 
-  Option \\"chunkSize\\" must be of type:
-    number
-  but instead received:
-    string
+  Invalid value for 'chunkSize'.
 
-  Example:
-  {
-    \\"chunkSize\\": 9007199254740991
-  }
+  Should be a number.
+ 
+  Configured value is: 'string'
 
 Please refer to https://github.com/okonet/lint-staged#configuration for more information..."
 `;

--- a/test/__snapshots__/getConfig.spec.js.snap
+++ b/test/__snapshots__/getConfig.spec.js.snap
@@ -56,6 +56,8 @@ Object {
 
 exports[`validateConfig should not throw and should print nothing for advanced valid config 1`] = `""`;
 
+exports[`validateConfig should not throw and should print nothing for custom renderer 1`] = `""`;
+
 exports[`validateConfig should not throw and should print nothing for simple valid config 1`] = `""`;
 
 exports[`validateConfig should not throw and should print validation warnings for mixed config 1`] = `
@@ -100,11 +102,19 @@ Please refer to https://github.com/okonet/lint-staged#configuration for more inf
 exports[`validateConfig should throw and should print validation errors for invalid config 1`] = `
 "● Validation Error:
 
-  Invalid value for 'chunkSize'.
+  chunkSize must be a \`number\` type, but the final value was: \`\\"string\\"\`.
 
-  Should be a number.
+Please refer to https://github.com/okonet/lint-staged#configuration for more information..."
+`;
+
+exports[`validateConfig should throw and should print validation errors for invalid linter config 1`] = `
+"● Validation Error:
+
+  Invalid value for 'linters[*.js]'.
+
+  Should be a string or an array of strings.
  
-  Configured value is: 'string'
+  Configured value is: '*.js'
 
 Please refer to https://github.com/okonet/lint-staged#configuration for more information..."
 `;

--- a/test/getConfig.spec.js
+++ b/test/getConfig.spec.js
@@ -170,6 +170,16 @@ describe('validateConfig', () => {
     expect(() => validateConfig(getConfig(invalidAdvancedConfig))).toThrowErrorMatchingSnapshot()
   })
 
+  it('should throw and should print validation errors for invalid linter config', () => {
+    const invalidAdvancedConfig = {
+      foo: false,
+      linters: {
+        '*.js': 1
+      }
+    }
+    expect(() => validateConfig(getConfig(invalidAdvancedConfig))).toThrowErrorMatchingSnapshot()
+  })
+
   it('should not throw and should print validation warnings for mixed config', () => {
     const invalidMixedConfig = {
       concurrent: false,
@@ -207,6 +217,14 @@ describe('validateConfig', () => {
       linters: {
         '*.js': ['eslint --fix', 'git add']
       }
+    }
+    expect(() => validateConfig(getConfig(validAdvancedConfig))).not.toThrow()
+    expect(console.printHistory()).toMatchSnapshot()
+  })
+
+  it('should not throw and should print nothing for custom renderer', () => {
+    const validAdvancedConfig = {
+      renderer: () => {}
     }
     expect(() => validateConfig(getConfig(validAdvancedConfig))).not.toThrow()
     expect(console.printHistory()).toMatchSnapshot()

--- a/yarn.lock
+++ b/yarn.lock
@@ -1299,16 +1299,7 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
-cosmiconfig@5.0.6:
-  version "5.0.6"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.0.6.tgz#dca6cf680a0bd03589aff684700858c81abeeb39"
-  integrity sha512-6DWfizHriCrFWURP1/qyhsiFvYdlJzbCzmtFWh744+KyWsJo5+kPzUZZaMRSSItoYc0pxFX7gEO7ZC1/gN/7AQ==
-  dependencies:
-    is-directory "^0.3.1"
-    js-yaml "^3.9.0"
-    parse-json "^4.0.0"
-
-cosmiconfig@^5.0.6:
+cosmiconfig@^5.0.2, cosmiconfig@^5.0.6:
   version "5.0.7"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.0.7.tgz#39826b292ee0d78eda137dfa3173bd1c21a43b04"
   integrity sha512-PcLqxTKiDmNT6pSpy4N6KtuPwb53W+2tzNvwOZw0WH9N6O0vLIBq0x8aj8Oj75ere4YcGi48bDFCL+3fRJdlNA==
@@ -3362,7 +3353,7 @@ jest-util@^23.4.0:
     slash "^1.0.0"
     source-map "^0.6.0"
 
-jest-validate@^23.5.0, jest-validate@^23.6.0:
+jest-validate@^23.6.0:
   version "23.6.0"
   resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-23.6.0.tgz#36761f99d1ed33fcd425b4e4c5595d62b6597474"
   integrity sha512-OFKapYxe72yz7agrDAWi8v2WL8GIfVqcbKRCLbRG9PAxtzF9b1SEDdTpytNDN12z2fJynoBwpMpvj2R39plI2A==


### PR DESCRIPTION
Fixes #567 

This pull request introduces a custom validator that replaces `jest-validate`

Improvements over the previous implementations are: 
- You can now set a function as a renderer
- Validations can be more precise
- Linters are validated (check that key is a glob, and that values are a string or array of strings)
- valid values for `renderer` are now explicit, where any string was possible before
- Check that `ignore` is an array of strings

I tried to use `joy` `yup` and `schema-utils` to express the schema to validate, but it felt more verbose and less flexible with regard to the number of possible options.

I just ensured that current tests pass, I can write more tests if needed.