### PR TITLE
fix: fix issue with scoped pkg listr-update-renderer

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     }
   },
   "dependencies": {
-    "@iamstarkov/listr-update-renderer": "0.4.1",
     "chalk": "^2.3.1",
     "commander": "^2.14.1",
     "cosmiconfig": "^5.0.2",
@@ -39,6 +38,7 @@
     "is-glob": "^4.0.0",
     "is-windows": "^1.0.2",
     "listr": "^0.14.2",
+    "listr-update-renderer": "^0.5.0",
     "lodash": "^4.17.11",
     "log-symbols": "^2.2.0",
     "micromatch": "^3.1.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,20 +25,6 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
-"@iamstarkov/listr-update-renderer@0.4.1":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@iamstarkov/listr-update-renderer/-/listr-update-renderer-0.4.1.tgz#d7c48092a2dcf90fd672b6c8b458649cb350c77e"
-  integrity sha512-IJyxQWsYDEkf8C8QthBn5N8tIUR9V9je6j3sMIpAkonaadjbvxmRC6RAhpa3RKxndhNnU2M6iNbtJwd7usQYIA==
-  dependencies:
-    chalk "^1.1.3"
-    cli-truncate "^0.2.1"
-    elegant-spinner "^1.0.1"
-    figures "^1.7.0"
-    indent-string "^3.0.0"
-    log-symbols "^1.0.2"
-    log-update "^2.3.0"
-    strip-ansi "^3.0.1"
-
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"
@@ -3614,6 +3600,20 @@ listr-update-renderer@^0.4.0:
     indent-string "^3.0.0"
     log-symbols "^1.0.2"
     log-update "^1.0.2"
+    strip-ansi "^3.0.1"
+
+listr-update-renderer@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz#4ea8368548a7b8aecb7e06d8c95cb45ae2ede6a2"
+  integrity sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==
+  dependencies:
+    chalk "^1.1.3"
+    cli-truncate "^0.2.1"
+    elegant-spinner "^1.0.1"
+    figures "^1.7.0"
+    indent-string "^3.0.0"
+    log-symbols "^1.0.2"
+    log-update "^2.3.0"
     strip-ansi "^3.0.1"
 
 listr-verbose-renderer@^0.4.0:


### PR DESCRIPTION
Seems to be an issue with listr-update-renderer, version 0.5.0 was
released more recent not scoped.

Closes #585

Original: https://www.npmjs.com/package/@iamstarkov/listr-update-renderer
Updated: https://www.npmjs.com/package/listr-update-renderer
