### PR TITLE
chore: update lodash version

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "is-glob": "^4.0.0",
     "is-windows": "^1.0.2",
     "listr": "^0.14.2",
-    "lodash": "^4.17.5",
+    "lodash": "^4.17.11",
     "log-symbols": "^2.2.0",
     "micromatch": "^3.1.8",
     "npm-which": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3693,7 +3693,7 @@ lodash@4.17.5:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
   integrity sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==
 
-lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
+lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.3.0:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==


### PR DESCRIPTION
The lodash version in lint-staged is vulnerable to prototype pollution. 

https://nodesecurity.io/advisories/782

This PR just updates the lodash version.