### PR TITLE
Add more tests

### DIFF
--- a/test/runAll.unmocked.spec.js
+++ b/test/runAll.unmocked.spec.js
@@ -307,6 +307,59 @@ nothing to commit, working tree clean"
     expect(await readFile('test.js')).toEqual(testJsFilePretty)
   })
 
+  it('Should fail when linter creates a .git/index.lock', async () => {
+    // Stage ugly file
+    await appendFile('test.js', testJsFileUgly)
+    await execGit(['add', 'test.js'])
+
+    // Edit ugly file but do not stage changes
+    const appended = '\n\nconsole.log("test");\n'
+    await appendFile('test.js', appended)
+    expect(await readFile('test.js')).toEqual(testJsFileUgly + appended)
+    const diff = await execGit(['diff'])
+
+    // Run lint-staged with `prettier --write` and commit pretty file
+    // The task creates a git lock file to simulate failure
+    const success = await gitCommit({
+      config: {
+        '*.js': files => [
+          `touch ${cwd}/.git/index.lock`,
+          `prettier --write ${files.join(' ')}`,
+          `git add ${files.join(' ')}`
+        ]
+      }
+    })
+    expect(success).toEqual(false)
+
+    // Something was wrong so new commit wasn't created
+    expect(await execGit(['rev-list', '--count', 'HEAD'])).toEqual('1')
+    expect(await execGit(['log', '-1', '--pretty=%B'])).toMatchInlineSnapshot(`
+" initial commit
+"
+`)
+
+    // But local modifications are gone
+    expect(await execGit(['diff'])).not.toEqual(diff)
+    expect(await execGit(['diff'])).toMatchInlineSnapshot(`
+"diff --git a/test.js b/test.js
+index f80f875..1c5643c 100644
+--- a/test.js
++++ b/test.js
+@@ -1,3 +1,3 @@
+ module.exports = {
+-    'foo': 'bar',
+-}
++  foo: \\"bar\\"
++};"
+`)
+
+    expect(await readFile('test.js')).not.toEqual(testJsFileUgly + appended)
+    expect(await readFile('test.js')).toEqual(testJsFilePretty)
+
+    // Remove lock file
+    await fs.remove(`${cwd}/.git/index.lock`)
+  })
+
   afterEach(async () => {
     wcDir.removeCallback()
   })


### PR DESCRIPTION
This PR adds two tests.

## 1: Should clear unstaged changes when linter applies same changes

1. There is a staged file that does not pass prettier’s formatting
1. There are unstaged modifications that properly prettify the file
1. `lint-staged` runs `prettier --fix` and `git add` to essentially do the same thing as the unstaged modifications

The result:

1. `lint-staged` succesfully fixed and committed the file
1. The unstaged modifications are gone, since they’re already in place

## 2: should fail when linter creates a .git/index.lock

1. There is a staged file that does not pass prettier’s formatting
1. There are further unstaged changes in the same file
1. `lint-staged` runs `prettier --fix` and `git add`, but also create a `.git/index.lock` file, failing git operations (like the `git add`)

The result:

1. `lint-staged` fails to create a new commit
1. `git status` matches the status before committing, but prettier's changes have been staged
1. The unstaged modifications are gone, replaced by previously staged modifications, and staged modifications contain linter changes.