### PR TITLE
perf: always execute git commands in process.cwd()

### DIFF
--- a/src/runAll.js
+++ b/src/runAll.js
@@ -83,7 +83,7 @@ module.exports = async function runAll(config) {
       {
         title: 'Stashing changes...',
         skip: async () => {
-          const hasPSF = await git.hasPartiallyStagedFiles({ cwd: gitDir })
+          const hasPSF = await git.hasPartiallyStagedFiles()
           if (!hasPSF) {
             return 'No partially staged files found...'
           }
@@ -91,7 +91,7 @@ module.exports = async function runAll(config) {
         },
         task: ctx => {
           ctx.hasStash = true
-          return git.gitStashSave({ cwd: gitDir })
+          return git.gitStashSave()
         }
       },
       {
@@ -107,12 +107,12 @@ module.exports = async function runAll(config) {
         title: 'Updating stash...',
         enabled: ctx => ctx.hasStash,
         skip: ctx => ctx.hasErrors && 'Skipping stash update since some tasks exited with errors',
-        task: () => git.updateStash({ cwd: gitDir })
+        task: () => git.updateStash()
       },
       {
         title: 'Restoring local changes...',
         enabled: ctx => ctx.hasStash,
-        task: () => git.gitStashPop({ cwd: gitDir })
+        task: () => git.gitStashPop()
       }
     ],
     listrBaseOptions


### PR DESCRIPTION
Running git actions in a sub-directory of the git repository doesn't affect git behaviour, but is significantly faster in large (mono) repositories, where linter commands only need to run in a single sub-directory.

See discussion for https://github.com/okonet/lint-staged/pull/622 more info.