### PR TITLE
Update node version requirement

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,8 +4,8 @@
 
 environment:
   matrix:
+    - nodejs_version: '12'
     - nodejs_version: '10'
-    - nodejs_version: '9'
     - nodejs_version: '8'
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@
 
 language: node_js
 node_js:
+  - '12'
   - '10'
-  - '9'
   - '8'
 
 before_install: yarn global add greenkeeper-lockfile@1

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const pkg = require('./package.json')
 require('please-upgrade-node')(
   Object.assign({}, pkg, {
     engines: {
-      node: '>=8.6.0'
+      node: '>=8.12.0'
     }
   })
 )


### PR DESCRIPTION
PR adds the lowest required node version to ~~_package.json_'s `engines.node`~~ to the bin entrypoint. The requirement currently comes from [execa](https://github.com/sindresorhus/execa/blob/master/package.json).

It also updates the CI environments to test with node versions `8`, `10` and `12`, because version 9 isn't really supported.

Replaces PR https://github.com/okonet/lint-staged/pull/525 as stale.