### PR TITLE
fix: run all commands returned by function linters

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,14 +194,14 @@ If for some reason you want to ignore files from the glob match, you can use `mi
 const micromatch = require('micromatch')
 module.exports = {
   '*.js': files => {
-    // from `files` filter those _NOT_ matching `*.test.js`
-    const match = micromatch.not(files, '*.test.js')
+    // from `files` filter those _NOT_ matching `*test.js`
+    const match = micromatch.not(files, '*test.js')
     return match.map(file => `eslint ${file}`)
   }
 }
 ```
 
-Please note that for most cases, globs can achieve the same effect. For the above example, a matching glob would be `!(*.test).js`.
+Please note that for most cases, globs can achieve the same effect. For the above example, a matching glob would be `!(*test).js`.
 
 ### Example: Use relative paths for commands
 

--- a/test/makeCmdTasks.spec.js
+++ b/test/makeCmdTasks.spec.js
@@ -61,8 +61,9 @@ describe('makeCmdTasks', () => {
 
   it('should work with function linter returning array of string', async () => {
     const res = await makeCmdTasks(() => ['test', 'test2'], false, gitDir, ['test.js'])
-    expect(res.length).toBe(1)
+    expect(res.length).toBe(2)
     expect(res[0].title).toEqual('test')
+    expect(res[1].title).toEqual('test2')
   })
 
   it('should work with function linter accepting arguments', async () => {
@@ -70,16 +71,25 @@ describe('makeCmdTasks', () => {
       filenames => filenames.map(file => `test ${file}`),
       false,
       gitDir,
-      ['test.js']
+      ['test.js', 'test2.js']
     )
-    expect(res.length).toBe(1)
-    expect(res[0].title).toEqual('test [file]')
+    expect(res.length).toBe(2)
+    expect(res[0].title).toEqual('test test.js')
+    expect(res[1].title).toEqual('test test2.js')
   })
 
   it('should work with array of mixed string and function linters', async () => {
-    const res = await makeCmdTasks([() => 'test', 'test2'], false, gitDir, ['test.js'])
-    expect(res.length).toBe(2)
+    const res = await makeCmdTasks(
+      [() => 'test', 'test2', files => files.map(file => `test ${file}`)],
+      false,
+      gitDir,
+      ['test.js', 'test2.js', 'test3.js']
+    )
+    expect(res.length).toBe(5)
     expect(res[0].title).toEqual('test')
     expect(res[1].title).toEqual('test2')
+    expect(res[2].title).toEqual('test test.js')
+    expect(res[3].title).toEqual('test test2.js')
+    expect(res[4].title).toEqual('test test3.js')
   })
 })

--- a/test/resolveTaskFn.spec.js
+++ b/test/resolveTaskFn.spec.js
@@ -24,11 +24,12 @@ describe('resolveTaskFn', () => {
     })
   })
 
-  it('should support function linters that return string', async () => {
+  it('should not append pathsToLint when isFn', async () => {
     expect.assertions(2)
     const taskFn = resolveTaskFn({
       ...defaultOpts,
-      linter: filenames => `node --arg=true ./myscript.js ${filenames}`
+      isFn: true,
+      linter: 'node --arg=true ./myscript.js test.js'
     })
 
     await taskFn()
@@ -40,25 +41,38 @@ describe('resolveTaskFn', () => {
     })
   })
 
-  it('should support function linters that return array of strings', async () => {
-    expect.assertions(3)
+  it('should not append pathsToLint when isFn and shell', async () => {
+    expect.assertions(2)
     const taskFn = resolveTaskFn({
       ...defaultOpts,
-      pathsToLint: ['foo.js', 'bar.js'],
-      linter: filenames => filenames.map(filename => `node --arg=true ./myscript.js ${filename}`)
+      isFn: true,
+      shell: true,
+      linter: 'node --arg=true ./myscript.js test.js'
     })
 
     await taskFn()
-    expect(execa).toHaveBeenCalledTimes(2)
-    expect(execa).nthCalledWith(1, 'node', ['--arg=true', './myscript.js', 'foo.js'], {
+    expect(execa).toHaveBeenCalledTimes(1)
+    expect(execa).lastCalledWith('node --arg=true ./myscript.js test.js', {
       preferLocal: true,
       reject: false,
-      shell: false
+      shell: true
     })
-    expect(execa).nthCalledWith(2, 'node', ['--arg=true', './myscript.js', 'bar.js'], {
+  })
+
+  it('should work with shell', async () => {
+    expect.assertions(2)
+    const taskFn = resolveTaskFn({
+      ...defaultOpts,
+      shell: true,
+      linter: 'node --arg=true ./myscript.js'
+    })
+
+    await taskFn()
+    expect(execa).toHaveBeenCalledTimes(1)
+    expect(execa).lastCalledWith('node --arg=true ./myscript.js test.js', {
       preferLocal: true,
       reject: false,
-      shell: false
+      shell: true
     })
   })
 

--- a/test/resolveTaskFn.unmocked.spec.js
+++ b/test/resolveTaskFn.unmocked.spec.js
@@ -6,16 +6,13 @@ describe('resolveTaskFn', () => {
   it('should call execa with shell when configured so', async () => {
     const taskFn = resolveTaskFn({
       pathsToLint: ['package.json'],
-      linter: () => 'node -e "process.exit(1)" || echo $?',
+      isFn: true,
+      linter: 'node -e "process.exit(1)" || echo $?',
       shell: true
     })
 
-    await expect(taskFn()).resolves.toMatchInlineSnapshot(`
-Array [
-  "√ function linter() {
-        return 'node -e \\"process.exit(1)\\" || echo $?';
-      } passed!",
-]
-`)
+    await expect(taskFn()).resolves.toMatchInlineSnapshot(
+      `"√ node -e \\"process.exit(1)\\" || echo $? passed!"`
+    )
   })
 })


### PR DESCRIPTION
Function linters have to be evaluated at makeCmdTasks, and resolveTaskFn has to run for each of the returned commands.

Currently, `makeCmdTasks` creates only a single task per function linter, and `resolveTaskFn` returns an array of promises. This PR fixes the logic by evaluating functions at `makeCmdTasks` level, and running `resolveTaskFn` for each of the commands returned, simplifying `resolveTaskFn`.

This PR fixes issues where a function linter returning an array of commands might only run the first of the commands.

- [ ] https://github.com/okonet/lint-staged/issues/647
- [ ] https://github.com/okonet/lint-staged/issues/649