### PR TITLE
Add 'silent' to default values for 'renderer' option

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "is-glob": "^4.0.0",
     "is-windows": "^1.0.2",
     "listr": "^0.14.2",
-    "listr-update-renderer": "^0.5.0",
     "lodash": "^4.17.11",
     "log-symbols": "^2.2.0",
     "micromatch": "^3.1.8",

--- a/src/getConfig.js
+++ b/src/getConfig.js
@@ -58,8 +58,8 @@ const schema = yup.object().shape({
     .mixed()
     .test(
       'renderer',
-      "Should be 'update', 'verbose' or a function.",
-      value => value === 'update' || value === 'verbose' || isFunction(value)
+      "Should be 'update', 'verbose', 'silent' or a function.",
+      value => ['update', 'verbose', 'silent'].includes(value) || isFunction(value)
     ),
   relative: yup.boolean().default(defaultConfig.relative)
 })
@@ -151,6 +151,7 @@ function unknownValidationReporter(config, option) {
  * For simple config, only the `linters` configuration is provided.
  *
  * @param {Object} sourceConfig
+ * @param {boolean} debugMode
  * @returns {{
  *  concurrent: boolean, chunkSize: number, globOptions: {matchBase: boolean, dot: boolean}, linters: {}, subTaskConcurrency: number, renderer: string
  * }}

--- a/test/__snapshots__/getConfig.spec.js.snap
+++ b/test/__snapshots__/getConfig.spec.js.snap
@@ -54,6 +54,12 @@ Object {
 }
 `;
 
+exports[`validateConfig should not throw and should print nothing for "silent" renderer 1`] = `""`;
+
+exports[`validateConfig should not throw and should print nothing for "update" renderer 1`] = `""`;
+
+exports[`validateConfig should not throw and should print nothing for "verbose" renderer 1`] = `""`;
+
 exports[`validateConfig should not throw and should print nothing for advanced valid config 1`] = `""`;
 
 exports[`validateConfig should not throw and should print nothing for custom renderer 1`] = `""`;

--- a/test/getConfig.spec.js
+++ b/test/getConfig.spec.js
@@ -229,4 +229,35 @@ describe('validateConfig', () => {
     expect(() => validateConfig(getConfig(validAdvancedConfig))).not.toThrow()
     expect(console.printHistory()).toMatchSnapshot()
   })
+
+  it('should not throw and should print nothing for "silent" renderer', () => {
+    const validAdvancedConfig = {
+      renderer: 'silent'
+    }
+    expect(() => validateConfig(getConfig(validAdvancedConfig))).not.toThrow()
+    expect(console.printHistory()).toMatchSnapshot()
+  })
+
+  it('should not throw and should print nothing for "verbose" renderer', () => {
+    const validAdvancedConfig = {
+      renderer: 'verbose'
+    }
+    expect(() => validateConfig(getConfig(validAdvancedConfig))).not.toThrow()
+    expect(console.printHistory()).toMatchSnapshot()
+  })
+
+  it('should not throw and should print nothing for "update" renderer', () => {
+    const validAdvancedConfig = {
+      renderer: 'update'
+    }
+    expect(() => validateConfig(getConfig(validAdvancedConfig))).not.toThrow()
+    expect(console.printHistory()).toMatchSnapshot()
+  })
+
+  it('should throw for unknown renderer value', () => {
+    const validAdvancedConfig = {
+      renderer: 'some-string'
+    }
+    expect(() => validateConfig(getConfig(validAdvancedConfig))).toThrow()
+  })
 })


### PR DESCRIPTION
Fixes #637.

@okonet, to continue our discussion from the issue, there are some thoughts:

1. It's impossible to pass any “valid” name for listr renderers, because listr doesn't support such lazy loading. When it gets renderer value and the value is a string, it tries to match it with predefined ones (silent, verbose, default) or load the default: https://github.com/SamVerschueren/listr/blob/master/lib/renderer.js#L10-L16.

2. As I said before, listr has three predefined renderers: “silent”, “verbose”, “default”, where “default” for some reason is a name for “listr-update-renderer”. So, “update” renderer actually doesn't exist anywhere and the option “update” from lint-staged just triggers listr to use “default” renderer. Maybe it worth to rename lint-staged's “update” value to “default” to make it less confusing and matching [the values described in listr repo](https://github.com/SamVerschueren/listr#renderer) (but of course the source of confusion is listr's “update” → “default” rename, not lint-staged's “update”).

3. And, again, as I said before, listr already has listr-update-renderer preinstalled, so it can be removed from lint-staged deps.

In this PR I removed listr-update-renderer from deps, add “silent” as a possible option for “renderer” and add some tests to be sure that validation works fine.

Also I have a question. The README says:

> **--debug:** Enabling the debug mode does the following:
> ...
> Use the verbose renderer for listr.

But right now it works only when “renderer” isn't set by user, doesn't it? Here: 

https://github.com/okonet/lint-staged/blob/279863d25ef7dab856ebae418b9863880902bf52/src/getConfig.js#L166-L169

So I think either README should be fixed or “verbose” renderer should be passed always when `--debug` is enabled.