### PR TITLE
Generate gitDir only once, using `git rev-parse --show-toplevel`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The fastest way to start using lint-staged is to run following command in your t
 
 ```bash
 npx mrm lint-staged
-``` 
+```
 
 It will install and configure [husky](https://github.com/typicode/husky) and lint-staged depending on code quality tools from `package.json` dependencies so please make sure you install (`npm install --save-dev`) and configure all code quality tools like [Prettier](https://prettier.io), [ESlint](https://eslint.org) prior that.
 
@@ -346,6 +346,7 @@ When using the IDE's GUI to commit changes with the `precommit` hook, you might 
 Until the issue is resolved in the IDE, you can use the following config to work around it:
 
 husky v1.x
+
 ```json
 {
   "husky": {
@@ -358,15 +359,15 @@ husky v1.x
 ```
 
 husky v0.x
+
 ```json
 {
   "scripts": {
-     "precommit": "lint-staged",
-     "postcommit": "git update-index --again"
+    "precommit": "lint-staged",
+    "postcommit": "git update-index --again"
   }
 }
 ```
-
 
 _Thanks to [this comment](https://youtrack.jetbrains.com/issue/IDEA-135454#comment=27-2710654) for the fix!_
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "dedent": "^0.7.0",
     "del": "^3.0.0",
     "execa": "^1.0.0",
-    "find-parent-dir": "^0.3.0",
     "g-status": "^2.0.2",
     "is-glob": "^4.0.0",
     "is-windows": "^1.0.2",

--- a/src/execGit.js
+++ b/src/execGit.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const debug = require('debug')('lint-staged:git')
+const execa = require('execa')
+const path = require('path')
+
+function getAbsolutePath(dir) {
+  return path.isAbsolute(dir) ? dir : path.resolve(dir)
+}
+
+module.exports = async function execGit(cmd, options = {}) {
+  const cwd = options.cwd || process.cwd()
+  debug('Running git command', cmd)
+  try {
+    const { stdout } = await execa('git', [].concat(cmd), {
+      ...options,
+      cwd: getAbsolutePath(cwd)
+    })
+    return stdout
+  } catch (err) {
+    throw new Error(err)
+  }
+}

--- a/src/generateTasks.js
+++ b/src/generateTasks.js
@@ -4,17 +4,15 @@ const path = require('path')
 const micromatch = require('micromatch')
 const pathIsInside = require('path-is-inside')
 const { getConfig } = require('./getConfig')
-const resolveGitDir = require('./resolveGitDir')
 
 const debug = require('debug')('lint-staged:gen-tasks')
 
-module.exports = async function generateTasks(config, stagedRelFiles) {
+module.exports = async function generateTasks(config, gitDir, stagedRelFiles) {
   debug('Generating linter tasks')
 
   const normalizedConfig = getConfig(config) // Ensure we have a normalized config
   const { linters, globOptions, ignore } = normalizedConfig
 
-  const gitDir = await resolveGitDir()
   const cwd = process.cwd()
   const stagedFiles = stagedRelFiles.map(file => path.resolve(gitDir, file))
 

--- a/src/generateTasks.js
+++ b/src/generateTasks.js
@@ -8,13 +8,13 @@ const resolveGitDir = require('./resolveGitDir')
 
 const debug = require('debug')('lint-staged:gen-tasks')
 
-module.exports = function generateTasks(config, stagedRelFiles) {
+module.exports = async function generateTasks(config, stagedRelFiles) {
   debug('Generating linter tasks')
 
   const normalizedConfig = getConfig(config) // Ensure we have a normalized config
   const { linters, globOptions, ignore } = normalizedConfig
 
-  const gitDir = resolveGitDir()
+  const gitDir = await resolveGitDir()
   const cwd = process.cwd()
   const stagedFiles = stagedRelFiles.map(file => path.resolve(gitDir, file))
 

--- a/src/gitWorkflow.js
+++ b/src/gitWorkflow.js
@@ -1,32 +1,14 @@
 'use strict'
 
-const path = require('path')
-const execa = require('execa')
 const gStatus = require('g-status')
 const del = require('del')
 const debug = require('debug')('lint-staged:git')
 
+const execGit = require('./execGit')
+
 let workingCopyTree = null
 let indexTree = null
 let formattedIndexTree = null
-
-function getAbsolutePath(dir) {
-  return path.isAbsolute(dir) ? dir : path.resolve(dir)
-}
-
-async function execGit(cmd, options) {
-  const { cwd } = options
-  debug('Running git command', cmd)
-  try {
-    const { stdout } = await execa('git', [].concat(cmd), {
-      ...options,
-      cwd: getAbsolutePath(cwd)
-    })
-    return stdout
-  } catch (err) {
-    throw new Error(err)
-  }
-}
 
 async function writeTree(options) {
   return execGit(['write-tree'], options)

--- a/src/gitWorkflow.js
+++ b/src/gitWorkflow.js
@@ -5,7 +5,6 @@ const execa = require('execa')
 const gStatus = require('g-status')
 const del = require('del')
 const debug = require('debug')('lint-staged:git')
-const resolveGitDir = require('./resolveGitDir')
 
 let workingCopyTree = null
 let indexTree = null
@@ -16,7 +15,7 @@ function getAbsolutePath(dir) {
 }
 
 async function execGit(cmd, options) {
-  const cwd = options && options.cwd ? options.cwd : resolveGitDir()
+  const { cwd } = options
   debug('Running git command', cmd)
   try {
     const { stdout } = await execa('git', [].concat(cmd), {
@@ -51,7 +50,7 @@ async function getDiffForTrees(tree1, tree2, options) {
 }
 
 async function hasPartiallyStagedFiles(options) {
-  const cwd = options && options.cwd ? options.cwd : resolveGitDir()
+  const { cwd } = options
   const files = await gStatus({ cwd })
   const partiallyStaged = files.filter(
     file =>

--- a/src/makeCmdTasks.js
+++ b/src/makeCmdTasks.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const resolveTaskFn = require('./resolveTaskFn')
-const resolveGitDir = require('./resolveGitDir')
 
 const debug = require('debug')('lint-staged:make-cmd-tasks')
 
@@ -16,12 +15,12 @@ const debug = require('debug')('lint-staged:make-cmd-tasks')
  */
 module.exports = async function makeCmdTasks(
   commands,
+  gitDir,
   pathsToLint,
   { chunkSize = Number.MAX_SAFE_INTEGER, subTaskConcurrency = 1 } = {}
 ) {
   debug('Creating listr tasks for commands %o', commands)
 
-  const gitDir = await resolveGitDir()
   const lintersArray = Array.isArray(commands) ? commands : [commands]
 
   return lintersArray.map(linter => ({

--- a/src/makeCmdTasks.js
+++ b/src/makeCmdTasks.js
@@ -14,14 +14,14 @@ const debug = require('debug')('lint-staged:make-cmd-tasks')
  * @param {number} options.chunkSize
  * @param {number} options.subTaskConcurrency
  */
-module.exports = function makeCmdTasks(
+module.exports = async function makeCmdTasks(
   commands,
   pathsToLint,
   { chunkSize = Number.MAX_SAFE_INTEGER, subTaskConcurrency = 1 } = {}
 ) {
   debug('Creating listr tasks for commands %o', commands)
 
-  const gitDir = resolveGitDir()
+  const gitDir = await resolveGitDir()
   const lintersArray = Array.isArray(commands) ? commands : [commands]
 
   return lintersArray.map(linter => ({

--- a/src/resolveGitDir.js
+++ b/src/resolveGitDir.js
@@ -1,7 +1,14 @@
 'use strict'
 
-const execa = require('execa')
+const execGit = require('./execGit')
+const printErrors = require('./printErrors')
 
 module.exports = async function resolveGitDir() {
-  return (await execa('git', ['rev-parse', '--show-toplevel'])).stdout
+  try {
+    const gitDir = await execGit(['rev-parse', '--show-toplevel'])
+    return gitDir
+  } catch (error) {
+    printErrors(error)
+    return null
+  }
 }

--- a/src/resolveGitDir.js
+++ b/src/resolveGitDir.js
@@ -2,14 +2,12 @@
 
 const execGit = require('./execGit')
 const path = require('path')
-const printErrors = require('./printErrors')
 
 module.exports = async function resolveGitDir(options) {
   try {
     const gitDir = await execGit(['rev-parse', '--show-toplevel'], options)
     return path.normalize(gitDir)
   } catch (error) {
-    printErrors(error)
     return null
   }
 }

--- a/src/resolveGitDir.js
+++ b/src/resolveGitDir.js
@@ -1,12 +1,13 @@
 'use strict'
 
 const execGit = require('./execGit')
+const path = require('path')
 const printErrors = require('./printErrors')
 
 module.exports = async function resolveGitDir() {
   try {
     const gitDir = await execGit(['rev-parse', '--show-toplevel'])
-    return gitDir
+    return path.normalize(gitDir)
   } catch (error) {
     printErrors(error)
     return null

--- a/src/resolveGitDir.js
+++ b/src/resolveGitDir.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const findParentDir = require('find-parent-dir')
+const execa = require('execa')
 
-module.exports = function resolveGitDir() {
-  return findParentDir.sync(process.cwd(), '.git')
+module.exports = async function resolveGitDir() {
+  return (await execa('git', ['rev-parse', '--show-toplevel'])).stdout
 }

--- a/src/resolveGitDir.js
+++ b/src/resolveGitDir.js
@@ -4,9 +4,9 @@ const execGit = require('./execGit')
 const path = require('path')
 const printErrors = require('./printErrors')
 
-module.exports = async function resolveGitDir() {
+module.exports = async function resolveGitDir(options) {
   try {
-    const gitDir = await execGit(['rev-parse', '--show-toplevel'])
+    const gitDir = await execGit(['rev-parse', '--show-toplevel'], options)
     return path.normalize(gitDir)
   } catch (error) {
     printErrors(error)

--- a/src/runAll.js
+++ b/src/runAll.js
@@ -34,7 +34,7 @@ module.exports = async function runAll(config) {
   const filenames = files.map(file => file.filename)
   debug('Loaded list of staged files in git:\n%O', filenames)
 
-  const tasks = (await generateTasks(config, filenames)).map(task => ({
+  const tasks = (await generateTasks(config, gitDir, filenames)).map(task => ({
     title: `Running tasks for ${task.pattern}`,
     task: async () =>
       new Listr(

--- a/src/runAll.js
+++ b/src/runAll.js
@@ -24,7 +24,12 @@ module.exports = async function runAll(config) {
   }
 
   const { concurrent, renderer, chunkSize, subTaskConcurrency } = config
-  const gitDir = await resolveGitDir()
+  const gitDir = await resolveGitDir(config)
+
+  if (!gitDir) {
+    throw new Error('Current directory is not a git directory!')
+  }
+
   debug('Resolved git directory to be `%s`', gitDir)
 
   sgf.cwd = gitDir

--- a/src/runAll.js
+++ b/src/runAll.js
@@ -43,7 +43,7 @@ module.exports = async function runAll(config) {
     title: `Running tasks for ${task.pattern}`,
     task: async () =>
       new Listr(
-        await makeCmdTasks(task.commands, task.fileList, {
+        await makeCmdTasks(task.commands, gitDir, task.fileList, {
           chunkSize,
           subTaskConcurrency
         }),

--- a/test/__snapshots__/runAll.2.spec.js.snap
+++ b/test/__snapshots__/runAll.2.spec.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`runAll should throw when not in a git directory 1`] = `"Current directory is not a git directory!"`;

--- a/test/__snapshots__/runAll.spec.js.snap
+++ b/test/__snapshots__/runAll.spec.js.snap
@@ -89,35 +89,6 @@ LOG Running linters... [started]
 LOG Running tasks for *.js [started]
 LOG echo \\"sample\\" [started]
 LOG echo \\"sample\\" [failed]
-LOG →
-LOG Running tasks for *.js [failed]
-LOG →
-LOG Running linters... [failed]
-LOG Updating stash... [started]
-LOG Updating stash... [skipped]
-LOG → Skipping stash update since some tasks exited with errors
-LOG Restoring local changes... [started]
-LOG Restoring local changes... [completed]
-LOG {
-  name: 'ListrError',
-  errors: [
-    {
-      privateMsg: '\\\\n\\\\n\\\\n× echo \\"sample\\" found some errors. Please fix them and try committing again.\\\\n\\\\nLinter finished with error',
-      context: {hasStash: true, hasErrors: true}
-    }
-  ],
-  context: {hasStash: true, hasErrors: true}
-}"
-`;
-
-exports[`runAll should skip updating stash if there are errors during linting 1`] = `
-"
-LOG Stashing changes... [started]
-LOG Stashing changes... [completed]
-LOG Running linters... [started]
-LOG Running tasks for *.js [started]
-LOG echo \\"sample\\" [started]
-LOG echo \\"sample\\" [failed]
 LOG → 
 LOG Running tasks for *.js [failed]
 LOG → 

--- a/test/generateTasks.spec.js
+++ b/test/generateTasks.spec.js
@@ -53,6 +53,7 @@ describe('generateTasks', () => {
       {
         '*.js': 'lint'
       },
+      workDir,
       ['test.js']
     )
     const commands = result.map(match => match.commands)
@@ -66,6 +67,7 @@ describe('generateTasks', () => {
           '*.js': 'lint'
         }
       },
+      workDir,
       ['test.js']
     )
     const commands = result.map(match => match.commands)
@@ -79,6 +81,7 @@ describe('generateTasks', () => {
           '*': 'lint'
         }
       },
+      workDir,
       files
     )
     task.fileList.forEach(file => {
@@ -94,6 +97,7 @@ describe('generateTasks', () => {
         },
         relative: true
       },
+      workDir,
       files
     )
     task.fileList.forEach(file => {
@@ -103,8 +107,7 @@ describe('generateTasks', () => {
 
   it('should not match non-children files', async () => {
     const relPath = path.join(process.cwd(), '..')
-    resolveGitDir.mockResolvedValueOnce(relPath)
-    const result = await generateTasks({ ...config }, files)
+    const result = await generateTasks({ ...config }, relPath, files)
     const linter = result.find(item => item.pattern === '*.js')
     expect(linter).toEqual({
       pattern: '*.js',
@@ -114,7 +117,7 @@ describe('generateTasks', () => {
   })
 
   it('should return an empty file list for linters with no matches.', async () => {
-    const result = await generateTasks(config, files)
+    const result = await generateTasks(config, workDir, files)
 
     result.forEach(task => {
       if (task.commands === 'unknown-js') {
@@ -126,7 +129,7 @@ describe('generateTasks', () => {
   })
 
   it('should match pattern "*.js"', async () => {
-    const result = await generateTasks(config, files)
+    const result = await generateTasks(config, workDir, files)
     const linter = result.find(item => item.pattern === '*.js')
     expect(linter).toEqual({
       pattern: '*.js',
@@ -142,7 +145,11 @@ describe('generateTasks', () => {
   })
 
   it('should match pattern "*.js" and return relative path', async () => {
-    const result = await generateTasks(Object.assign({}, config, { relative: true }), files)
+    const result = await generateTasks(
+      Object.assign({}, config, { relative: true }),
+      workDir,
+      files
+    )
     const linter = result.find(item => item.pattern === '*.js')
     expect(linter).toEqual({
       pattern: '*.js',
@@ -158,7 +165,7 @@ describe('generateTasks', () => {
   })
 
   it('should match pattern "**/*.js"', async () => {
-    const result = await generateTasks(config, files)
+    const result = await generateTasks(config, workDir, files)
     const linter = result.find(item => item.pattern === '**/*.js')
     expect(linter).toEqual({
       pattern: '**/*.js',
@@ -174,7 +181,11 @@ describe('generateTasks', () => {
   })
 
   it('should match pattern "**/*.js" with relative path', async () => {
-    const result = await generateTasks(Object.assign({}, config, { relative: true }), files)
+    const result = await generateTasks(
+      Object.assign({}, config, { relative: true }),
+      workDir,
+      files
+    )
     const linter = result.find(item => item.pattern === '**/*.js')
     expect(linter).toEqual({
       pattern: '**/*.js',
@@ -190,7 +201,7 @@ describe('generateTasks', () => {
   })
 
   it('should match pattern "deeper/*.js"', async () => {
-    const result = await generateTasks(config, files)
+    const result = await generateTasks(config, workDir, files)
     const linter = result.find(item => item.pattern === 'deeper/*.js')
     expect(linter).toEqual({
       pattern: 'deeper/*.js',
@@ -200,7 +211,7 @@ describe('generateTasks', () => {
   })
 
   it('should match pattern ".hidden/*.js"', async () => {
-    const result = await generateTasks(config, files)
+    const result = await generateTasks(config, workDir, files)
     const linter = result.find(item => item.pattern === '.hidden/*.js')
     expect(linter).toEqual({
       pattern: '.hidden/*.js',
@@ -210,7 +221,7 @@ describe('generateTasks', () => {
   })
 
   it('should match pattern "*.{css,js}"', async () => {
-    const result = await generateTasks(config, files)
+    const result = await generateTasks(config, workDir, files)
     const linter = result.find(item => item.pattern === '*.{css,js}')
     expect(linter).toEqual({
       pattern: '*.{css,js}',
@@ -241,6 +252,7 @@ describe('generateTasks', () => {
           'TeSt.*': 'lint'
         }
       },
+      workDir,
       files
     )
     const linter = result.find(item => item.pattern === 'TeSt.*')
@@ -261,6 +273,7 @@ describe('generateTasks', () => {
         ignore: ['**/ignore/**', '**/ignore.*'],
         linters: { [pattern]: commands }
       },
+      workDir,
       ['ignore/me.js', 'ignore.me.js', 'cool/js.js']
     )
     expect(result[0]).toEqual({
@@ -279,6 +292,7 @@ describe('generateTasks', () => {
           '../outside/*.js': 'my-cmd'
         }
       },
+      workDir,
       ['root.js', 'prj/test.js', 'outside/test.js', 'outside/test2.js']
     )
 

--- a/test/generateTasks.spec.js
+++ b/test/generateTasks.spec.js
@@ -26,7 +26,7 @@ const files = [
 // Mocks get hoisted
 jest.mock('../src/resolveGitDir.js')
 const workDir = path.join(os.tmpdir(), 'tmp-lint-staged')
-resolveGitDir.mockReturnValue(workDir)
+resolveGitDir.mockResolvedValue(workDir)
 
 const config = {
   linters: {
@@ -48,8 +48,8 @@ describe('generateTasks', () => {
     process.cwd.mockRestore()
   })
 
-  it('should work with simple configuration', () => {
-    const result = generateTasks(
+  it('should work with simple configuration', async () => {
+    const result = await generateTasks(
       {
         '*.js': 'lint'
       },
@@ -59,8 +59,8 @@ describe('generateTasks', () => {
     expect(commands).toEqual(['lint'])
   })
 
-  it('should work with advanced configuration', () => {
-    const result = generateTasks(
+  it('should work with advanced configuration', async () => {
+    const result = await generateTasks(
       {
         linters: {
           '*.js': 'lint'
@@ -72,8 +72,8 @@ describe('generateTasks', () => {
     expect(commands).toEqual(['lint'])
   })
 
-  it('should return absolute paths', () => {
-    const [task] = generateTasks(
+  it('should return absolute paths', async () => {
+    const [task] = await generateTasks(
       {
         linters: {
           '*': 'lint'
@@ -86,8 +86,8 @@ describe('generateTasks', () => {
     })
   })
 
-  it('should return relative paths', () => {
-    const [task] = generateTasks(
+  it('should return relative paths', async () => {
+    const [task] = await generateTasks(
       {
         linters: {
           '*': 'lint'
@@ -101,10 +101,10 @@ describe('generateTasks', () => {
     })
   })
 
-  it('should not match non-children files', () => {
+  it('should not match non-children files', async () => {
     const relPath = path.join(process.cwd(), '..')
-    resolveGitDir.mockReturnValueOnce(relPath)
-    const result = generateTasks({ ...config }, files)
+    resolveGitDir.mockResolvedValueOnce(relPath)
+    const result = await generateTasks({ ...config }, files)
     const linter = result.find(item => item.pattern === '*.js')
     expect(linter).toEqual({
       pattern: '*.js',
@@ -113,8 +113,8 @@ describe('generateTasks', () => {
     })
   })
 
-  it('should return an empty file list for linters with no matches.', () => {
-    const result = generateTasks(config, files)
+  it('should return an empty file list for linters with no matches.', async () => {
+    const result = await generateTasks(config, files)
 
     result.forEach(task => {
       if (task.commands === 'unknown-js') {
@@ -125,8 +125,8 @@ describe('generateTasks', () => {
     })
   })
 
-  it('should match pattern "*.js"', () => {
-    const result = generateTasks(config, files)
+  it('should match pattern "*.js"', async () => {
+    const result = await generateTasks(config, files)
     const linter = result.find(item => item.pattern === '*.js')
     expect(linter).toEqual({
       pattern: '*.js',
@@ -141,8 +141,8 @@ describe('generateTasks', () => {
     })
   })
 
-  it('should match pattern "*.js" and return relative path', () => {
-    const result = generateTasks(Object.assign({}, config, { relative: true }), files)
+  it('should match pattern "*.js" and return relative path', async () => {
+    const result = await generateTasks(Object.assign({}, config, { relative: true }), files)
     const linter = result.find(item => item.pattern === '*.js')
     expect(linter).toEqual({
       pattern: '*.js',
@@ -157,8 +157,8 @@ describe('generateTasks', () => {
     })
   })
 
-  it('should match pattern "**/*.js"', () => {
-    const result = generateTasks(config, files)
+  it('should match pattern "**/*.js"', async () => {
+    const result = await generateTasks(config, files)
     const linter = result.find(item => item.pattern === '**/*.js')
     expect(linter).toEqual({
       pattern: '**/*.js',
@@ -173,8 +173,8 @@ describe('generateTasks', () => {
     })
   })
 
-  it('should match pattern "**/*.js" with relative path', () => {
-    const result = generateTasks(Object.assign({}, config, { relative: true }), files)
+  it('should match pattern "**/*.js" with relative path', async () => {
+    const result = await generateTasks(Object.assign({}, config, { relative: true }), files)
     const linter = result.find(item => item.pattern === '**/*.js')
     expect(linter).toEqual({
       pattern: '**/*.js',
@@ -189,8 +189,8 @@ describe('generateTasks', () => {
     })
   })
 
-  it('should match pattern "deeper/*.js"', () => {
-    const result = generateTasks(config, files)
+  it('should match pattern "deeper/*.js"', async () => {
+    const result = await generateTasks(config, files)
     const linter = result.find(item => item.pattern === 'deeper/*.js')
     expect(linter).toEqual({
       pattern: 'deeper/*.js',
@@ -199,8 +199,8 @@ describe('generateTasks', () => {
     })
   })
 
-  it('should match pattern ".hidden/*.js"', () => {
-    const result = generateTasks(config, files)
+  it('should match pattern ".hidden/*.js"', async () => {
+    const result = await generateTasks(config, files)
     const linter = result.find(item => item.pattern === '.hidden/*.js')
     expect(linter).toEqual({
       pattern: '.hidden/*.js',
@@ -209,8 +209,8 @@ describe('generateTasks', () => {
     })
   })
 
-  it('should match pattern "*.{css,js}"', () => {
-    const result = generateTasks(config, files)
+  it('should match pattern "*.{css,js}"', async () => {
+    const result = await generateTasks(config, files)
     const linter = result.find(item => item.pattern === '*.{css,js}')
     expect(linter).toEqual({
       pattern: '*.{css,js}',
@@ -230,8 +230,8 @@ describe('generateTasks', () => {
     })
   })
 
-  it('should support globOptions specified in advanced configuration', () => {
-    const result = generateTasks(
+  it('should support globOptions specified in advanced configuration', async () => {
+    const result = await generateTasks(
       {
         globOptions: {
           matchBase: false,
@@ -253,10 +253,10 @@ describe('generateTasks', () => {
     })
   })
 
-  it('should ignore patterns in the ignore array of configuration', () => {
+  it('should ignore patterns in the ignore array of configuration', async () => {
     const pattern = '**/*.js'
     const commands = 'lint'
-    const result = generateTasks(
+    const result = await generateTasks(
       {
         ignore: ['**/ignore/**', '**/ignore.*'],
         linters: { [pattern]: commands }
@@ -270,9 +270,9 @@ describe('generateTasks', () => {
     })
   })
 
-  it('should not filter files for pattern which begins with `..`', () => {
+  it('should not filter files for pattern which begins with `..`', async () => {
     jest.spyOn(process, 'cwd').mockReturnValueOnce(path.join(workDir, 'prj'))
-    const result = generateTasks(
+    const result = await generateTasks(
       {
         linters: {
           '*.js': 'my-cmd',

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -3,6 +3,8 @@ import cosmiconfig from 'cosmiconfig'
 import path from 'path'
 import lintStaged from '../src/index'
 
+jest.unmock('execa')
+
 const replaceSerializer = (from, to) => ({
   test: val => typeof val === 'string' && from.test(val),
   print: val => val.replace(from, to)

--- a/test/makeCmdTasks.spec.js
+++ b/test/makeCmdTasks.spec.js
@@ -9,7 +9,8 @@ describe('makeCmdTasks', () => {
   })
 
   it('should return an array', async () => {
-    expect(await makeCmdTasks('test', ['test.js'])).toBeInstanceOf(Array)
+    const array = await makeCmdTasks('test', gitDir, ['test.js'])
+    expect(array).toBeInstanceOf(Array)
   })
 
   it('should work with a single command', async () => {

--- a/test/makeCmdTasks.spec.js
+++ b/test/makeCmdTasks.spec.js
@@ -2,6 +2,8 @@ import execa from 'execa'
 import makeCmdTasks from '../src/makeCmdTasks'
 
 describe('makeCmdTasks', () => {
+  const gitDir = process.cwd()
+
   beforeEach(() => {
     execa.mockClear()
   })
@@ -12,7 +14,7 @@ describe('makeCmdTasks', () => {
 
   it('should work with a single command', async () => {
     expect.assertions(4)
-    const res = await makeCmdTasks('test', ['test.js'])
+    const res = await makeCmdTasks('test', gitDir, ['test.js'])
     expect(res.length).toBe(1)
     const [linter] = res
     expect(linter.title).toBe('test')
@@ -24,7 +26,7 @@ describe('makeCmdTasks', () => {
 
   it('should work with multiple commands', async () => {
     expect.assertions(9)
-    const res = await makeCmdTasks(['test', 'test2'], ['test.js'])
+    const res = await makeCmdTasks(['test', 'test2'], gitDir, ['test.js'])
     expect(res.length).toBe(2)
     const [linter1, linter2] = res
     expect(linter1.title).toBe('test')
@@ -33,12 +35,12 @@ describe('makeCmdTasks', () => {
     let taskPromise = linter1.task()
     expect(taskPromise).toBeInstanceOf(Promise)
     await taskPromise
-    expect(execa).toHaveBeenCalledTimes(2)
+    expect(execa).toHaveBeenCalledTimes(1)
     expect(execa).lastCalledWith('test', ['test.js'], { reject: false })
     taskPromise = linter2.task()
     expect(taskPromise).toBeInstanceOf(Promise)
     await taskPromise
-    expect(execa).toHaveBeenCalledTimes(3)
+    expect(execa).toHaveBeenCalledTimes(2)
     expect(execa).lastCalledWith('test2', ['test.js'], { reject: false })
   })
 })

--- a/test/makeCmdTasks.spec.js
+++ b/test/makeCmdTasks.spec.js
@@ -6,13 +6,13 @@ describe('makeCmdTasks', () => {
     execa.mockClear()
   })
 
-  it('should return an array', () => {
-    expect(makeCmdTasks('test', ['test.js'])).toBeInstanceOf(Array)
+  it('should return an array', async () => {
+    expect(await makeCmdTasks('test', ['test.js'])).toBeInstanceOf(Array)
   })
 
   it('should work with a single command', async () => {
     expect.assertions(4)
-    const res = makeCmdTasks('test', ['test.js'])
+    const res = await makeCmdTasks('test', ['test.js'])
     expect(res.length).toBe(1)
     const [linter] = res
     expect(linter.title).toBe('test')
@@ -24,7 +24,7 @@ describe('makeCmdTasks', () => {
 
   it('should work with multiple commands', async () => {
     expect.assertions(9)
-    const res = makeCmdTasks(['test', 'test2'], ['test.js'])
+    const res = await makeCmdTasks(['test', 'test2'], ['test.js'])
     expect(res.length).toBe(2)
     const [linter1, linter2] = res
     expect(linter1.title).toBe('test')
@@ -33,12 +33,12 @@ describe('makeCmdTasks', () => {
     let taskPromise = linter1.task()
     expect(taskPromise).toBeInstanceOf(Promise)
     await taskPromise
-    expect(execa).toHaveBeenCalledTimes(1)
+    expect(execa).toHaveBeenCalledTimes(2)
     expect(execa).lastCalledWith('test', ['test.js'], { reject: false })
     taskPromise = linter2.task()
     expect(taskPromise).toBeInstanceOf(Promise)
     await taskPromise
-    expect(execa).toHaveBeenCalledTimes(2)
+    expect(execa).toHaveBeenCalledTimes(3)
     expect(execa).lastCalledWith('test2', ['test.js'], { reject: false })
   })
 })

--- a/test/resolveGitDir.spec.js
+++ b/test/resolveGitDir.spec.js
@@ -20,4 +20,9 @@ describe('resolveGitDir', () => {
     expect(path.resolve(await resolveGitDir())).toEqual(expected)
     process.cwd = processCwdBkp
   })
+
+  it('should return null when not in a git directory', async () => {
+    const gitDir = await resolveGitDir({ cwd: '/' }) // assume root is not a git directory
+    expect(gitDir).toEqual(null)
+  })
 })

--- a/test/resolveGitDir.spec.js
+++ b/test/resolveGitDir.spec.js
@@ -1,18 +1,23 @@
 import path from 'path'
 import resolveGitDir from '../src/resolveGitDir'
 
+/**
+ * resolveGitDir runs execa, so the mock needs to be disabled for these tests
+ */
+jest.unmock('execa')
+
 describe('resolveGitDir', () => {
-  it('should resolve to current working dir when .git is in the same dir', () => {
+  it('should resolve to current working dir when .git is in the same dir', async () => {
     const expected = process.cwd()
-    expect(resolveGitDir()).toEqual(expected)
+    expect(await resolveGitDir()).toEqual(expected)
   })
 
-  it('should resolve to the parent dir when .git is in the parent dir', () => {
+  it('should resolve to the parent dir when .git is in the parent dir', async () => {
     const expected = path.dirname(__dirname)
     const processCwdBkp = process.cwd
     process.cwd = () => __dirname
     // path.resolve to strip trailing slash
-    expect(path.resolve(resolveGitDir())).toEqual(expected)
+    expect(path.resolve(await resolveGitDir())).toEqual(expected)
     process.cwd = processCwdBkp
   })
 })

--- a/test/resolveTaskFn.spec.js
+++ b/test/resolveTaskFn.spec.js
@@ -118,7 +118,6 @@ Mock error"
   })
 
   it('should set hasErrors on context to true on error', async () => {
-    expect.assertions(1)
     execa.mockResolvedValueOnce({
       stdout: 'Mock error',
       stderr: '',
@@ -128,6 +127,7 @@ Mock error"
     })
     const context = {}
     const taskFn = resolveTaskFn({ ...defaultOpts, linter: 'mock-fail-linter' })
+    expect.assertions(1)
     try {
       await taskFn(context)
     } catch (err) {

--- a/test/runAll.2.spec.js
+++ b/test/runAll.2.spec.js
@@ -1,0 +1,11 @@
+import { getConfig } from '../src/getConfig'
+import runAll from '../src/runAll'
+
+jest.unmock('execa')
+
+describe('runAll', () => {
+  it('should throw when not in a git directory', async () => {
+    const config = getConfig({ concurrent: true, cwd: '/' })
+    await expect(runAll(config)).rejects.toThrowErrorMatchingSnapshot()
+  })
+})

--- a/test/runAll.spec.js
+++ b/test/runAll.spec.js
@@ -30,8 +30,8 @@ describe('runAll', () => {
   })
 
   it('should throw when invalid config is provided', () => {
-    expect(() => runAll({})).toThrowErrorMatchingSnapshot()
-    expect(() => runAll()).toThrowErrorMatchingSnapshot()
+    expect(runAll({})).rejects.toThrowErrorMatchingSnapshot()
+    expect(runAll()).rejects.toThrowErrorMatchingSnapshot()
   })
 
   it('should not throw when a valid config is provided', () => {
@@ -99,7 +99,7 @@ describe('runAll', () => {
     sgfMock.mockImplementationOnce((params, callback) => {
       callback(null, [{ filename: 'sample.js', status: 'Modified' }])
     })
-    execa.mockImplementationOnce(() =>
+    execa.mockImplementation(() =>
       Promise.resolve({
         stdout: '',
         stderr: 'Linter finished with error',
@@ -126,7 +126,7 @@ describe('runAll', () => {
     sgfMock.mockImplementationOnce((params, callback) => {
       callback(null, [{ filename: 'sample.js', status: 'Modified' }])
     })
-    execa.mockImplementationOnce(() =>
+    execa.mockImplementation(() =>
       Promise.resolve({
         stdout: '',
         stderr: '',

--- a/test/runAll.spec.js
+++ b/test/runAll.spec.js
@@ -29,9 +29,9 @@ describe('runAll', () => {
     global.console = globalConsoleTemp
   })
 
-  it('should throw when invalid config is provided', () => {
-    expect(runAll({})).rejects.toThrowErrorMatchingSnapshot()
-    expect(runAll()).rejects.toThrowErrorMatchingSnapshot()
+  it('should throw when invalid config is provided', async () => {
+    await expect(runAll({})).rejects.toThrowErrorMatchingSnapshot()
+    await expect(runAll()).rejects.toThrowErrorMatchingSnapshot()
   })
 
   it('should not throw when a valid config is provided', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2098,11 +2098,6 @@ find-node-modules@1.0.4:
     findup-sync "0.4.2"
     merge "^1.2.0"
 
-find-parent-dir@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/find-parent-dir/-/find-parent-dir-0.3.0.tgz#33c44b429ab2b2f0646299c5f9f718f376ff8d54"
-  integrity sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=
-
 find-root@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.0.0.tgz#962ff211aab25c6520feeeb8d6287f8f6e95807a"


### PR DESCRIPTION
This pull reguest refactors the `resolveGitDir` to run `git rev-parse --show-toplevel`. It also calculates this only once in the `runAll` method, passing it down to the `gitWorkflow`, `makeCmdTasks` and `generateTasks` methods.

~~Additionally, when `config.relative === true`, the the `cwd` where all `git` commands are run is the actual `process.cwd()` (location of `package.lock`), instead of the `gitDir`. This significantly speeds up the `stash`/`pop` workflow of partial file commits in large monorepos. In our case, the runtime of the initial stash goes down to 400 ms from over 5 seconds.~~ This will be moved to a separate PR.

What do you think?