### PR TITLE
refactor: use internal execGit to list staged files

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -2,6 +2,6 @@
   "linters": {
     "*.{js,json,md}": ["prettier --write", "git add"],
     "*.js": ["npm run lint:base --fix", "git add"],
-    ".*{rc, json}": "jsonlint"
+    ".*{rc, json}": ["jsonlint", "git add"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,9 +43,7 @@
     "npm-which": "^3.0.1",
     "p-map": "^1.1.1",
     "path-is-inside": "^1.0.2",
-    "pify": "^3.0.0",
     "please-upgrade-node": "^3.0.2",
-    "staged-git-files": "1.1.2",
     "string-argv": "^0.0.2",
     "stringify-object": "^3.2.2",
     "yup": "^0.27.0"
@@ -61,6 +59,7 @@
     "eslint": "^4.18.1",
     "eslint-config-okonet": "^5.0.1",
     "eslint-plugin-node": "^6.0.0",
+    "fs-extra": "^8.0.1",
     "husky": "^1.1.4",
     "jest": "^23.6.0",
     "jest-snapshot-serializer-ansi": "^1.0.0",

--- a/src/getStagedFiles.js
+++ b/src/getStagedFiles.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const execGit = require('./execGit')
+
+module.exports = async function getStagedFiles(options) {
+  try {
+    const lines = await execGit(['diff', '--staged', '--diff-filter=ACM', '--name-only'], options)
+    return lines ? lines.split('\n') : []
+  } catch (error) {
+    return null
+  }
+}

--- a/test/__snapshots__/runAll.spec.js.snap
+++ b/test/__snapshots__/runAll.spec.js.snap
@@ -29,6 +29,8 @@ LOG Running tasks for *.js [completed]
 LOG Running linters... [completed]"
 `;
 
+exports[`runAll should reject promise when error during getStagedFiles 1`] = `"Unable to get staged files!"`;
+
 exports[`runAll should resolve the promise with no files 1`] = `
 "
 LOG No staged files match any of provided globs."

--- a/test/getStagedFiles.spec.js
+++ b/test/getStagedFiles.spec.js
@@ -1,0 +1,26 @@
+import getStagedFiles from '../src/getStagedFiles'
+import execGit from '../src/execGit'
+
+jest.mock('../src/execGit')
+
+describe('getStagedFiles', () => {
+  it('should return array of file names', async () => {
+    execGit.mockImplementationOnce(async () => 'foo.js\nbar.js')
+    const staged = await getStagedFiles()
+    expect(staged).toEqual(['foo.js', 'bar.js'])
+  })
+
+  it('should return empty array when no staged files', async () => {
+    execGit.mockImplementationOnce(async () => '')
+    const staged = await getStagedFiles()
+    expect(staged).toEqual([])
+  })
+
+  it('should return null in case of error', async () => {
+    execGit.mockImplementationOnce(async () => {
+      throw new Error('fatal: not a git repository (or any of the parent directories): .git')
+    })
+    const staged = await getStagedFiles()
+    expect(staged).toEqual(null)
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2190,6 +2190,15 @@ fs-extra@^1.0.0:
     jsonfile "^2.1.0"
     klaw "^1.0.0"
 
+fs-extra@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.0.1.tgz#90294081f978b1f182f347a440a209154344285b"
+  integrity sha512-W+XLrggcDzlle47X/XnS7FXrXu9sDo+Ze9zpndeBxdgv88FHLm1HtmkhEwavruS6koanBjp098rUpHs65EmG7A==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-minipass@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.5.tgz#06c277218454ec288df77ada54a03b8702aacb9d"
@@ -3472,6 +3481,13 @@ jsonfile@^2.1.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-2.4.0.tgz#3736a2b428b87bbda0cc83b53fa3d633a35c2ae8"
   integrity sha1-NzaitCi4e72gzIO1P6PWM6NcKug=
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+  integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
   optionalDependencies:
     graceful-fs "^4.1.6"
 
@@ -5144,11 +5160,6 @@ stack-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.2.tgz#33eba3897788558bebfc2db059dc158ec36cebb8"
   integrity sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==
 
-staged-git-files@1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/staged-git-files/-/staged-git-files-1.1.2.tgz#4326d33886dc9ecfa29a6193bf511ba90a46454b"
-  integrity sha512-0Eyrk6uXW6tg9PYkhi/V/J4zHp33aNyi2hOCmhFLqLTIhbgqWn5jlSzI+IU0VqrZq6+DbHcabQl/WP6P3BG0QA==
-
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
@@ -5467,6 +5478,11 @@ union-value@^1.0.0:
     get-value "^2.0.6"
     is-extendable "^0.1.1"
     set-value "^0.4.3"
+
+universalify@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
+  integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
 unset-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This pull request removes the `staged-git-files` and `pify` dependencies and uses the internal `execGit` to list staged files. This is done via

```bash
git diff --staged --diff-filter=ACM --name-only
```

This should be the same behaviour as `staged-git-files, since only the filenames were used.