### PR TITLE
refactor: use native git stashes in git workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "cosmiconfig": "^5.2.0",
     "debug": "^3.1.0",
     "dedent": "^0.7.0",
-    "del": "^3.0.0",
     "execa": "^1.0.0",
     "is-glob": "^4.0.0",
     "is-windows": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -73,9 +73,10 @@
     }
   },
   "jest": {
-    "testEnvironment": "node",
+    "collectCoverage": true,
     "setupFiles": ["./testSetup.js"],
-    "snapshotSerializers": ["jest-snapshot-serializer-ansi"]
+    "snapshotSerializers": ["jest-snapshot-serializer-ansi"],
+    "testEnvironment": "node"
   },
   "keywords": [
     "lint",

--- a/src/gitWorkflow.js
+++ b/src/gitWorkflow.js
@@ -4,24 +4,6 @@ const debug = require('debug')('lint-staged:git')
 
 const execGit = require('./execGit')
 
-async function hasPartiallyStagedFiles(options) {
-  const stdout = await execGit(['status', '--porcelain'], options)
-  if (!stdout) return false
-
-  const changedFiles = stdout.split('\n')
-  const partiallyStaged = changedFiles.filter(line => {
-    /**
-     * See https://git-scm.com/docs/git-status#_short_format
-     * The first letter of the line represents current index status,
-     * and second the working tree
-     */
-    const [index, workingTree] = line
-    return index !== ' ' && workingTree !== ' ' && index !== '?' && workingTree !== '?'
-  })
-
-  return partiallyStaged.length > 0
-}
-
 async function saveStagedFiles(options) {
   debug('Saving modified files...')
   // Stash changed changes
@@ -53,7 +35,6 @@ async function clearStagedFileStash(options) {
 
 module.exports = {
   execGit,
-  hasPartiallyStagedFiles,
   saveStagedFiles,
   restoreStagedFiles,
   clearStagedFileStash

--- a/src/gitWorkflow.js
+++ b/src/gitWorkflow.js
@@ -1,34 +1,8 @@
 'use strict'
 
-const del = require('del')
 const debug = require('debug')('lint-staged:git')
 
 const execGit = require('./execGit')
-
-let workingCopyTree = null
-let indexTree = null
-let formattedIndexTree = null
-
-async function writeTree(options) {
-  return execGit(['write-tree'], options)
-}
-
-async function getDiffForTrees(tree1, tree2, options) {
-  debug(`Generating diff between trees ${tree1} and ${tree2}...`)
-  return execGit(
-    [
-      'diff-tree',
-      '--ignore-submodules',
-      '--binary',
-      '--no-color',
-      '--no-ext-diff',
-      '--unified=0',
-      tree1,
-      tree2
-    ],
-    options
-  )
-}
 
 async function hasPartiallyStagedFiles(options) {
   const stdout = await execGit(['status', '--porcelain'], options)
@@ -48,118 +22,39 @@ async function hasPartiallyStagedFiles(options) {
   return partiallyStaged.length > 0
 }
 
-// eslint-disable-next-line
-async function gitStashSave(options) {
-  debug('Stashing files...')
-  // Save ref to the current index
-  indexTree = await writeTree(options)
-  // Add working copy changes to index
-  await execGit(['add', '.'], options)
-  // Save ref to the working copy index
-  workingCopyTree = await writeTree(options)
-  // Restore the current index
-  await execGit(['read-tree', indexTree], options)
-  // Remove all modifications
-  await execGit(['checkout-index', '-af'], options)
-  // await execGit(['clean', '-dfx'], options)
-  debug('Done stashing files!')
-  return [workingCopyTree, indexTree]
+async function saveStagedFiles(options) {
+  debug('Saving modified files...')
+  // Stash changed changes
+  await execGit(['stash', 'push', '-m temporary lint-staged stash'], options)
+
+  // Restore changed files back
+  await execGit(['stash', 'apply', '--index'], options)
+
+  debug('Done saving modified files!')
 }
 
-async function updateStash(options) {
-  formattedIndexTree = await writeTree(options)
-  return formattedIndexTree
+async function restoreStagedFiles(options) {
+  debug('Restoring modified files...')
+
+  // Reset everything to clear out modifications by linters
+  await execGit(['reset', '--hard'], options)
+
+  // Restore changed files back
+  await execGit(['stash', 'apply', '--index'], options)
+
+  debug('Done restoring modified files!')
 }
 
-async function applyPatchFor(tree1, tree2, options) {
-  const diff = await getDiffForTrees(tree1, tree2, options)
-  /**
-   * This is crucial for patch to work
-   * For some reason, git-apply requires that the patch ends with the newline symbol
-   * See http://git.661346.n2.nabble.com/Bug-in-Git-Gui-Creates-corrupt-patch-td2384251.html
-   * and https://stackoverflow.com/questions/13223868/how-to-stage-line-by-line-in-git-gui-although-no-newline-at-end-of-file-warnin
-   */
-  // TODO: Figure out how to test this. For some reason tests were working but in the real env it was failing
-  const patch = `${diff}\n` // TODO: This should also work on Windows but test would be good
-  if (patch) {
-    try {
-      /**
-       * Apply patch to index. We will apply it with --reject so it it will try apply hunk by hunk
-       * We're not interested in failied hunks since this mean that formatting conflicts with user changes
-       * and we prioritize user changes over formatter's
-       */
-      await execGit(
-        ['apply', '-v', '--whitespace=nowarn', '--reject', '--recount', '--unidiff-zero'],
-        {
-          ...options,
-          input: patch
-        }
-      )
-    } catch (err) {
-      debug('Could not apply patch to the stashed files cleanly')
-      debug(err)
-      debug('Patch content:')
-      debug(patch)
-      throw new Error('Could not apply patch to the stashed files cleanly.', err)
-    }
-  }
-}
-
-async function gitStashPop(options) {
-  if (workingCopyTree === null) {
-    throw new Error('Trying to restore from stash but could not find working copy stash.')
-  }
-
-  debug('Restoring working copy')
-  // Restore the stashed files in the index
-  await execGit(['read-tree', workingCopyTree], options)
-  // and sync it to the working copy (i.e. update files on fs)
-  await execGit(['checkout-index', '-af'], options)
-
-  // Then, restore the index after working copy is restored
-  if (indexTree !== null && formattedIndexTree === null) {
-    // Restore changes that were in index if there are no formatting changes
-    debug('Restoring index')
-    await execGit(['read-tree', indexTree], options)
-  } else {
-    /**
-     * There are formatting changes we want to restore in the index
-     * and in the working copy. So we start by restoring the index
-     * and after that we'll try to carry as many as possible changes
-     * to the working copy by applying the patch with --reject option.
-     */
-    debug('Restoring index with formatting changes')
-    await execGit(['read-tree', formattedIndexTree], options)
-    try {
-      await applyPatchFor(indexTree, formattedIndexTree, options)
-    } catch (err) {
-      debug(
-        'Found conflicts between formatters and local changes. Formatters changes will be ignored for conflicted hunks.'
-      )
-      /**
-       * Clean up working directory from *.rej files that contain conflicted hanks.
-       * These hunks are coming from formatters so we'll just delete them since they are irrelevant.
-       */
-      try {
-        const rejFiles = await del(['*.rej'], options)
-        debug('Deleted files and folders:\n', rejFiles.join('\n'))
-      } catch (delErr) {
-        debug('Error deleting *.rej files', delErr)
-      }
-    }
-  }
-  // Clean up references
-  workingCopyTree = null
-  indexTree = null
-  formattedIndexTree = null
-
-  return null
+async function clearStagedFileStash(options) {
+  debug('Clearing saved modified files...')
+  await execGit(['stash', 'drop'], options)
+  debug('Done clearing saved modified files!')
 }
 
 module.exports = {
   execGit,
-  gitStashSave,
-  gitStashPop,
   hasPartiallyStagedFiles,
-  updateStash
+  saveStagedFiles,
+  restoreStagedFiles,
+  clearStagedFileStash
 }

--- a/src/gitWorkflow.js
+++ b/src/gitWorkflow.js
@@ -7,7 +7,7 @@ const execGit = require('./execGit')
 async function saveStagedFiles(options) {
   debug('Saving modified files...')
   // Stash changed changes
-  await execGit(['stash', 'push', '-m temporary lint-staged stash'], options)
+  await execGit(['stash', 'save', 'temporary lint-staged stash'], options)
 
   // Restore changed files back
   await execGit(['stash', 'apply', '--index'], options)

--- a/src/runAll.js
+++ b/src/runAll.js
@@ -82,17 +82,16 @@ module.exports = async function runAll(config) {
     [
       {
         title: 'Stashing changes...',
-        skip: async () => {
+        skip: async ctx => {
           const hasPSF = await git.hasPartiallyStagedFiles({ cwd: gitDir })
-          if (!hasPSF) {
-            return 'No partially staged files found...'
+          if (hasPSF) {
+            ctx.hasPSF = true
+            return false
           }
-          return false
+
+          return 'No partially staged files found...'
         },
-        task: ctx => {
-          ctx.hasStash = true
-          return git.gitStashSave({ cwd: gitDir })
-        }
+        task: () => git.saveStagedFiles({ cwd: gitDir })
       },
       {
         title: 'Running linters...',
@@ -104,15 +103,14 @@ module.exports = async function runAll(config) {
           })
       },
       {
-        title: 'Updating stash...',
-        enabled: ctx => ctx.hasStash,
-        skip: ctx => ctx.hasErrors && 'Skipping stash update since some tasks exited with errors',
-        task: () => git.updateStash({ cwd: gitDir })
+        title: 'Restoring local changes...',
+        enabled: ctx => ctx.hasErrors,
+        task: () => git.restoreStagedFiles({ cwd: gitDir })
       },
       {
-        title: 'Restoring local changes...',
-        enabled: ctx => ctx.hasStash,
-        task: () => git.gitStashPop({ cwd: gitDir })
+        title: 'Clearing temporary stashed changed...',
+        skip: ctx => !ctx.hasPSF,
+        task: () => git.clearStagedFileStash({ cwd: gitDir })
       }
     ],
     listrBaseOptions

--- a/src/runAll.js
+++ b/src/runAll.js
@@ -81,16 +81,7 @@ module.exports = async function runAll(config) {
   return new Listr(
     [
       {
-        title: 'Stashing changes...',
-        skip: async ctx => {
-          const hasPSF = await git.hasPartiallyStagedFiles({ cwd: gitDir })
-          if (hasPSF) {
-            ctx.hasPSF = true
-            return false
-          }
-
-          return 'No partially staged files found...'
-        },
+        title: 'Backing up local changes...',
         task: () => git.saveStagedFiles({ cwd: gitDir })
       },
       {
@@ -108,8 +99,7 @@ module.exports = async function runAll(config) {
         task: () => git.restoreStagedFiles({ cwd: gitDir })
       },
       {
-        title: 'Clearing temporary stashed changed...',
-        skip: ctx => !ctx.hasPSF,
+        title: 'Clearing temporary backup...',
         task: () => git.clearStagedFileStash({ cwd: gitDir })
       }
     ],

--- a/test/__snapshots__/runAll.spec.js.snap
+++ b/test/__snapshots__/runAll.spec.js.snap
@@ -2,31 +2,30 @@
 
 exports[`runAll should not skip stashing and restoring if there are partially staged files 1`] = `
 "
-LOG Stashing changes... [started]
-LOG Stashing changes... [completed]
+LOG Backing up local changes... [started]
+LOG Backing up local changes... [completed]
 LOG Running linters... [started]
 LOG Running tasks for *.js [started]
 LOG echo \\"sample\\" [started]
 LOG echo \\"sample\\" [completed]
 LOG Running tasks for *.js [completed]
 LOG Running linters... [completed]
-LOG Updating stash... [started]
-LOG Updating stash... [completed]
-LOG Restoring local changes... [started]
-LOG Restoring local changes... [completed]"
+LOG Clearing temporary backup... [started]
+LOG Clearing temporary backup... [completed]"
 `;
 
 exports[`runAll should not skip tasks if there are files 1`] = `
 "
-LOG Stashing changes... [started]
-LOG Stashing changes... [skipped]
-LOG → No partially staged files found...
+LOG Backing up local changes... [started]
+LOG Backing up local changes... [completed]
 LOG Running linters... [started]
 LOG Running tasks for *.js [started]
 LOG echo \\"sample\\" [started]
 LOG echo \\"sample\\" [completed]
 LOG Running tasks for *.js [completed]
-LOG Running linters... [completed]"
+LOG Running linters... [completed]
+LOG Clearing temporary backup... [started]
+LOG Clearing temporary backup... [completed]"
 `;
 
 exports[`runAll should resolve the promise with no files 1`] = `
@@ -36,8 +35,8 @@ LOG No staged files match any of provided globs."
 
 exports[`runAll should skip linters and stash update but perform working copy restore if terminated 1`] = `
 "
-LOG Stashing changes... [started]
-LOG Stashing changes... [completed]
+LOG Backing up local changes... [started]
+LOG Backing up local changes... [completed]
 LOG Running linters... [started]
 LOG Running tasks for *.js [started]
 LOG echo \\"sample\\" [started]
@@ -46,34 +45,20 @@ LOG →
 LOG Running tasks for *.js [failed]
 LOG → 
 LOG Running linters... [failed]
-LOG Updating stash... [started]
-LOG Updating stash... [skipped]
-LOG → Skipping stash update since some tasks exited with errors
 LOG Restoring local changes... [started]
 LOG Restoring local changes... [completed]
+LOG Clearing temporary backup... [started]
+LOG Clearing temporary backup... [completed]
 LOG {
   name: 'ListrError',
   errors: [
     {
       privateMsg: '\\\\n\\\\n\\\\n‼ echo \\"sample\\" was terminated with SIGINT',
-      context: {hasStash: true, hasErrors: true}
+      context: {hasErrors: true}
     }
   ],
-  context: {hasStash: true, hasErrors: true}
+  context: {hasErrors: true}
 }"
-`;
-
-exports[`runAll should skip stashing and restoring if there are no partially staged files 1`] = `
-"
-LOG Stashing changes... [started]
-LOG Stashing changes... [skipped]
-LOG → No partially staged files found...
-LOG Running linters... [started]
-LOG Running tasks for *.js [started]
-LOG echo \\"sample\\" [started]
-LOG echo \\"sample\\" [completed]
-LOG Running tasks for *.js [completed]
-LOG Running linters... [completed]"
 `;
 
 exports[`runAll should skip stashing changes if no lint-staged files are changed 1`] = `
@@ -83,8 +68,8 @@ LOG No staged files match any of provided globs."
 
 exports[`runAll should skip updating stash if there are errors during linting 1`] = `
 "
-LOG Stashing changes... [started]
-LOG Stashing changes... [completed]
+LOG Backing up local changes... [started]
+LOG Backing up local changes... [completed]
 LOG Running linters... [started]
 LOG Running tasks for *.js [started]
 LOG echo \\"sample\\" [started]
@@ -93,20 +78,19 @@ LOG →
 LOG Running tasks for *.js [failed]
 LOG → 
 LOG Running linters... [failed]
-LOG Updating stash... [started]
-LOG Updating stash... [skipped]
-LOG → Skipping stash update since some tasks exited with errors
 LOG Restoring local changes... [started]
 LOG Restoring local changes... [completed]
+LOG Clearing temporary backup... [started]
+LOG Clearing temporary backup... [completed]
 LOG {
   name: 'ListrError',
   errors: [
     {
       privateMsg: '\\\\n\\\\n\\\\n× echo \\"sample\\" found some errors. Please fix them and try committing again.\\\\n\\\\nLinter finished with error',
-      context: {hasStash: true, hasErrors: true}
+      context: {hasErrors: true}
     }
   ],
-  context: {hasStash: true, hasErrors: true}
+  context: {hasErrors: true}
 }"
 `;
 

--- a/test/execGit.spec.js
+++ b/test/execGit.spec.js
@@ -1,0 +1,36 @@
+/* eslint no-underscore-dangle: 0 */
+
+import path from 'path'
+import tmp from 'tmp'
+import execa from 'execa'
+
+import execGit from '../src/execGit'
+
+tmp.setGracefulCleanup()
+
+describe('gitWorkflow', () => {
+  describe('execGit', () => {
+    it('should execute git in process.cwd if working copy is not specified', async () => {
+      await execGit(['init', 'param'])
+      expect(execa).toHaveBeenCalledWith('git', ['init', 'param'], {
+        cwd: path.resolve(process.cwd())
+      })
+    })
+
+    it('should execute git in a given working copy', async () => {
+      await execGit(['init', 'param'], { cwd: 'test/__fixtures__' })
+      expect(execa).toHaveBeenCalledWith('git', ['init', 'param'], {
+        cwd: path.resolve(process.cwd(), 'test', '__fixtures__')
+      })
+    })
+
+    it('should work with relative paths', async () => {
+      await execGit(['init', 'param'], {
+        cwd: 'test/__fixtures__'
+      })
+      expect(execa).toHaveBeenCalledWith('git', ['init', 'param'], {
+        cwd: path.resolve(process.cwd(), 'test', '__fixtures__')
+      })
+    })
+  })
+})

--- a/test/gitStash.spec.js
+++ b/test/gitStash.spec.js
@@ -63,7 +63,8 @@ describe('git', () => {
     await fsp.writeFile(path.join(wcDirPath, 'test.js'), initialContent)
   })
 
-  afterEach(() => {
+  afterEach(async () => {
+    await gitflow.clearStagedFileStash(gitOpts)
     wcDir.removeCallback()
   })
 

--- a/test/gitWorkflow.spec.js
+++ b/test/gitWorkflow.spec.js
@@ -1,35 +1,244 @@
-/* eslint no-underscore-dangle: 0 */
-
-import path from 'path'
-import tmp from 'tmp'
 import execa from 'execa'
-import { execGit } from '../src/gitWorkflow'
+import fs from 'fs'
+import path from 'path'
+import pify from 'pify'
+import tmp from 'tmp'
+
+import gitWorkflow from '../src/gitWorkflow'
+
+const fsp = pify(fs)
 
 tmp.setGracefulCleanup()
+jest.unmock('execa')
+
+const testJsFilePretty = `module.exports = {
+  foo: "bar"
+};
+`
+
+const testJsFileUgly = `module.exports = {
+    'foo': 'bar',
+}
+`
+
+const testJsFileUnfixable = `const obj = {
+    'foo': 'bar'
+`
+
+let wcDir
+let wcDirPath
+let gitOpts
+
+// Get file content
+const readFile = async (filename, dir = wcDirPath) =>
+  fsp.readFile(path.join(dir, filename), { encoding: 'utf-8' })
+
+// Append to file, creating if it doesn't exist
+const appendFile = async (filename, content, dir = wcDirPath) => {
+  await fsp.appendFile(path.join(dir, filename), content)
+}
+
+// Wrap execGit to always pass `gitOps`
+const execGit = async args => gitWorkflow.execGit(args, gitOpts)
+
+// Emulate lint-staged in pre-commit-hook
+const runLintStaged = async (fix = false) => {
+  // First save backup
+  await gitWorkflow.saveStagedFiles(gitOpts)
+
+  try {
+    if (fix) {
+      // Run prettier with --write
+      await execa('prettier', ['--write', 'test.js'], { cwd: wcDirPath })
+      // add files
+      await execGit(['add', 'test.js'])
+    } else {
+      // Run prettier
+      await execa('prettier', ['--list-different', 'test.js'], { cwd: wcDirPath })
+    }
+
+    // commit
+    await execGit(['commit', '-m test'])
+  } catch (error) {
+    // in case of linter error restore backup
+    await gitWorkflow.restoreStagedFiles(gitOpts)
+  }
+
+  await gitWorkflow.clearStagedFileStash(gitOpts)
+}
 
 describe('gitWorkflow', () => {
-  describe('execGit', () => {
-    it('should execute git in process.cwd if working copy is not specified', async () => {
-      await execGit(['init', 'param'])
-      expect(execa).toHaveBeenCalledWith('git', ['init', 'param'], {
-        cwd: path.resolve(process.cwd())
-      })
-    })
+  beforeEach(async () => {
+    wcDir = tmp.dirSync({ unsafeCleanup: true })
+    wcDirPath = wcDir.name
+    gitOpts = { cwd: wcDirPath }
 
-    it('should execute git in a given working copy', async () => {
-      await execGit(['init', 'param'], { cwd: 'test/__fixtures__' })
-      expect(execa).toHaveBeenCalledWith('git', ['init', 'param'], {
-        cwd: path.resolve(process.cwd(), 'test', '__fixtures__')
-      })
-    })
+    // Init repository with initial commit
+    await execGit('init')
+    await execGit(['config', 'user.name', '"test"'])
+    await execGit(['config', 'user.email', '"test@test.com"'])
+    await appendFile('README.md', '# Test\n')
+    await execGit(['add', 'README.md'])
+    await execGit(['commit', '-m initial commit'])
+  })
 
-    it('should work with relative paths', async () => {
-      await execGit(['init', 'param'], {
-        cwd: 'test/__fixtures__'
-      })
-      expect(execa).toHaveBeenCalledWith('git', ['init', 'param'], {
-        cwd: path.resolve(process.cwd(), 'test', '__fixtures__')
-      })
-    })
+  it('Should commit file when no errors from linter', async () => {
+    // Stage pretty file
+    await appendFile('test.js', testJsFilePretty)
+    await execGit(['add', 'test.js'])
+
+    // Run lint-staged with `prettier --list-different` and commit pretty file
+    await runLintStaged()
+
+    // Nothing is wrong, so a new commit is created
+    expect(await execGit(['rev-list', '--count', 'HEAD'])).toEqual('2')
+    expect(await execGit(['log', '-1', '--pretty=%B'])).toMatch('test')
+    expect(await readFile('test.js')).toEqual(testJsFilePretty)
+  })
+
+  it('Should commit file when no errors and linter modifies file', async () => {
+    // Stage ugly file
+    await appendFile('test.js', testJsFileUgly)
+    await execGit(['add', 'test.js'])
+
+    // Run lint-staged with `prettier --write` and commit pretty file
+    await runLintStaged(true)
+
+    // Nothing is wrong, so a new commit is created and file is pretty
+    expect(await execGit(['rev-list', '--count', 'HEAD'])).toEqual('2')
+    expect(await execGit(['log', '-1', '--pretty=%B'])).toMatch('test')
+    expect(await readFile('test.js')).toEqual(testJsFilePretty)
+  })
+
+  it('Should fail to commit file when errors from linter', async () => {
+    // Stage ugly file
+    await appendFile('test.js', testJsFileUgly)
+    await execGit(['add', 'test.js'])
+    const status = await execGit(['status'])
+
+    // Run lint-staged with `prettier --list-different` to break the linter
+    await runLintStaged()
+
+    // Something was wrong so the repo is returned to original state
+    expect(await execGit(['rev-list', '--count', 'HEAD'])).toEqual('1')
+    expect(await execGit(['log', '-1', '--pretty=%B'])).toMatch('initial commit')
+    expect(await execGit(['status'])).toEqual(status)
+    expect(await readFile('test.js')).toEqual(testJsFileUgly)
+  })
+
+  it('Should fail to commit file when errors from linter and linter modifies files', async () => {
+    // Add unfixable file to commit so `prettier --write` breaks
+    await appendFile('test.js', testJsFileUnfixable)
+    await execGit(['add', 'test.js'])
+    const status = await execGit(['status'])
+
+    // Run lint-staged with `prettier --write` to break the linter
+    await runLintStaged(true)
+
+    // Something was wrong so the repo is returned to original state
+    expect(await execGit(['rev-list', '--count', 'HEAD'])).toEqual('1')
+    expect(await execGit(['log', '-1', '--pretty=%B'])).toMatch('initial commit')
+    expect(await execGit(['status'])).toEqual(status)
+    expect(await readFile('test.js')).toEqual(testJsFileUnfixable)
+  })
+
+  it('Should commit partial change when no errors from linter', async () => {
+    // Stage pretty file
+    await appendFile('test.js', testJsFilePretty)
+    await execGit(['add', 'test.js'])
+
+    // Edit pretty file but do not stage changes
+    const appended = '\nconsole.log("test");\n'
+    await appendFile('test.js', appended)
+
+    // Run lint-staged with `prettier --list-different` and commit pretty file
+    await runLintStaged()
+
+    // Nothing is wrong, so a new commit is created and file is pretty
+    expect(await execGit(['rev-list', '--count', 'HEAD'])).toEqual('2')
+    expect(await execGit(['log', '-1', '--pretty=%B'])).toMatch('test')
+
+    // Latest commit contains pretty file
+    // `git show` strips empty line from here here
+    expect(await execGit(['show', 'HEAD:test.js'])).toMatch(testJsFilePretty.replace(/\n$/, ''))
+
+    // Since edit was not staged, the file is still modified
+    expect(await execGit(['status'])).toMatch('modified:   test.js')
+    expect(await readFile('test.js')).toMatch(testJsFilePretty + appended)
+  })
+
+  it('Should commit entire file on partial change when no errors from linter and linter modifies file', async () => {
+    // Stage ugly file
+    await appendFile('test.js', testJsFileUgly)
+    await execGit(['add', 'test.js'])
+
+    // Edit ugly file but do not stage changes
+    const appended = '\nconsole.log("test");\n'
+    await appendFile('test.js', appended)
+
+    // Run lint-staged with `prettier --list-different` and commit pretty file
+    await runLintStaged(true)
+
+    // Nothing is wrong, so a new commit is created and file is pretty
+    expect(await execGit(['rev-list', '--count', 'HEAD'])).toEqual('2')
+    expect(await execGit(['log', '-1', '--pretty=%B'])).toMatch('test')
+
+    // Latest commit contains pretty file with edits
+    // `git show` strips empty line from here here
+    expect(await execGit(['show', 'HEAD:test.js'])).toMatch(
+      (testJsFilePretty + appended).replace(/\n$/, '')
+    )
+
+    // Nothing is staged
+    expect(await execGit(['status'])).toMatch(
+      'On branch master\nnothing to commit, working tree clean'
+    )
+
+    // File is pretty, and has been edited
+    expect(await readFile('test.js')).toMatch(testJsFilePretty + appended)
+  })
+
+  it('Should fail to partial change when errors from linter', async () => {
+    // Stage ugly file
+    await appendFile('test.js', testJsFileUgly)
+    await execGit(['add', 'test.js'])
+
+    // Edit ugly file but do not stage changes
+    const appended = '\nconsole.log("test");\n'
+    await appendFile('test.js', appended)
+    const status = await execGit(['status'])
+
+    // Run lint-staged with `prettier --list-different` to break the linter
+    await runLintStaged()
+
+    // Something was wrong so the repo is returned to original state
+    expect(await execGit(['rev-list', '--count', 'HEAD'])).toEqual('1')
+    expect(await execGit(['log', '-1', '--pretty=%B'])).toMatch('initial commit')
+    expect(await execGit(['status'])).toEqual(status)
+    expect(await readFile('test.js')).toMatch(testJsFileUgly + appended)
+  })
+
+  it('Should fail to commit partial change when errors from linter and linter modifies files', async () => {
+    // Add unfixable file to commit so `prettier --write` breaks
+    await appendFile('test.js', testJsFileUnfixable)
+    await execGit(['add', 'test.js'])
+
+    // Edit unfixable file but do not stage changes
+    const appended = '\nconsole.log("test");\n'
+    await appendFile('test.js', appended)
+    const status = await execGit(['status'])
+
+    // Run lint-staged with `prettier --write` to break the linter
+    await runLintStaged(true)
+
+    // Something was wrong so the repo is returned to original state
+    expect(await execGit(['rev-list', '--count', 'HEAD'])).toEqual('1')
+    expect(await execGit(['log', '-1', '--pretty=%B'])).toMatch('initial commit')
+    expect(await execGit(['status'])).toEqual(status)
+    expect(await readFile('test.js')).toMatch(testJsFileUnfixable + appended)
+  })
+
+  afterEach(async () => {
+    wcDir.removeCallback()
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -227,18 +227,6 @@ array-includes@^3.0.3:
     define-properties "^1.1.2"
     es-abstract "^1.7.0"
 
-array-union@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
-  integrity sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=
-  dependencies:
-    array-uniq "^1.0.1"
-
-array-uniq@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
-  integrity sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=
-
 array-unique@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
@@ -1458,18 +1446,6 @@ define-property@^2.0.2:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
 
-del@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/del/-/del-3.0.0.tgz#53ecf699ffcbcb39637691ab13baf160819766e5"
-  integrity sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=
-  dependencies:
-    globby "^6.1.0"
-    is-path-cwd "^1.0.0"
-    is-path-in-cwd "^1.0.0"
-    p-map "^1.1.1"
-    pify "^3.0.0"
-    rimraf "^2.2.8"
-
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
@@ -2345,17 +2321,6 @@ globals@^9.18.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
   integrity sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==
 
-globby@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-6.1.0.tgz#f5a6d70e8395e21c858fb0489d64df02424d506c"
-  integrity sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=
-  dependencies:
-    array-union "^1.0.1"
-    glob "^7.0.3"
-    object-assign "^4.0.1"
-    pify "^2.0.0"
-    pinkie-promise "^2.0.0"
-
 graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.15"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
@@ -2845,25 +2810,6 @@ is-observable@^1.1.0:
   integrity sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==
   dependencies:
     symbol-observable "^1.1.0"
-
-is-path-cwd@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz#d225ec23132e89edd38fda767472e62e65f1106d"
-  integrity sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=
-
-is-path-in-cwd@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz#5ac48b345ef675339bd6c7a48a912110b241cf52"
-  integrity sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==
-  dependencies:
-    is-path-inside "^1.0.0"
-
-is-path-inside@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.1.tgz#8ef5b7de50437a3fdca6b4e865ef7aa55cb48036"
-  integrity sha1-jvW33lBDej/cprToZe96pVy0gDY=
-  dependencies:
-    path-is-inside "^1.0.1"
 
 is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
@@ -4327,7 +4273,7 @@ path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
-path-is-inside@^1.0.1, path-is-inside@^1.0.2:
+path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
   integrity sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=
@@ -4828,7 +4774,7 @@ right-pad@^1.0.1:
   resolved "https://registry.yarnpkg.com/right-pad/-/right-pad-1.0.1.tgz#8ca08c2cbb5b55e74dafa96bf7fd1a27d568c8d0"
   integrity sha1-jKCMLLtbVedNr6lr9/0aJ9VoyNA=
 
-rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@~2.6.2:
+rimraf@^2.5.4, rimraf@^2.6.1, rimraf@~2.6.2:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==


### PR DESCRIPTION
This PR overhauls and simplifies the behaviour of the git workflow to work like this:

When run, lint-staged will:
1. Create a stash using `git stash save "temporary lint-staged stash"`.
1. Apply that stash back using `git stash apply --index`. This will "remember" staged files from other modifications. We are now back to square one, but we have still have the stash.
1. Run all the linters, possible modifiying files, possibly throwing errors
1. **If there are linting errors:**
    1. Do a hard reset using `git reset --hard` to clear everything.
    2. Restore temporary stash, going back to square one. This will in effect always delete all possibly-modified files during the linter step, if there's a failure
1. Drop the temporary stash

This seems very simple and performs fast. If I understood the workflow correctly, this is the wanted behaviour. Besides, if anything fails before the final step, the stash will be left for the user to revert.

I didn't touch the tests yet, because I wanted to open this PR for discussion. I did try this out on our large monorepo, where it performs correctly as in the git state remains unchanged after commits, and in the case partial commits fail.

Thoughts?