### PR TITLE
build: Add Windows to Travis CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@
 ### .travis.yml
 ###
 
+os:
+  - linux
+  - windows
 language: node_js
 node_js:
   - '10'


### PR DESCRIPTION
Activating Windows build again since the root cause seems to be resolved by https://github.com/travis-ci/travis-build/pull/1719