### PR TITLE
refactor: change "Running linters..." to "Running tasks..."

### DIFF
--- a/src/runAll.js
+++ b/src/runAll.js
@@ -123,7 +123,7 @@ https://github.com/okonet/lint-staged#using-js-functions-to-customize-linter-com
         }
       },
       {
-        title: 'Running linters...',
+        title: 'Running tasks...',
         task: () => new Listr(tasks, { ...listrOptions, concurrent: true, exitOnError: false })
       },
       {

--- a/test/__snapshots__/runAll.spec.js.snap
+++ b/test/__snapshots__/runAll.spec.js.snap
@@ -125,14 +125,14 @@ https://github.com/okonet/lint-staged#using-js-functions-to-customize-linter-com
 LOG Stashing changes... [started]
 LOG Stashing changes... [skipped]
 LOG → No partially staged files found...
-LOG Running linters... [started]
+LOG Running tasks... [started]
 LOG Running tasks for *.js [started]
 LOG echo \\"sample\\" [started]
 LOG echo \\"sample\\" [failed]
 LOG → 
 LOG Running tasks for *.js [failed]
 LOG → 
-LOG Running linters... [failed]
+LOG Running tasks... [failed]
 LOG {
   name: 'ListrError',
   errors: [

--- a/test/__snapshots__/runAll.spec.js.snap
+++ b/test/__snapshots__/runAll.spec.js.snap
@@ -4,12 +4,12 @@ exports[`runAll should not skip stashing and restoring if there are partially st
 "
 LOG Stashing changes... [started]
 LOG Stashing changes... [completed]
-LOG Running linters... [started]
+LOG Running tasks... [started]
 LOG Running tasks for *.js [started]
 LOG echo \\"sample\\" [started]
 LOG echo \\"sample\\" [completed]
 LOG Running tasks for *.js [completed]
-LOG Running linters... [completed]
+LOG Running tasks... [completed]
 LOG Updating stash... [started]
 LOG Updating stash... [completed]
 LOG Restoring local changes... [started]
@@ -21,12 +21,12 @@ exports[`runAll should not skip tasks if there are files 1`] = `
 LOG Stashing changes... [started]
 LOG Stashing changes... [skipped]
 LOG → No partially staged files found...
-LOG Running linters... [started]
+LOG Running tasks... [started]
 LOG Running tasks for *.js [started]
 LOG echo \\"sample\\" [started]
 LOG echo \\"sample\\" [completed]
 LOG Running tasks for *.js [completed]
-LOG Running linters... [completed]"
+LOG Running tasks... [completed]"
 `;
 
 exports[`runAll should reject promise when error during getStagedFiles 1`] = `"Unable to get staged files!"`;
@@ -40,14 +40,14 @@ exports[`runAll should skip linters and stash update but perform working copy re
 "
 LOG Stashing changes... [started]
 LOG Stashing changes... [completed]
-LOG Running linters... [started]
+LOG Running tasks... [started]
 LOG Running tasks for *.js [started]
 LOG echo \\"sample\\" [started]
 LOG echo \\"sample\\" [failed]
 LOG → 
 LOG Running tasks for *.js [failed]
 LOG → 
-LOG Running linters... [failed]
+LOG Running tasks... [failed]
 LOG Updating stash... [started]
 LOG Updating stash... [skipped]
 LOG → Skipping stash update since some tasks exited with errors
@@ -70,12 +70,12 @@ exports[`runAll should skip stashing and restoring if there are no partially sta
 LOG Stashing changes... [started]
 LOG Stashing changes... [skipped]
 LOG → No partially staged files found...
-LOG Running linters... [started]
+LOG Running tasks... [started]
 LOG Running tasks for *.js [started]
 LOG echo \\"sample\\" [started]
 LOG echo \\"sample\\" [completed]
 LOG Running tasks for *.js [completed]
-LOG Running linters... [completed]"
+LOG Running tasks... [completed]"
 `;
 
 exports[`runAll should skip stashing changes if no lint-staged files are changed 1`] = `
@@ -87,14 +87,14 @@ exports[`runAll should skip updating stash if there are errors during linting 1`
 "
 LOG Stashing changes... [started]
 LOG Stashing changes... [completed]
-LOG Running linters... [started]
+LOG Running tasks... [started]
 LOG Running tasks for *.js [started]
 LOG echo \\"sample\\" [started]
 LOG echo \\"sample\\" [failed]
 LOG → 
 LOG Running tasks for *.js [failed]
 LOG → 
-LOG Running linters... [failed]
+LOG Running tasks... [failed]
 LOG Updating stash... [started]
 LOG Updating stash... [skipped]
 LOG → Skipping stash update since some tasks exited with errors


### PR DESCRIPTION
In the console output `lint-staged` mostly refers to "tasks" (examples: [1](https://github.com/okonet/lint-staged/blob/master/src/runAll.js#L69), [2](https://github.com/okonet/lint-staged/blob/28da59a975da367b3ca9710e5387049c29fb1467/src/runAll.js#L95)) but in this line it refers to "linters" ([source](https://github.com/okonet/lint-staged/blob/28da59a975da367b3ca9710e5387049c29fb1467/src/runAll.js#L118)). I've found `lint-staged` to be incredibly useful beyond just linting, so I was hoping we could change them to "tasks" to be consistent?