### PR TITLE
Allow to pass config instead of configPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,20 @@ const success = await lintStaged({
 })
 ```
 
+You can also pass config directly with `config` option:
+
+
+```js
+const success = await lintStaged({
+  config: {
+    '*.js': 'eslint --fix'
+  },
+  shell: false,
+  quiet: false,
+  debug: false
+})
+```
+
 ### Using with JetBrains IDEs _(WebStorm, PyCharm, IntelliJ IDEA, RubyMine, etc.)_
 
 _**Update**_: The latest version of JetBrains IDEs now support running hooks as you would expect.

--- a/src/index.js
+++ b/src/index.js
@@ -43,6 +43,7 @@ function loadConfig(configPath) {
  *
  * @param {object} options
  * @param {string} [options.configPath] - Path to configuration file
+ * @param {object}  [options.config] - Object with configuration for programmatic API
  * @param {boolean} [options.relative] - Pass relative filepaths to tasks
  * @param {boolean} [options.shell] - Skip parsing of tasks for better shell support
  * @param {boolean} [options.quiet] - Disable lint-staged’s own console output
@@ -52,12 +53,12 @@ function loadConfig(configPath) {
  * @returns {Promise<boolean>} Promise of whether the linting passed or failed
  */
 module.exports = function lintStaged(
-  { configPath, relative = false, shell = false, quiet = false, debug = false } = {},
+  { configPath, config, relative = false, shell = false, quiet = false, debug = false } = {},
   logger = console
 ) {
   debugLog('Loading config using `cosmiconfig`')
 
-  return loadConfig(configPath)
+  return (config ? Promise.resolve({ config, filepath: '(input)' }) : loadConfig(configPath))
     .then(result => {
       if (result == null) throw errConfigNotFound
 


### PR DESCRIPTION
It would be very useful if someone wants to use lint-staged as library (me)