### PR TITLE
fix: include renames when getting list of staged files

### DIFF
--- a/src/getStagedFiles.js
+++ b/src/getStagedFiles.js
@@ -4,7 +4,7 @@ const execGit = require('./execGit')
 
 module.exports = async function getStagedFiles(options) {
   try {
-    const lines = await execGit(['diff', '--staged', '--diff-filter=ACM', '--name-only'], options)
+    const lines = await execGit(['diff', '--staged', '--diff-filter=ACMR', '--name-only'], options)
     return lines ? lines.split('\n') : []
   } catch (error) {
     return null


### PR DESCRIPTION
This PR adds the `R` to diff-filter when getting list of staged files, for when git decides a file has been renamed. Fixes https://github.com/okonet/lint-staged/issues/683.

Should we add a new test for renames, @okonet? It seems everything is working fine, but if you had doubts about it causing issues, maybe a test would be nice.