### PR TITLE
Updated resolver to ignore currently set GIT_DIR

### DIFF
--- a/src/resolveGitDir.js
+++ b/src/resolveGitDir.js
@@ -5,7 +5,12 @@ const path = require('path')
 
 module.exports = async function resolveGitDir(options) {
   try {
-    const gitDir = await execGit(['rev-parse', '--show-toplevel'], options)
+    // git cli uses GIT_DIR to fast track its response however it might be set to a different path
+    // depending on where the caller initiated this from, hence clear GIT_DIR
+    const gitDir = await execGit(['rev-parse', '--show-toplevel'], {
+      ...options,
+      env: { GIT_DIR: undefined }
+    })
     return path.normalize(gitDir)
   } catch (error) {
     return null

--- a/test/resolveGitDir.spec.js
+++ b/test/resolveGitDir.spec.js
@@ -21,6 +21,15 @@ describe('resolveGitDir', () => {
     process.cwd = processCwdBkp
   })
 
+  it('should resolve to the parent dir when .git is in the parent dir even when the GIT_DIR environment variable is set', async () => {
+    const expected = path.dirname(__dirname)
+    const processCwdBkp = process.cwd
+    process.cwd = () => __dirname
+    process.env.GIT_DIR = 'wrong/path/.git' // refer to https://github.com/DonJayamanne/gitHistoryVSCode/issues/233#issuecomment-375769718
+    expect(path.resolve(await resolveGitDir())).toEqual(expected)
+    process.cwd = processCwdBkp
+  })
+
   it('should return null when not in a git directory', async () => {
     const gitDir = await resolveGitDir({ cwd: '/' }) // assume root is not a git directory
     expect(gitDir).toEqual(null)


### PR DESCRIPTION
A potential fix for https://github.com/okonet/lint-staged/issues/627