### PR TITLE
fix: always use posix paths

### DIFF
--- a/src/execGit.js
+++ b/src/execGit.js
@@ -2,22 +2,12 @@
 
 const debug = require('debug')('lint-staged:git')
 const execa = require('execa')
-const path = require('path')
-
-function getAbsolutePath(dir) {
-  return path.isAbsolute(dir) ? dir : path.resolve(dir)
-}
 
 module.exports = async function execGit(cmd, options = {}) {
-  const cwd = options.cwd || process.cwd()
   debug('Running git command', cmd)
-  try {
-    const { stdout } = await execa('git', [].concat(cmd), {
-      ...options,
-      cwd: getAbsolutePath(cwd)
-    })
-    return stdout
-  } catch (err) {
-    throw new Error(err)
-  }
+  const { stdout } = await execa('git', [].concat(cmd), {
+    ...options,
+    cwd: options.cwd || process.cwd()
+  })
+  return stdout
 }

--- a/src/resolveGitDir.js
+++ b/src/resolveGitDir.js
@@ -9,7 +9,7 @@ module.exports = async function resolveGitDir(options = {}) {
     // depending on where the caller initiated this from, hence clear GIT_DIR
     delete process.env.GIT_DIR
     const gitDir = await execGit(['rev-parse', '--show-toplevel'], options)
-    return path.normalize(gitDir)
+    return path.posix.resolve(gitDir)
   } catch (error) {
     return null
   }

--- a/test/gitWorkflow.spec.js
+++ b/test/gitWorkflow.spec.js
@@ -10,26 +10,15 @@ tmp.setGracefulCleanup()
 describe('gitWorkflow', () => {
   describe('execGit', () => {
     it('should execute git in process.cwd if working copy is not specified', async () => {
+      const cwd = path.posix.resolve(process.cwd())
       await execGit(['init', 'param'])
-      expect(execa).toHaveBeenCalledWith('git', ['init', 'param'], {
-        cwd: path.resolve(process.cwd())
-      })
+      expect(execa).toHaveBeenCalledWith('git', ['init', 'param'], { cwd })
     })
 
     it('should execute git in a given working copy', async () => {
-      await execGit(['init', 'param'], { cwd: 'test/__fixtures__' })
-      expect(execa).toHaveBeenCalledWith('git', ['init', 'param'], {
-        cwd: path.resolve(process.cwd(), 'test', '__fixtures__')
-      })
-    })
-
-    it('should work with relative paths', async () => {
-      await execGit(['init', 'param'], {
-        cwd: 'test/__fixtures__'
-      })
-      expect(execa).toHaveBeenCalledWith('git', ['init', 'param'], {
-        cwd: path.resolve(process.cwd(), 'test', '__fixtures__')
-      })
+      const cwd = path.posix.resolve(process.cwd(), 'test', '__fixtures__')
+      await execGit(['init', 'param'], { cwd })
+      expect(execa).toHaveBeenCalledWith('git', ['init', 'param'], { cwd })
     })
   })
 


### PR DESCRIPTION
Since `path.normalize` creates Windows-preferred path separators on Windows, `lint-staged` fails on some Windows environments. This PR changes `resolveGitDir` to return a path via `path.resolve` instead, which seems a better choice.

See https://github.com/okonet/lint-staged/issues/669 for the bug report.