### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Run linters against staged git files and don't let :poop: slip into your code base!
 
-The latest versions of `lint-staged` require Node.js v6 or newer. (Versions of `lint-staged` prior to v7 still work with Node.js v4.)
+The latest versions of `lint-staged` require Node.js v8.6 or newer. (Versions of `lint-staged` prior to v7 still work with Node.js v4.)
 
 ## Why
 


### PR DESCRIPTION
The README.md file mentions that the latest versions require Node.js v6 or newer. However, I think this applies to lint-staged v7.x.x which is stated here: https://github.com/okonet/lint-staged/releases/tag/v7.0.0. Starting lint-staged v8.0.0, Node.js v8.6 is required as mentioned here: https://github.com/okonet/lint-staged/releases/tag/v8.0.0