### PR TITLE
fix: always use unix slashes in paths and correctly handle ../ globs

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "listr": "^0.14.3",
     "log-symbols": "^3.0.0",
     "micromatch": "^4.0.2",
+    "normalize-path": "^3.0.0",
     "please-upgrade-node": "^3.1.1",
     "string-argv": "^0.3.0",
     "stringify-object": "^3.3.0"

--- a/src/execGit.js
+++ b/src/execGit.js
@@ -5,13 +5,9 @@ const execa = require('execa')
 
 module.exports = async function execGit(cmd, options = {}) {
   debug('Running git command', cmd)
-  try {
-    const { stdout } = await execa('git', [].concat(cmd), {
-      ...options,
-      cwd: options.cwd || process.cwd()
-    })
-    return stdout
-  } catch (err) {
-    throw new Error(err)
-  }
+  const { stdout } = await execa('git', [].concat(cmd), {
+    ...options,
+    cwd: options.cwd || process.cwd()
+  })
+  return stdout
 }

--- a/src/execGit.js
+++ b/src/execGit.js
@@ -2,19 +2,13 @@
 
 const debug = require('debug')('lint-staged:git')
 const execa = require('execa')
-const path = require('path')
-
-function getAbsolutePath(dir) {
-  return path.isAbsolute(dir) ? dir : path.resolve(dir)
-}
 
 module.exports = async function execGit(cmd, options = {}) {
-  const cwd = options.cwd || process.cwd()
   debug('Running git command', cmd)
   try {
     const { stdout } = await execa('git', [].concat(cmd), {
       ...options,
-      cwd: getAbsolutePath(cwd)
+      cwd: options.cwd || process.cwd()
     })
     return stdout
   } catch (err) {

--- a/src/resolveGitDir.js
+++ b/src/resolveGitDir.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const execGit = require('./execGit')
-const path = require('path')
+const normalize = require('normalize-path')
 
 module.exports = async function resolveGitDir(options = {}) {
   try {
@@ -9,7 +9,7 @@ module.exports = async function resolveGitDir(options = {}) {
     // depending on where the caller initiated this from, hence clear GIT_DIR
     delete process.env.GIT_DIR
     const gitDir = await execGit(['rev-parse', '--show-toplevel'], options)
-    return path.resolve(gitDir)
+    return normalize(gitDir)
   } catch (error) {
     return null
   }

--- a/src/resolveGitDir.js
+++ b/src/resolveGitDir.js
@@ -9,7 +9,7 @@ module.exports = async function resolveGitDir(options = {}) {
     // depending on where the caller initiated this from, hence clear GIT_DIR
     delete process.env.GIT_DIR
     const gitDir = await execGit(['rev-parse', '--show-toplevel'], options)
-    return path.normalize(gitDir)
+    return path.resolve(gitDir)
   } catch (error) {
     return null
   }

--- a/src/runAll.js
+++ b/src/runAll.js
@@ -69,7 +69,7 @@ https://github.com/okonet/lint-staged#using-js-functions-to-customize-linter-com
     )
   }
 
-  const tasks = (await generateTasks({ config, cwd, gitDir, files, relative })).map(task => ({
+  const tasks = generateTasks({ config, cwd, gitDir, files, relative }).map(task => ({
     title: `Running tasks for ${task.pattern}`,
     task: async () =>
       new Listr(

--- a/test/gitWorkflow.spec.js
+++ b/test/gitWorkflow.spec.js
@@ -10,26 +10,15 @@ tmp.setGracefulCleanup()
 describe('gitWorkflow', () => {
   describe('execGit', () => {
     it('should execute git in process.cwd if working copy is not specified', async () => {
+      const cwd = process.cwd()
       await execGit(['init', 'param'])
-      expect(execa).toHaveBeenCalledWith('git', ['init', 'param'], {
-        cwd: path.resolve(process.cwd())
-      })
+      expect(execa).toHaveBeenCalledWith('git', ['init', 'param'], { cwd })
     })
 
     it('should execute git in a given working copy', async () => {
-      await execGit(['init', 'param'], { cwd: 'test/__fixtures__' })
-      expect(execa).toHaveBeenCalledWith('git', ['init', 'param'], {
-        cwd: path.resolve(process.cwd(), 'test', '__fixtures__')
-      })
-    })
-
-    it('should work with relative paths', async () => {
-      await execGit(['init', 'param'], {
-        cwd: 'test/__fixtures__'
-      })
-      expect(execa).toHaveBeenCalledWith('git', ['init', 'param'], {
-        cwd: path.resolve(process.cwd(), 'test', '__fixtures__')
-      })
+      const cwd = path.join(process.cwd(), 'test', '__fixtures__')
+      await execGit(['init', 'param'], { cwd })
+      expect(execa).toHaveBeenCalledWith('git', ['init', 'param'], { cwd })
     })
   })
 

--- a/test/resolveGitDir.spec.js
+++ b/test/resolveGitDir.spec.js
@@ -1,4 +1,6 @@
+import normalize from 'normalize-path'
 import path from 'path'
+
 import resolveGitDir from '../src/resolveGitDir'
 
 /**
@@ -8,12 +10,12 @@ jest.unmock('execa')
 
 describe('resolveGitDir', () => {
   it('should resolve to current working dir when .git is in the same dir', async () => {
-    const expected = process.cwd()
+    const expected = normalize(process.cwd())
     expect(await resolveGitDir()).toEqual(expected)
   })
 
   it('should resolve to the parent dir when .git is in the parent dir', async () => {
-    const expected = path.dirname(__dirname)
+    const expected = normalize(path.dirname(__dirname))
     const processCwdBkp = process.cwd
     process.cwd = () => __dirname
     // path.resolve to strip trailing slash
@@ -22,7 +24,7 @@ describe('resolveGitDir', () => {
   })
 
   it('should resolve to the parent dir when .git is in the parent dir even when the GIT_DIR environment variable is set', async () => {
-    const expected = path.dirname(__dirname)
+    const expected = normalize(path.dirname(__dirname))
     const processCwdBkp = process.cwd
     process.cwd = () => __dirname
     process.env.GIT_DIR = 'wrong/path/.git' // refer to https://github.com/DonJayamanne/gitHistoryVSCode/issues/233#issuecomment-375769718

--- a/test/resolveGitDir.spec.js
+++ b/test/resolveGitDir.spec.js
@@ -18,8 +18,7 @@ describe('resolveGitDir', () => {
     const expected = normalize(path.dirname(__dirname))
     const processCwdBkp = process.cwd
     process.cwd = () => __dirname
-    // path.resolve to strip trailing slash
-    expect(path.resolve(await resolveGitDir())).toEqual(expected)
+    expect(await resolveGitDir()).toEqual(expected)
     process.cwd = processCwdBkp
   })
 
@@ -28,7 +27,7 @@ describe('resolveGitDir', () => {
     const processCwdBkp = process.cwd
     process.cwd = () => __dirname
     process.env.GIT_DIR = 'wrong/path/.git' // refer to https://github.com/DonJayamanne/gitHistoryVSCode/issues/233#issuecomment-375769718
-    expect(path.resolve(await resolveGitDir())).toEqual(expected)
+    expect(await resolveGitDir()).toEqual(expected)
     process.cwd = processCwdBkp
   })
 

--- a/test/runAll.spec.js
+++ b/test/runAll.spec.js
@@ -1,31 +1,35 @@
 import makeConsoleMock from 'consolemock'
 import execa from 'execa'
+import normalize from 'normalize-path'
 
+import resolveGitDir from '../src/resolveGitDir'
 import getStagedFiles from '../src/getStagedFiles'
 import runAll from '../src/runAll'
 import { hasPartiallyStagedFiles, gitStashSave, gitStashPop, updateStash } from '../src/gitWorkflow'
 
+jest.mock('../src/resolveGitDir')
 jest.mock('../src/getStagedFiles')
 jest.mock('../src/gitWorkflow')
 
+resolveGitDir.mockImplementation(async () => normalize(process.cwd()))
 getStagedFiles.mockImplementation(async () => [])
 
-const globalConsoleTemp = global.console
+const globalConsoleTemp = console
 
 describe('runAll', () => {
   beforeAll(() => {
-    global.console = makeConsoleMock()
+    console = makeConsoleMock()
   })
 
   afterEach(() => {
-    global.console.clearHistory()
+    console.clearHistory()
     gitStashSave.mockClear()
     gitStashPop.mockClear()
     updateStash.mockClear()
   })
 
   afterAll(() => {
-    global.console = globalConsoleTemp
+    console = globalConsoleTemp
   })
 
   it('should not throw when a valid config is provided', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4296,6 +4296,11 @@ normalize-path@^2.1.1:
   dependencies:
     remove-trailing-separator "^1.0.1"
 
+normalize-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
+  integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
+
 npm-bundled@^1.0.1:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.6.tgz#e7ba9aadcef962bb61248f91721cd932b3fe6bdd"


### PR DESCRIPTION
This PR adds the [normalize-path](https://github.com/jonschlinkert/normalize-path) module for always converting file paths to unix-like forward slashes. It also fixes a bug in `generateTasks` where absolute paths were resolved incorrectly when the working directory is a sub directory of the git repository.

## TODO
- [x] Figure out why some tests started failing