### PR TITLE
Add custom titles to tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,21 @@ See more on [this blog post](https://medium.com/@tomchentw/imagemin-lint-staged-
 }
 ```
 
+### Adding custom titles for tasks
+
+```json
+{
+  "*.{js,jsx}": {
+    "title": "Running JavaScript tasks",
+    "tasks": [
+      { "title": "Formatting", "task": "prettier --write" },
+      { "title": "Linting", "task": "eslint --fix" },
+      { "title": "Adding modified files to the commit", "task": "git add" }
+    ]
+  }
+}
+```
+
 ## Frequently Asked Questions
 
 ### Using with JetBrains IDEs _(WebStorm, PyCharm, IntelliJ IDEA, RubyMine, etc.)_

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Options:
 
 * **`--config [path]`**: This can be used to manually specify the `lint-staged` config file location. However, if the specified file cannot be found, it will error out instead of performing the usual search. You may pass a npm package name for configuration also.
 * **`--shell`**: By default linter commands will be parsed for speed and security. This has the side-effect that regular shell scripts might not work as expected. You can skip parsing of commands with this option.
-* **`--quiet`**: By default `lint-staged` will print progress status to console while running linters. Use this flag to supress all output, exept for linter scripts.
+* **`--quiet`**: By default `lint-staged` will print progress status to console while running linters. Use this flag to supress all output, except for linter scripts.
 * **`--debug`**: Enabling the debug mode does the following:
   * `lint-staged` uses the [debug](https://github.com/visionmedia/debug) module internally to log information about staged files, commands being executed, location of binaries, etc. Debug logs, which are automatically enabled by passing the flag, can also be enabled by setting the environment variable `$DEBUG` to `lint-staged*`.
   * Use the [`verbose` renderer](https://github.com/SamVerschueren/listr-verbose-renderer) for `listr`.

--- a/src/generateTasks.js
+++ b/src/generateTasks.js
@@ -2,6 +2,7 @@
 
 const micromatch = require('micromatch')
 const path = require('path')
+const normalizeTasksConfig = require('./normalizeTasksConfig')
 
 const debug = require('debug')('lint-staged:gen-tasks')
 
@@ -26,7 +27,7 @@ module.exports = async function generateTasks(config, gitDir, stagedRelFiles) {
 
   return Object.keys(config).map(pattern => {
     const isParentDirPattern = pattern.startsWith('../')
-    const commands = config[pattern]
+    const { title, commands } = normalizeTasksConfig(pattern, config[pattern])
 
     const fileList = micromatch(
       stagedFiles
@@ -48,7 +49,7 @@ module.exports = async function generateTasks(config, gitDir, stagedRelFiles) {
       path.resolve(cwd, file)
     )
 
-    const task = { pattern, commands, fileList }
+    const task = { title, pattern, commands, fileList }
     debug('Generated task: \n%O', task)
 
     return task

--- a/src/generateTasks.js
+++ b/src/generateTasks.js
@@ -18,15 +18,15 @@ const isPathInside = (parent, child) => {
   return relative && !relative.startsWith('..') && !path.isAbsolute(relative)
 }
 
-module.exports = async function generateTasks(linters, gitDir, stagedRelFiles) {
+module.exports = async function generateTasks(config, gitDir, stagedRelFiles) {
   debug('Generating linter tasks')
 
   const cwd = process.cwd()
   const stagedFiles = stagedRelFiles.map(file => path.resolve(gitDir, file))
 
-  return Object.keys(linters).map(pattern => {
+  return Object.keys(config).map(pattern => {
     const isParentDirPattern = pattern.startsWith('../')
-    const commands = linters[pattern]
+    const commands = config[pattern]
 
     const fileList = micromatch(
       stagedFiles

--- a/src/makeCmdTasks.js
+++ b/src/makeCmdTasks.js
@@ -10,14 +10,13 @@ const debug = require('debug')('lint-staged:make-cmd-tasks')
  * @param {Array<string|Function>|string|Function} commands
  * @param {Boolean} shell
  * @param {Array<string>} pathsToLint
- * @param {Object} [options]
  */
 module.exports = async function makeCmdTasks(commands, shell, gitDir, pathsToLint) {
   debug('Creating listr tasks for commands %o', commands)
   const commandsArray = Array.isArray(commands) ? commands : [commands]
 
   return commandsArray.reduce((tasks, command) => {
-    // linter function may return array of commands that already include `pathsToLit`
+    // linter function may return array of commands that already include `pathsToLint`
     const isFn = typeof command === 'function'
     const resolved = isFn ? command(pathsToLint) : command
     const linters = Array.isArray(resolved) ? resolved : [resolved] // Wrap non-array linter as array

--- a/src/normalizeCommandConfig.js
+++ b/src/normalizeCommandConfig.js
@@ -1,0 +1,34 @@
+'use strict'
+
+/**
+ * @param {String[]} pathsToLint
+ * @param {*} command
+ * @param {Boolean} [shouldBeProvidedPaths]
+ * @returns {Array<{ title: String, task: String, shouldBeProvidedPaths: Boolean }>}
+ */
+module.exports = function normalizeCommandConfig(
+  pathsToLint,
+  command,
+  shouldBeProvidedPaths = true
+) {
+  if (Array.isArray(command)) {
+    return command.reduce(
+      (commands, com) => [
+        ...commands,
+        ...normalizeCommandConfig(pathsToLint, com, shouldBeProvidedPaths)
+      ],
+      []
+    )
+  }
+
+  if (command && command.task) {
+    return [{ title: command.title || command.task, task: command.task, shouldBeProvidedPaths }]
+  }
+
+  if (typeof command === 'function') {
+    const resolved = command(pathsToLint)
+    return normalizeCommandConfig(pathsToLint, resolved, false)
+  }
+
+  return [{ title: command, task: command, shouldBeProvidedPaths }]
+}

--- a/src/normalizeTasksConfig.js
+++ b/src/normalizeTasksConfig.js
@@ -1,0 +1,16 @@
+'use strict'
+
+/**
+ * @param {string} pattern
+ * @param {*} commands
+ * @returns {{ title: string, commands: * }}
+ */
+module.exports = function normalizeTasksConfig(pattern, commands) {
+  const defaultTitle = `Running tasks for ${pattern}`
+
+  if (commands && commands.tasks) {
+    return { title: commands.title || defaultTitle, commands: commands.tasks }
+  }
+
+  return { title: defaultTitle, commands }
+}

--- a/src/resolveTaskFn.js
+++ b/src/resolveTaskFn.js
@@ -80,8 +80,8 @@ function makeErr(linter, result, context = {}) {
  * @param {string} options.gitDir
  * @param {Boolean} [options.shouldBeProvidedPaths]
  * @param {string} options.linter
- * @param {Boolean} options.shellMode
  * @param {Array<string>} options.pathsToLint
+ * @param {Boolean} [options.shell]
  * @returns {function(): Promise<Array<string>>}
  */
 module.exports = function resolveTaskFn({

--- a/src/resolveTaskFn.js
+++ b/src/resolveTaskFn.js
@@ -78,13 +78,19 @@ function makeErr(linter, result, context = {}) {
  *
  * @param {Object} options
  * @param {string} options.gitDir
- * @param {Boolean} options.isFn
+ * @param {Boolean} [options.shouldBeProvidedPaths]
  * @param {string} options.linter
  * @param {Boolean} options.shellMode
  * @param {Array<string>} options.pathsToLint
  * @returns {function(): Promise<Array<string>>}
  */
-module.exports = function resolveTaskFn({ gitDir, isFn, linter, pathsToLint, shell = false }) {
+module.exports = function resolveTaskFn({
+  gitDir,
+  shouldBeProvidedPaths = true,
+  linter,
+  pathsToLint,
+  shell = false
+}) {
   const execaOptions = { preferLocal: true, reject: false, shell }
 
   let cmd
@@ -94,11 +100,11 @@ module.exports = function resolveTaskFn({ gitDir, isFn, linter, pathsToLint, she
     execaOptions.shell = true
     // If `shell`, passed command shouldn't be parsed
     // If `linter` is a function, command already includes `pathsToLint`.
-    cmd = isFn ? linter : `${linter} ${pathsToLint.join(' ')}`
+    cmd = shouldBeProvidedPaths ? `${linter} ${pathsToLint.join(' ')}` : linter
   } else {
     const [parsedCmd, ...parsedArgs] = stringArgv.parseArgsStringToArgv(linter)
     cmd = parsedCmd
-    args = isFn ? parsedArgs : parsedArgs.concat(pathsToLint)
+    args = shouldBeProvidedPaths ? parsedArgs.concat(pathsToLint) : parsedArgs
   }
 
   // Only use gitDir as CWD if we are using the git binary

--- a/src/runAll.js
+++ b/src/runAll.js
@@ -66,7 +66,7 @@ https://github.com/okonet/lint-staged#using-js-functions-to-customize-linter-com
   }
 
   const tasks = (await generateTasks(config, gitDir, files)).map(task => ({
-    title: `Running tasks for ${task.pattern}`,
+    title: task.title,
     task: async () =>
       new Listr(await makeCmdTasks(task.commands, shellMode, gitDir, task.fileList), {
         // In sub-tasks we don't want to run concurrently

--- a/test/generateTasks.spec.js
+++ b/test/generateTasks.spec.js
@@ -64,6 +64,7 @@ describe('generateTasks', () => {
     const result = await generateTasks({ ...config }, relPath, files)
     const linter = result.find(item => item.pattern === '*.js')
     expect(linter).toEqual({
+      title: expect.stringContaining('*.js'),
       pattern: '*.js',
       commands: 'root-js',
       fileList: []
@@ -86,6 +87,7 @@ describe('generateTasks', () => {
     const result = await generateTasks(config, workDir, files)
     const linter = result.find(item => item.pattern === '*.js')
     expect(linter).toEqual({
+      title: expect.stringContaining('*.js'),
       pattern: '*.js',
       commands: 'root-js',
       fileList: [
@@ -102,6 +104,7 @@ describe('generateTasks', () => {
     const result = await generateTasks(config, workDir, files)
     const linter = result.find(item => item.pattern === '**/*.js')
     expect(linter).toEqual({
+      title: expect.stringContaining('**/*.js'),
       pattern: '**/*.js',
       commands: 'any-js',
       fileList: [
@@ -118,6 +121,7 @@ describe('generateTasks', () => {
     const result = await generateTasks(config, workDir, files)
     const linter = result.find(item => item.pattern === 'deeper/*.js')
     expect(linter).toEqual({
+      title: expect.stringContaining('deeper/*.js'),
       pattern: 'deeper/*.js',
       commands: 'deeper-js',
       fileList: [`${workDir}/deeper/test.js`, `${workDir}/deeper/test2.js`].map(path.normalize)
@@ -128,6 +132,7 @@ describe('generateTasks', () => {
     const result = await generateTasks(config, workDir, files)
     const linter = result.find(item => item.pattern === '.hidden/*.js')
     expect(linter).toEqual({
+      title: expect.stringContaining('.hidden/*.js'),
       pattern: '.hidden/*.js',
       commands: 'hidden-js',
       fileList: [path.normalize(`${workDir}/.hidden/test.js`)]
@@ -138,6 +143,7 @@ describe('generateTasks', () => {
     const result = await generateTasks(config, workDir, files)
     const linter = result.find(item => item.pattern === '*.{css,js}')
     expect(linter).toEqual({
+      title: expect.stringContaining('*.{css,js}'),
       pattern: '*.{css,js}',
       commands: 'root-css-or-js',
       fileList: [

--- a/test/normalizeCommandConfig.spec.js
+++ b/test/normalizeCommandConfig.spec.js
@@ -1,0 +1,68 @@
+import normalizeCommandConfig from '../src/normalizeCommandConfig'
+
+describe('normalizeCommandConfig', () => {
+  it('should normalize string commands', () => {
+    const linters = normalizeCommandConfig(['foo.js'], 'eslint --fix')
+
+    expect(linters).toEqual([
+      { title: 'eslint --fix', task: 'eslint --fix', shouldBeProvidedPaths: true }
+    ])
+  })
+
+  it('should normalize array commands', () => {
+    const linters = normalizeCommandConfig(['foo.js'], ['prettier --write', 'git add'])
+
+    expect(linters).toEqual([
+      { title: 'prettier --write', task: 'prettier --write', shouldBeProvidedPaths: true },
+      { title: 'git add', task: 'git add', shouldBeProvidedPaths: true }
+    ])
+  })
+
+  it('should normalize function commands', () => {
+    const tsc = () => 'tsc --noEmit'
+    const linters = normalizeCommandConfig(['foo.js'], tsc)
+
+    expect(linters).toEqual([
+      { title: 'tsc --noEmit', task: 'tsc --noEmit', shouldBeProvidedPaths: false }
+    ])
+  })
+
+  it('should normalize object commands without a title', () => {
+    const linters = normalizeCommandConfig(['foo.js'], { task: 'prettier --write' })
+
+    expect(linters).toEqual([
+      { title: 'prettier --write', task: 'prettier --write', shouldBeProvidedPaths: true }
+    ])
+  })
+
+  it('should normalize object commands with a title', () => {
+    const linters = normalizeCommandConfig(['foo.js'], {
+      title: 'Formatting files',
+      task: 'prettier --write'
+    })
+
+    expect(linters).toEqual([
+      { title: 'Formatting files', task: 'prettier --write', shouldBeProvidedPaths: true }
+    ])
+  })
+
+  it('should normalize the kitchen sink', () => {
+    const linters = normalizeCommandConfig(
+      ['foo.js'],
+      [
+        {
+          title: 'Formatting files',
+          task: 'prettier --write'
+        },
+        'eslint --fix',
+        () => 'git add'
+      ]
+    )
+
+    expect(linters).toEqual([
+      { title: 'Formatting files', task: 'prettier --write', shouldBeProvidedPaths: true },
+      { title: 'eslint --fix', task: 'eslint --fix', shouldBeProvidedPaths: true },
+      { title: 'git add', task: 'git add', shouldBeProvidedPaths: false }
+    ])
+  })
+})

--- a/test/normalizeTasksConfig.spec.js
+++ b/test/normalizeTasksConfig.spec.js
@@ -1,0 +1,51 @@
+import normalizeTasksConfig from '../src/normalizeTasksConfig'
+
+describe('normalizeTasksConfig', () => {
+  it('should return the default title for null-ish tasks', () => {
+    const { title, commands } = normalizeTasksConfig('*.js', undefined)
+
+    expect(title).toBe('Running tasks for *.js')
+    expect(commands).toBe(undefined)
+  })
+
+  it('should return the default title for string tasks', () => {
+    const { title, commands } = normalizeTasksConfig('*.js', 'eslint --fix')
+
+    expect(title).toBe('Running tasks for *.js')
+    expect(commands).toBe('eslint --fix')
+  })
+
+  it('should return the default title for function tasks', () => {
+    const tsc = () => 'tsc -p tsconfig.json --noEmit'
+    const { title, commands } = normalizeTasksConfig('**/*.ts?(x)', tsc)
+
+    expect(title).toBe('Running tasks for **/*.ts?(x)')
+    expect(commands).toEqual(tsc)
+  })
+
+  it('should return the default title for array tasks', () => {
+    const { title, commands } = normalizeTasksConfig('*.js', ['eslint --fix', 'git add'])
+
+    expect(title).toBe('Running tasks for *.js')
+    expect(commands).toEqual(['eslint --fix', 'git add'])
+  })
+
+  it('should return the default title for object tasks without a title property', () => {
+    const { title, commands } = normalizeTasksConfig('**/*.js', {
+      tasks: 'prettier --write'
+    })
+
+    expect(title).toBe('Running tasks for **/*.js')
+    expect(commands).toBe('prettier --write')
+  })
+
+  it('should return the custom title for object tasks with a title property', () => {
+    const { title, commands } = normalizeTasksConfig('**/*.js', {
+      title: 'Running tasks JavaScript files',
+      tasks: 'prettier --write'
+    })
+
+    expect(title).toBe('Running tasks JavaScript files')
+    expect(commands).toBe('prettier --write')
+  })
+})

--- a/test/resolveTaskFn.spec.js
+++ b/test/resolveTaskFn.spec.js
@@ -24,11 +24,11 @@ describe('resolveTaskFn', () => {
     })
   })
 
-  it('should not append pathsToLint when isFn', async () => {
+  it('should not append pathsToLint when shouldBeProvidedPaths is false', async () => {
     expect.assertions(2)
     const taskFn = resolveTaskFn({
       ...defaultOpts,
-      isFn: true,
+      shouldBeProvidedPaths: false,
       linter: 'node --arg=true ./myscript.js test.js'
     })
 
@@ -41,11 +41,11 @@ describe('resolveTaskFn', () => {
     })
   })
 
-  it('should not append pathsToLint when isFn and shell', async () => {
+  it('should not append pathsToLint when shouldBeProvidedPaths is false and shell', async () => {
     expect.assertions(2)
     const taskFn = resolveTaskFn({
       ...defaultOpts,
-      isFn: true,
+      shouldBeProvidedPaths: false,
       shell: true,
       linter: 'node --arg=true ./myscript.js test.js'
     })


### PR DESCRIPTION
Sometimes I'm looking to add a more descriptive name to what the task is doing, or perhaps wanting to shorten the task name if it happens to be a long command. This change is backwards compatible and allows custom names for both the task and command level:

```json
{
  "*.{js,jsx}": {
    "title": "Running JavaScript tasks",
    "tasks": [
      { "title": "Formatting", "task": "prettier --write" },
      { "title": "Linting", "task": "eslint --fix" },
      { "title": "Adding modified files to the commit", "task": "git add" }
    ]
  }
}
```
Fixes #410