### PR TITLE
fix: validateConfig validates function task return values

### DIFF
--- a/test/__snapshots__/validateConfig.spec.js.snap
+++ b/test/__snapshots__/validateConfig.spec.js.snap
@@ -1,8 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`validateConfig should not throw and should print nothing for function linter 1`] = `""`;
+exports[`validateConfig should not throw and should print nothing for function task 1`] = `""`;
 
 exports[`validateConfig should not throw and should print nothing for valid config 1`] = `""`;
+
+exports[`validateConfig should not throw when config contains deprecated key but with valid task 1`] = `""`;
 
 exports[`validateConfig should throw and should print validation errors for invalid config 1`] = `
 "● Validation Error:
@@ -148,3 +150,15 @@ Please refer to https://github.com/okonet/lint-staged#configuration for more inf
 `;
 
 exports[`validateConfig should throw when detecting deprecated advanced configuration 2`] = `""`;
+
+exports[`validateConfig should throw when function task returns incorrect values 1`] = `
+"● Validation Error:
+
+  Invalid value for 'filenames => filenames.map(file => [\`eslint --fix \${file}\`, \`git add \${file}\`])'.
+
+  Function task should return a string or an array of strings.
+ 
+  Configured value is: [['eslint --fix [filename]', 'git add [filename]']]
+
+Please refer to https://github.com/okonet/lint-staged#configuration for more information..."
+`;

--- a/test/validateConfig.spec.js
+++ b/test/validateConfig.spec.js
@@ -36,7 +36,7 @@ describe('validateConfig', () => {
     expect(console.printHistory()).toMatchSnapshot()
   })
 
-  it('should not throw and should print nothing for function linter', () => {
+  it('should not throw and should print nothing for function task', () => {
     expect(() =>
       validateConfig({
         '*.js': filenames => {
@@ -47,6 +47,13 @@ describe('validateConfig', () => {
       })
     ).not.toThrow()
     expect(console.printHistory()).toMatchSnapshot()
+  })
+
+  it('should throw when function task returns incorrect values', () => {
+    const invalidConfig = {
+      '*.js': filenames => filenames.map(file => [`eslint --fix ${file}`, `git add ${file}`])
+    }
+    expect(() => validateConfig(invalidConfig)).toThrowErrorMatchingSnapshot()
   })
 
   it('should throw when detecting deprecated advanced configuration', () => {
@@ -64,6 +71,14 @@ describe('validateConfig', () => {
     }
 
     expect(() => validateConfig(advancedConfig)).toThrowErrorMatchingSnapshot()
+    expect(console.printHistory()).toMatchSnapshot()
+  })
+
+  it('should not throw when config contains deprecated key but with valid task', () => {
+    const stillValidConfig = {
+      concurrent: 'my command'
+    }
+    expect(() => validateConfig(stillValidConfig)).not.toThrow()
     expect(console.printHistory()).toMatchSnapshot()
   })
 })


### PR DESCRIPTION
This PR adds more precise validation of function tasks, which should be of the form `(filenames: string[]) => string | string[]`. Specifically, the return value is validated by supplying the task with an array of single filename `['[filename]']`.

#### Fixes:
- [x] https://github.com/okonet/lint-staged/issues/680