### PR TITLE
feat: make node-api accessible

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,33 @@ See more on [this blog post](https://medium.com/@tomchentw/imagemin-lint-staged-
 
 ## Frequently Asked Questions
 
+### Can I use `lint-staged` via node?
+
+Yes!
+
+```js
+const lintStaged = require('lint-staged')
+
+try {
+  const success = await lintStaged()
+  console.log(success ? 'Linting was successful!' : 'Linting failed!')
+} catch(e) {
+  // Failed to load configuration
+  console.error(e)
+}
+```
+
+Parameters to `lintStaged` are equivalent to their CLI counterparts:
+
+```js
+const success = await lintStaged({
+  configPath: './path/to/configuration/file',
+  shell: false,
+  quiet: false,
+  debug: false
+})
+```
+
 ### Using with JetBrains IDEs _(WebStorm, PyCharm, IntelliJ IDEA, RubyMine, etc.)_
 
 _**Update**_: The latest version of JetBrains IDEs now support running hooks as you would expect.

--- a/bin/lint-staged
+++ b/bin/lint-staged
@@ -43,12 +43,10 @@ lintStaged({
   shell: !!cmdline.shell,
   quiet: !!cmdline.quiet,
   debug: !!cmdline.debug
-}).then(
-  exitCode => {
-    process.exitCode = exitCode
-  },
-  err => {
-    console.error(err)
+})
+  .then(passed => {
+    process.exitCode = passed ? 0 : 1
+  })
+  .catch(() => {
     process.exitCode = 1
-  }
-)
+  })

--- a/bin/lint-staged
+++ b/bin/lint-staged
@@ -2,7 +2,14 @@
 
 'use strict'
 
