### PR TITLE
docs: fix example with paths relative from git repo root

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ Linter commands work on a subset of all staged files, defined by a _glob pattern
   * **`"*.js"`** will match all JS files, like `/test.js` and `/foo/bar/test.js`
   * **`"!(*test).js"`**. will match all JS files, except those ending in `test.js`, so `foo.js` but not `foo.test.js`
 * If the glob pattern does contain a slash (`/`), it will match for paths as well:
-  * **`"/*.js"`** will match all JS files in the git repo root, so `/test.js` but not `/foo/bar/test.js`
-  * **`"foo/**/\*.js"`** will match all JS files inside the`/foo`directory, so`/foo/bar/test.js`but not`/test.js`
+  * **`"/*.js"`** will match all JS files in the git repo root, so `./test.js` but not `./foo/bar/test.js`
+  * **`"foo/**/\*.js"`** will match all JS files inside the `./foo` directory, so `./foo/bar/test.js` but not `./test.js`
 
 When matching, `lint-staged` will do the following
 


### PR DESCRIPTION
This PR fixes the readme's glob option to match files from the git root, since the filepaths globbed are absolute.

Fixes https://github.com/okonet/lint-staged/issues/689