-const pkg = require('./package.json')
+// Force colors for packages that depend on https://www.npmjs.com/package/supports-color
+// but do this only in TTY mode
+if (process.stdout.isTTY) {
+  // istanbul ignore next
+  process.env.FORCE_COLOR = '1'
+}
+
+const pkg = require('../package.json')
 require('please-upgrade-node')(
   Object.assign({}, pkg, {
     engines: {
@@ -13,6 +20,7 @@ require('please-upgrade-node')(
 
 const cmdline = require('commander')
 const debugLib = require('debug')
+const lintStaged = require('../src')
 
 const debug = debugLib('lint-staged:bin')
 
@@ -30,4 +38,12 @@ if (cmdline.debug) {
 
 debug('Running `lint-staged@%s`', pkg.version)
 
-require('./src')(console, cmdline.config, !!cmdline.shell, !!cmdline.quiet, !!cmdline.debug)
+lintStaged(console, cmdline.config, !!cmdline.shell, !!cmdline.quiet, !!cmdline.debug).then(
+  exitCode => {
+    process.exitCode = exitCode
+  },
+  err => {
+    console.error(err)
+    process.exitCode = 1
+  }
+)

--- a/bin/lint-staged
+++ b/bin/lint-staged
@@ -38,7 +38,12 @@ if (cmdline.debug) {
 
 debug('Running `lint-staged@%s`', pkg.version)
 
-lintStaged(console, cmdline.config, !!cmdline.shell, !!cmdline.quiet, !!cmdline.debug).then(
+lintStaged({
+  configPath: cmdline.config,
+  shell: !!cmdline.shell,
+  quiet: !!cmdline.quiet,
+  debug: !!cmdline.debug
+}).then(
   exitCode => {
     process.exitCode = exitCode
   },

--- a/package.json
+++ b/package.json
@@ -10,8 +10,11 @@
     "Suhas Karanth <sudo.suhas@gmail.com>",
     "Iiro Jäppinen <iiro@jappinen.fi> (https://iiro.fi)"
   ],
-  "bin": "index.js",
-  "files": ["index.js", "src"],
+  "main": "./src/index.js",
+  "bin": {
+    "lint-staged": "./bin/lint-staged"
+  },
+  "files": ["src", "bin"],
   "scripts": {
     "cz": "git-cz",
     "lint:base": "eslint --rule \"prettier/prettier: 2\"",
@@ -23,7 +26,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "node index.js"
+      "pre-commit": "./bin/lint-staged"
     }
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -11,9 +11,7 @@
     "Iiro Jäppinen <iiro@jappinen.fi> (https://iiro.fi)"
   ],
   "main": "./src/index.js",
-  "bin": {
-    "lint-staged": "./bin/lint-staged"
-  },
+  "bin": "./bin/lint-staged",
   "files": ["src", "bin"],
   "scripts": {
     "cz": "git-cz",

--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,7 @@ function loadConfig(configPath) {
  * @param {boolean} [options.debug] - Enable debug mode
  * @param {Logger} [logger]
  *
- * @returns {Promise<number>} Promise containing the exit code to use
+ * @returns {Promise<boolean>} Promise of whether the linting passed or failed
  */
 module.exports = function lintStaged(
   { configPath, shell = false, quiet = false, debug = false } = {},
@@ -77,11 +77,11 @@ module.exports = function lintStaged(
       return runAll(config, shell, quiet, debug, logger)
         .then(() => {
           debugLog('linters were executed successfully!')
-          return Promise.resolve(0)
+          return Promise.resolve(true)
         })
         .catch(error => {
           printErrors(error, logger)
-          return Promise.resolve(1)
+          return Promise.resolve(false)
         })
     })
     .catch(err => {
@@ -102,6 +102,6 @@ module.exports = function lintStaged(
         See https://github.com/okonet/lint-staged#configuration.
       `)
 
-      return Promise.resolve(1)
+      return Promise.reject(err)
     })
 }

--- a/src/makeCmdTasks.js
+++ b/src/makeCmdTasks.js
@@ -10,7 +10,6 @@ const debug = require('debug')('lint-staged:make-cmd-tasks')
  * @param {Array<string|Function>|string|Function} commands
  * @param {Boolean} shell
  * @param {Array<string>} pathsToLint
- * @param {Object} [options]
  */
 module.exports = async function makeCmdTasks(commands, shell, gitDir, pathsToLint) {
   debug('Creating listr tasks for commands %o', commands)

--- a/src/printErrors.js
+++ b/src/printErrors.js
@@ -4,7 +4,7 @@
 // Work-around for duplicated error logs, see #142
 const errMsg = err => (err.privateMsg != null ? err.privateMsg : err.message)
 
-module.exports = function printErrors(errorInstance, logger = console) {
+module.exports = function printErrors(errorInstance, logger) {
   if (Array.isArray(errorInstance.errors)) {
     errorInstance.errors.forEach(lintError => {
       logger.error(errMsg(lintError))

--- a/src/printErrors.js
+++ b/src/printErrors.js
@@ -4,12 +4,12 @@
 // Work-around for duplicated error logs, see #142
 const errMsg = err => (err.privateMsg != null ? err.privateMsg : err.message)
 
-module.exports = function printErrors(errorInstance) {
+module.exports = function printErrors(errorInstance, logger = console) {
   if (Array.isArray(errorInstance.errors)) {
     errorInstance.errors.forEach(lintError => {
-      console.error(errMsg(lintError))
+      logger.error(errMsg(lintError))
     })
   } else {
-    console.error(errMsg(errorInstance))
+    logger.error(errMsg(errorInstance))
   }
 }

--- a/src/resolveTaskFn.js
+++ b/src/resolveTaskFn.js
@@ -80,8 +80,8 @@ function makeErr(linter, result, context = {}) {
  * @param {string} options.gitDir
  * @param {Boolean} options.isFn
  * @param {string} options.linter
- * @param {Boolean} options.shellMode
  * @param {Array<string>} options.pathsToLint
+ * @param {Boolean} [options.shell]
  * @returns {function(): Promise<Array<string>>}
  */
 module.exports = function resolveTaskFn({ gitDir, isFn, linter, pathsToLint, shell = false }) {

--- a/src/runAll.js
+++ b/src/runAll.js
@@ -30,7 +30,7 @@ const MAX_ARG_LENGTH =
  * @param {Boolean} [shellMode] Use execa’s shell mode to execute linter commands
  * @param {Boolean} [quietMode] Use Listr’s silent renderer
  * @param {Boolean} [debugMode] Enable debug mode
- * @param {Logger} [logger]
+ * @param {Logger} logger
  * @returns {Promise}
  */
 module.exports = async function runAll(

--- a/src/runAll.js
+++ b/src/runAll.js
@@ -1,5 +1,7 @@
 'use strict'
 
+/** @typedef {import('./index').Logger} Logger */
+
 const chalk = require('chalk')
 const dedent = require('dedent')
 const Listr = require('listr')
@@ -23,17 +25,20 @@ const MAX_ARG_LENGTH =
 
 /**
  * Executes all tasks and either resolves or rejects the promise
+ *
  * @param config {Object}
- * @param {Boolean} shellMode Use execa’s shell mode to execute linter commands
- * @param {Boolean} quietMode Use Listr’s silent renderer
- * @param {Boolean} debugMode Enable debug mode
+ * @param {Boolean} [shellMode] Use execa’s shell mode to execute linter commands
+ * @param {Boolean} [quietMode] Use Listr’s silent renderer
+ * @param {Boolean} [debugMode] Enable debug mode
+ * @param {Logger} [logger]
  * @returns {Promise}
  */
 module.exports = async function runAll(
   config,
   shellMode = false,
   quietMode = false,
-  debugMode = false
+  debugMode = false,
+  logger = console
 ) {
   debug('Running all linter scripts')
 
@@ -55,7 +60,7 @@ module.exports = async function runAll(
 
   const argLength = files.join(' ').length
   if (argLength > MAX_ARG_LENGTH) {
-    console.warn(
+    logger.warn(
       dedent`${symbols.warning}  ${chalk.yellow(
         `lint-staged generated an argument string of ${argLength} characters, and commands might not run correctly on your platform.
 It is recommended to use functions as linters and split your command based on the number of staged files. For more info, please visit:
@@ -91,7 +96,7 @@ https://github.com/okonet/lint-staged#using-js-functions-to-customize-linter-com
   // If all of the configured "linters" should be skipped
   // avoid executing any lint-staged logic
   if (tasks.every(task => task.skip())) {
-    console.log('No staged files match any of provided globs.')
+    logger.log('No staged files match any of provided globs.')
     return 'No tasks to run.'
   }
 

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -77,3 +77,18 @@ ERROR
 ERROR Please make sure you have created it correctly.
 See https://github.com/okonet/lint-staged#configuration."
 `;
+
+exports[`lintStaged should use cosmiconfig if no params are passed 1`] = `
+"
+ERROR Unable to get staged files!"
+`;
+
+exports[`lintStaged should use use the console if no logger is passed 1`] = `
+"
+ERROR Could not parse lint-staged config.
+
+Error: Configuration should not be empty!
+ERROR 
+ERROR Please make sure you have created it correctly.
+See https://github.com/okonet/lint-staged#configuration."
+`;

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -1,11 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`lintStaged should exit with code 1 on linter errors 1`] = `
+"
+ERROR 
+
+
+× node -e \\"process.exit(1)\\" found some errors. Please fix them and try committing again."
+`;
+
 exports[`lintStaged should load an npm config package when specified 1`] = `
 "
 LOG Running lint-staged with the following config:
 LOG {
   '*': 'mytask'
-}"
+}
+ERROR Unable to get staged files!"
 `;
 
 exports[`lintStaged should load config file when specified 1`] = `
@@ -13,17 +22,22 @@ exports[`lintStaged should load config file when specified 1`] = `
 LOG Running lint-staged with the following config:
 LOG {
   '*': 'mytask'
-}"
+}
+ERROR Unable to get staged files!"
 `;
 
-exports[`lintStaged should not output config in normal mode 1`] = `""`;
+exports[`lintStaged should not output config in normal mode 1`] = `
+"
+ERROR Unable to get staged files!"
+`;
 
 exports[`lintStaged should output config in debug mode 1`] = `
 "
 LOG Running lint-staged with the following config:
 LOG {
   '*': 'mytask'
-}"
+}
+ERROR Unable to get staged files!"
 `;
 
 exports[`lintStaged should parse function linter from js config 1`] = `
@@ -32,7 +46,8 @@ LOG Running lint-staged with the following config:
 LOG {
   '*.css': filenames => \`echo \${filenames.join(' ')}\`,
   '*.js': filenames => filenames.map(filename => \`echo \${filename}\`)
-}"
+}
+ERROR Unable to get staged files!"
 `;
 
 exports[`lintStaged should print helpful error message when config file is not found 1`] = `

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -50,7 +50,7 @@ LOG {
 ERROR Unable to get staged files!"
 `;
 
-exports[`lintStaged should print helpful error message when config file is not found 1`] = `
+exports[`lintStaged should print helpful error message when config file is not found 2`] = `
 "
 ERROR Config could not be found.
 ERROR 
@@ -58,7 +58,7 @@ ERROR Please make sure you have created it correctly.
 See https://github.com/okonet/lint-staged#configuration."
 `;
 
-exports[`lintStaged should print helpful error message when explicit config file is not found 1`] = `
+exports[`lintStaged should print helpful error message when explicit config file is not found 2`] = `
 
 ERROR Could not parse lint-staged config.
 
@@ -68,7 +68,7 @@ ERROR Please make sure you have created it correctly.
 See https://github.com/okonet/lint-staged#configuration.
 `;
 
-exports[`lintStaged should throw when invalid config is provided 1`] = `
+exports[`lintStaged should throw when invalid config is provided 2`] = `
 "
 ERROR Could not parse lint-staged config.
 

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -58,7 +58,7 @@ ERROR Please make sure you have created it correctly.
 See https://github.com/okonet/lint-staged#configuration."
 `;
 
-exports[`lintStaged should print helpful error message when explicit config file is not found 2`] = `
+exports[`lintStaged should print helpful error message when explicit config file is not found 1`] = `
 
 ERROR Could not parse lint-staged config.
 

--- a/test/__snapshots__/runAll.spec.js.snap
+++ b/test/__snapshots__/runAll.spec.js.snap
@@ -111,3 +111,8 @@ LOG {
   context: {hasStash: true, hasErrors: true}
 }"
 `;
+
+exports[`runAll should use an injected logger 1`] = `
+"
+LOG No staged files match any of provided globs."
+`;

--- a/test/__snapshots__/runAll.spec.js.snap
+++ b/test/__snapshots__/runAll.spec.js.snap
@@ -116,3 +116,31 @@ exports[`runAll should use an injected logger 1`] = `
 "
 LOG No staged files match any of provided globs."
 `;
+
+exports[`runAll should warn if the argument length is longer than what the platform can handle 1`] = `
+"
+WARN ‼  lint-staged generated an argument string of 999999 characters, and commands might not run correctly on your platform.
+It is recommended to use functions as linters and split your command based on the number of staged files. For more info, please visit:
+https://github.com/okonet/lint-staged#using-js-functions-to-customize-linter-commands
+LOG Stashing changes... [started]
+LOG Stashing changes... [skipped]
+LOG → No partially staged files found...
+LOG Running linters... [started]
+LOG Running tasks for *.js [started]
+LOG echo \\"sample\\" [started]
+LOG echo \\"sample\\" [failed]
+LOG → 
+LOG Running tasks for *.js [failed]
+LOG → 
+LOG Running linters... [failed]
+LOG {
+  name: 'ListrError',
+  errors: [
+    {
+      privateMsg: '\\\\n\\\\n\\\\n× echo \\"sample\\" found some errors. Please fix them and try committing again.\\\\n\\\\nLinter finished with error',
+      context: {hasErrors: true}
+    }
+  ],
+  context: {hasErrors: true}
+}"
+`;

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -98,9 +98,9 @@ describe('lintStaged', () => {
   it('should print helpful error message when config file is not found', async () => {
     expect.assertions(2)
     mockCosmiconfigWith(null)
-    await lintStaged(logger)
+    const exitCode = await lintStaged(logger)
     expect(logger.printHistory()).toMatchSnapshot()
-    expect(process.exitCode).toEqual(1)
+    expect(exitCode).toEqual(1)
   })
 
   it('should print helpful error message when explicit config file is not found', async () => {
@@ -115,9 +115,9 @@ describe('lintStaged', () => {
       )
     )
 
-    await lintStaged(logger, nonExistentConfig)
+    const exitCode = await lintStaged(logger, nonExistentConfig)
     expect(logger.printHistory()).toMatchSnapshot()
-    expect(process.exitCode).toEqual(1)
+    expect(exitCode).toEqual(1)
   })
 
   it('should exit with code 1 on linter errors', async () => {
@@ -126,8 +126,8 @@ describe('lintStaged', () => {
     }
     mockCosmiconfigWith({ config })
     getStagedFiles.mockImplementationOnce(async () => ['sample.java'])
-    await lintStaged(logger, undefined)
+    const exitCode = await lintStaged(logger, undefined)
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining('node -e "process.exit(1)"'))
-    expect(process.exitCode).toEqual(1)
+    expect(exitCode).toEqual(1)
   })
 })

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -4,10 +4,6 @@ import path from 'path'
 
 jest.unmock('execa')
 
-// silence console from Jest output
-console.log = jest.fn(() => {})
-console.error = jest.fn(() => {})
-
 // eslint-disable-next-line import/first
 import getStagedFiles from '../src/getStagedFiles'
 // eslint-disable-next-line import/first
@@ -43,7 +39,7 @@ describe('lintStaged', () => {
       '*': 'mytask'
     }
     mockCosmiconfigWith({ config })
-    await lintStaged(logger, undefined, false, false, true)
+    await lintStaged({ debug: true, quiet: true }, logger)
     expect(logger.printHistory()).toMatchSnapshot()
   })
 
@@ -53,25 +49,26 @@ describe('lintStaged', () => {
       '*': 'mytask'
     }
     mockCosmiconfigWith({ config })
-    await lintStaged(logger)
+    await lintStaged({ quiet: true }, logger)
     expect(logger.printHistory()).toMatchSnapshot()
   })
 
   it('should throw when invalid config is provided', async () => {
     const config = {}
     mockCosmiconfigWith({ config })
-    await lintStaged(logger)
+    await lintStaged({ quiet: true }, logger)
     expect(logger.printHistory()).toMatchSnapshot()
   })
 
   it('should load config file when specified', async () => {
     expect.assertions(1)
     await lintStaged(
-      logger,
-      path.join(__dirname, '__mocks__', 'my-config.json'),
-      false,
-      false,
-      true
+      {
+        configPath: path.join(__dirname, '__mocks__', 'my-config.json'),
+        debug: true,
+        quiet: true
+      },
+      logger
     )
     expect(logger.printHistory()).toMatchSnapshot()
   })
@@ -79,11 +76,12 @@ describe('lintStaged', () => {
   it('should parse function linter from js config', async () => {
     expect.assertions(1)
     await lintStaged(
-      logger,
-      path.join(__dirname, '__mocks__', 'advanced-config.js'),
-      false,
-      false,
-      true
+      {
+        configPath: path.join(__dirname, '__mocks__', 'advanced-config.js'),
+        debug: true,
+        quiet: true
+      },
+      logger
     )
     expect(logger.printHistory()).toMatchSnapshot()
   })
@@ -91,14 +89,14 @@ describe('lintStaged', () => {
   it('should load an npm config package when specified', async () => {
     expect.assertions(1)
     jest.mock('my-lint-staged-config')
-    await lintStaged(logger, 'my-lint-staged-config', false, false, true)
+    await lintStaged({ configPath: 'my-lint-staged-config', quiet: true, debug: true }, logger)
     expect(logger.printHistory()).toMatchSnapshot()
   })
 
   it('should print helpful error message when config file is not found', async () => {
     expect.assertions(2)
     mockCosmiconfigWith(null)
-    const exitCode = await lintStaged(logger)
+    const exitCode = await lintStaged({ quiet: true }, logger)
     expect(logger.printHistory()).toMatchSnapshot()
     expect(exitCode).toEqual(1)
   })
@@ -115,7 +113,7 @@ describe('lintStaged', () => {
       )
     )
 
-    const exitCode = await lintStaged(logger, nonExistentConfig)
+    const exitCode = await lintStaged({ configPath: nonExistentConfig, quiet: true }, logger)
     expect(logger.printHistory()).toMatchSnapshot()
     expect(exitCode).toEqual(1)
   })
@@ -126,8 +124,8 @@ describe('lintStaged', () => {
     }
     mockCosmiconfigWith({ config })
     getStagedFiles.mockImplementationOnce(async () => ['sample.java'])
-    const exitCode = await lintStaged(logger, undefined)
-    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('node -e "process.exit(1)"'))
+    const exitCode = await lintStaged({ quiet: true }, logger)
+    expect(logger.printHistory()).toMatchSnapshot()
     expect(exitCode).toEqual(1)
   })
 })

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -56,7 +56,9 @@ describe('lintStaged', () => {
   it('should throw when invalid config is provided', async () => {
     const config = {}
     mockCosmiconfigWith({ config })
-    await lintStaged({ quiet: true }, logger)
+    await expect(lintStaged({ quiet: true }, logger)).rejects.toMatchInlineSnapshot(
+      `[Error: Configuration should not be empty!]`
+    )
     expect(logger.printHistory()).toMatchSnapshot()
   })
 
@@ -96,9 +98,10 @@ describe('lintStaged', () => {
   it('should print helpful error message when config file is not found', async () => {
     expect.assertions(2)
     mockCosmiconfigWith(null)
-    const exitCode = await lintStaged({ quiet: true }, logger)
+    await expect(lintStaged({ quiet: true }, logger)).rejects.toMatchInlineSnapshot(
+      `[Error: Config could not be found]`
+    )
     expect(logger.printHistory()).toMatchSnapshot()
-    expect(exitCode).toEqual(1)
   })
 
   it('should print helpful error message when explicit config file is not found', async () => {
@@ -113,9 +116,13 @@ describe('lintStaged', () => {
       )
     )
 
-    const exitCode = await lintStaged({ configPath: nonExistentConfig, quiet: true }, logger)
+    await expect(
+      lintStaged({ configPath: nonExistentConfig, quiet: true }, logger)
+    ).rejects.toMatchInlineSnapshot(
+      `[Error: ENOENT: no such file or directory, open '/Users/chunter/workspace/github/cameronhunter/lint-staged/fake-config-file.yml']`
+    )
+
     expect(logger.printHistory()).toMatchSnapshot()
-    expect(exitCode).toEqual(1)
   })
 
   it('should exit with code 1 on linter errors', async () => {
@@ -124,8 +131,8 @@ describe('lintStaged', () => {
     }
     mockCosmiconfigWith({ config })
     getStagedFiles.mockImplementationOnce(async () => ['sample.java'])
-    const exitCode = await lintStaged({ quiet: true }, logger)
+    const passed = await lintStaged({ quiet: true }, logger)
     expect(logger.printHistory()).toMatchSnapshot()
-    expect(exitCode).toEqual(1)
+    expect(passed).toBe(false)
   })
 })

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -118,9 +118,7 @@ describe('lintStaged', () => {
 
     await expect(
       lintStaged({ configPath: nonExistentConfig, quiet: true }, logger)
-    ).rejects.toMatchInlineSnapshot(
-      `[Error: ENOENT: no such file or directory, open '/Users/chunter/workspace/github/cameronhunter/lint-staged/fake-config-file.yml']`
-    )
+    ).rejects.toThrowError()
 
     expect(logger.printHistory()).toMatchSnapshot()
   })

--- a/test/index2.spec.js
+++ b/test/index2.spec.js
@@ -18,11 +18,8 @@ describe('lintStaged', () => {
   it('should pass quiet flag to Listr', async () => {
     expect.assertions(1)
     await lintStaged(
-      console,
-      path.join(__dirname, '__mocks__', 'my-config.json'),
-      false,
-      true,
-      false
+      { configPath: path.join(__dirname, '__mocks__', 'my-config.json'), quiet: true },
+      console
     )
     expect(Listr.mock.calls[0][1]).toEqual({ dateFormat: false, renderer: 'silent' })
   })
@@ -30,11 +27,11 @@ describe('lintStaged', () => {
   it('should pass debug flag to Listr', async () => {
     expect.assertions(1)
     await lintStaged(
-      console,
-      path.join(__dirname, '__mocks__', 'my-config.json'),
-      false,
-      false,
-      true
+      {
+        configPath: path.join(__dirname, '__mocks__', 'my-config.json'),
+        debug: true
+      },
+      console
     )
     expect(Listr.mock.calls[0][1]).toEqual({ dateFormat: false, renderer: 'verbose' })
   })

--- a/test/printErrors.spec.js
+++ b/test/printErrors.spec.js
@@ -3,24 +3,16 @@ import makeConsoleMock from 'consolemock'
 import printErrors from '../src/printErrors'
 
 describe('printErrors', () => {
-  const originalConsole = console
-
-  beforeAll(() => {
-    console = makeConsoleMock()
-  })
+  const logger = makeConsoleMock()
 
   beforeEach(() => {
-    console.clearHistory()
-  })
-
-  afterAll(() => {
-    global.console = originalConsole
+    logger.clearHistory()
   })
 
   it('should print plain errors', () => {
     const err = new Error('We have a problem')
-    printErrors(err)
-    expect(console.printHistory()).toMatchSnapshot()
+    printErrors(err, logger)
+    expect(logger.printHistory()).toMatchSnapshot()
   })
 
   it('should print Listr nested errors', async () => {
@@ -59,8 +51,8 @@ describe('printErrors', () => {
     try {
       await list.run()
     } catch (err) {
-      printErrors(err)
-      expect(console.printHistory()).toMatchSnapshot()
+      printErrors(err, logger)
+      expect(logger.printHistory()).toMatchSnapshot()
     }
   })
 })

--- a/test/runAll.spec.js
+++ b/test/runAll.spec.js
@@ -110,6 +110,18 @@ describe('runAll', () => {
     expect(gitStashPop).toHaveBeenCalledTimes(1)
   })
 
+  it('should warn if the argument length is longer than what the platform can handle', async () => {
+    hasPartiallyStagedFiles.mockImplementationOnce(() => Promise.resolve(false))
+    getStagedFiles.mockImplementationOnce(async () => new Array(100000).fill('sample.js'))
+
+    try {
+      await runAll({ '*.js': () => 'echo "sample"' })
+    } catch (err) {
+      console.log(err)
+    }
+    expect(console.printHistory()).toMatchSnapshot()
+  })
+
   it('should skip linters and stash update but perform working copy restore if terminated', async () => {
     expect.assertions(4)
     hasPartiallyStagedFiles.mockImplementationOnce(() => Promise.resolve(true))

--- a/test/runAll.spec.js
+++ b/test/runAll.spec.js
@@ -49,6 +49,13 @@ describe('runAll', () => {
     expect(console.printHistory()).toMatchSnapshot()
   })
 
+  it('should use an injected logger', async () => {
+    expect.assertions(1)
+    const logger = makeConsoleMock()
+    await runAll({ '*.js': ['echo "sample"'] }, undefined, true, undefined, logger)
+    expect(logger.printHistory()).toMatchSnapshot()
+  })
+
   it('should not skip tasks if there are files', async () => {
     expect.assertions(1)
     getStagedFiles.mockImplementationOnce(async () => ['sample.js'])


### PR DESCRIPTION
We have a use-case where we need to call `lint-staged` from inside another node script (there are other pre-commit steps that need to run). Currently we're calling out to `lint-staged` via `execa` but it's slower than calling it in-process via an exposed node API.