### PR TITLE
Create shorter title for function tasks with many staged files

### DIFF
--- a/src/runAll.js
+++ b/src/runAll.js
@@ -73,7 +73,7 @@ https://github.com/okonet/lint-staged#using-js-functions-to-customize-linter-com
     title: `Running tasks for ${task.pattern}`,
     task: async () =>
       new Listr(
-        await makeCmdTasks({ commands: task.commands, gitDir, shell, pathsToLint: task.fileList }),
+        await makeCmdTasks({ commands: task.commands, files: task.fileList, gitDir, shell }),
         {
           // In sub-tasks we don't want to run concurrently
           // and we want to abort on errors

--- a/test/makeCmdTasks.spec.js
+++ b/test/makeCmdTasks.spec.js
@@ -9,13 +9,13 @@ describe('makeCmdTasks', () => {
   })
 
   it('should return an array', async () => {
-    const array = await makeCmdTasks({ commands: 'test', gitDir, pathsToLint: ['test.js'] })
+    const array = await makeCmdTasks({ commands: 'test', gitDir, files: ['test.js'] })
     expect(array).toBeInstanceOf(Array)
   })
 
   it('should work with a single command', async () => {
     expect.assertions(4)
-    const res = await makeCmdTasks({ commands: 'test', gitDir, pathsToLint: ['test.js'] })
+    const res = await makeCmdTasks({ commands: 'test', gitDir, files: ['test.js'] })
     expect(res.length).toBe(1)
     const [linter] = res
     expect(linter.title).toBe('test')
@@ -30,7 +30,7 @@ describe('makeCmdTasks', () => {
     const res = await makeCmdTasks({
       commands: ['test', 'test2'],
       gitDir,
-      pathsToLint: ['test.js']
+      files: ['test.js']
     })
     expect(res.length).toBe(2)
     const [linter1, linter2] = res
@@ -58,7 +58,7 @@ describe('makeCmdTasks', () => {
   })
 
   it('should work with function linter returning a string', async () => {
-    const res = await makeCmdTasks({ commands: () => 'test', gitDir, pathsToLint: ['test.js'] })
+    const res = await makeCmdTasks({ commands: () => 'test', gitDir, files: ['test.js'] })
     expect(res.length).toBe(1)
     expect(res[0].title).toEqual('test')
   })
@@ -67,7 +67,7 @@ describe('makeCmdTasks', () => {
     const res = await makeCmdTasks({
       commands: () => ['test', 'test2'],
       gitDir,
-      pathsToLint: ['test.js']
+      files: ['test.js']
     })
     expect(res.length).toBe(2)
     expect(res[0].title).toEqual('test')
@@ -78,7 +78,7 @@ describe('makeCmdTasks', () => {
     const res = await makeCmdTasks({
       commands: filenames => filenames.map(file => `test ${file}`),
       gitDir,
-      pathsToLint: ['test.js', 'test2.js']
+      files: ['test.js', 'test2.js']
     })
     expect(res.length).toBe(2)
     expect(res[0].title).toEqual('test test.js')
@@ -89,7 +89,7 @@ describe('makeCmdTasks', () => {
     const res = await makeCmdTasks({
       commands: [() => 'test', 'test2', files => files.map(file => `test ${file}`)],
       gitDir,
-      pathsToLint: ['test.js', 'test2.js', 'test3.js']
+      files: ['test.js', 'test2.js', 'test3.js']
     })
     expect(res.length).toBe(5)
     expect(res[0].title).toEqual('test')

--- a/test/makeCmdTasks.spec.js
+++ b/test/makeCmdTasks.spec.js
@@ -81,8 +81,8 @@ describe('makeCmdTasks', () => {
       files: ['test.js', 'test2.js']
     })
     expect(res.length).toBe(2)
-    expect(res[0].title).toEqual('test test.js')
-    expect(res[1].title).toEqual('test test2.js')
+    expect(res[0].title).toEqual('test [file]')
+    expect(res[1].title).toEqual('test [file]')
   })
 
   it('should work with array of mixed string and function linters', async () => {
@@ -94,8 +94,18 @@ describe('makeCmdTasks', () => {
     expect(res.length).toBe(5)
     expect(res[0].title).toEqual('test')
     expect(res[1].title).toEqual('test2')
-    expect(res[2].title).toEqual('test test.js')
-    expect(res[3].title).toEqual('test test2.js')
-    expect(res[4].title).toEqual('test test3.js')
+    expect(res[2].title).toEqual('test [file]')
+    expect(res[3].title).toEqual('test [file]')
+    expect(res[4].title).toEqual('test [file]')
+  })
+
+  it('should generate short names for function tasks with long file list', async () => {
+    const res = await makeCmdTasks({
+      commands: filenames => `test ${filenames.map(file => `--file ${file}`).join(' ')}`,
+      gitDir,
+      files: Array(100).fill('file.js') // 100 times `file.js`
+    })
+    expect(res.length).toBe(1)
+    expect(res[0].title).toEqual('test --file [file]')
   })
 })

--- a/test/resolveTaskFn.spec.js
+++ b/test/resolveTaskFn.spec.js
@@ -1,7 +1,7 @@
 import execa from 'execa'
 import resolveTaskFn from '../src/resolveTaskFn'
 
-const defaultOpts = { pathsToLint: ['test.js'] }
+const defaultOpts = { files: ['test.js'] }
 
 describe('resolveTaskFn', () => {
   beforeEach(() => {
@@ -12,7 +12,7 @@ describe('resolveTaskFn', () => {
     expect.assertions(2)
     const taskFn = resolveTaskFn({
       ...defaultOpts,
-      linter: 'node --arg=true ./myscript.js'
+      command: 'node --arg=true ./myscript.js'
     })
 
     await taskFn()
@@ -29,7 +29,7 @@ describe('resolveTaskFn', () => {
     const taskFn = resolveTaskFn({
       ...defaultOpts,
       isFn: true,
-      linter: 'node --arg=true ./myscript.js test.js'
+      command: 'node --arg=true ./myscript.js test.js'
     })
 
     await taskFn()
@@ -47,7 +47,7 @@ describe('resolveTaskFn', () => {
       ...defaultOpts,
       isFn: true,
       shell: true,
-      linter: 'node --arg=true ./myscript.js test.js'
+      command: 'node --arg=true ./myscript.js test.js'
     })
 
     await taskFn()
@@ -64,7 +64,7 @@ describe('resolveTaskFn', () => {
     const taskFn = resolveTaskFn({
       ...defaultOpts,
       shell: true,
-      linter: 'node --arg=true ./myscript.js'
+      command: 'node --arg=true ./myscript.js'
     })
 
     await taskFn()
@@ -80,7 +80,7 @@ describe('resolveTaskFn', () => {
     expect.assertions(2)
     const taskFn = resolveTaskFn({
       ...defaultOpts,
-      linter: 'git add',
+      command: 'git add',
       gitDir: '../'
     })
 
@@ -96,7 +96,7 @@ describe('resolveTaskFn', () => {
 
   it('should not pass `gitDir` as `cwd` to `execa()` if a non-git binary is called', async () => {
     expect.assertions(2)
-    const taskFn = resolveTaskFn({ ...defaultOpts, linter: 'jest', gitDir: '../' })
+    const taskFn = resolveTaskFn({ ...defaultOpts, command: 'jest', gitDir: '../' })
 
     await taskFn()
     expect(execa).toHaveBeenCalledTimes(1)
@@ -111,7 +111,7 @@ describe('resolveTaskFn', () => {
     expect.assertions(2)
     const taskFn = resolveTaskFn({
       ...defaultOpts,
-      linter: 'git add',
+      command: 'git add',
       relative: true
     })
 
@@ -135,7 +135,7 @@ describe('resolveTaskFn', () => {
       cmd: 'mock cmd'
     })
 
-    const taskFn = resolveTaskFn({ ...defaultOpts, linter: 'mock-fail-linter' })
+    const taskFn = resolveTaskFn({ ...defaultOpts, command: 'mock-fail-linter' })
     try {
       await taskFn()
     } catch (err) {
@@ -161,7 +161,7 @@ Mock error"
       cmd: 'mock cmd'
     })
 
-    const taskFn = resolveTaskFn({ ...defaultOpts, linter: 'mock-killed-linter' })
+    const taskFn = resolveTaskFn({ ...defaultOpts, command: 'mock-killed-linter' })
     try {
       await taskFn()
     } catch (err) {
@@ -177,7 +177,7 @@ Mock error"
   it('should not set hasErrors on context if no error occur', async () => {
     expect.assertions(1)
     const context = {}
-    const taskFn = resolveTaskFn({ ...defaultOpts, linter: 'jest', gitDir: '../' })
+    const taskFn = resolveTaskFn({ ...defaultOpts, command: 'jest', gitDir: '../' })
     await taskFn(context)
     expect(context.hasErrors).toBeUndefined()
   })
@@ -191,7 +191,7 @@ Mock error"
       cmd: 'mock cmd'
     })
     const context = {}
-    const taskFn = resolveTaskFn({ ...defaultOpts, linter: 'mock-fail-linter' })
+    const taskFn = resolveTaskFn({ ...defaultOpts, command: 'mock-fail-linter' })
     expect.assertions(1)
     try {
       await taskFn(context)

--- a/test/resolveTaskFn.unmocked.spec.js
+++ b/test/resolveTaskFn.unmocked.spec.js
@@ -5,9 +5,9 @@ jest.unmock('execa')
 describe('resolveTaskFn', () => {
   it('should call execa with shell when configured so', async () => {
     const taskFn = resolveTaskFn({
-      pathsToLint: ['package.json'],
+      command: 'node -e "process.exit(1)" || echo $?',
+      files: ['package.json'],
       isFn: true,
-      linter: 'node -e "process.exit(1)" || echo $?',
       shell: true
     })
 

--- a/test/runAll.unmocked.spec.js
+++ b/test/runAll.unmocked.spec.js
@@ -172,16 +172,9 @@ describe('runAll', () => {
     expect(await execGit(['show', 'HEAD:test.js'])).toEqual(testJsFilePretty.replace(/\n$/, ''))
 
     // Since edit was not staged, the file is still modified
-    expect(await execGit(['status'])).toMatchInlineSnapshot(`
-"On branch master
-Changes not staged for commit:
-  (use \\"git add <file>...\\" to update what will be committed)
-  (use \\"git checkout -- <file>...\\" to discard changes in working directory)
-
-	modified:   test.js
-
-no changes added to commit (use \\"git add\\" and/or \\"git commit -a\\")"
-`)
+    const status = await execGit(['status'])
+    expect(status).toMatch('modified:   test.js')
+    expect(status).toMatch('no changes added to commit')
     expect(await readFile('test.js')).toEqual(testJsFilePretty + appended)
   })
 
@@ -210,16 +203,9 @@ no changes added to commit (use \\"git add\\" and/or \\"git commit -a\\")"
     expect(await execGit(['show', 'HEAD:test.js'])).toEqual(testJsFilePretty.replace(/\n$/, ''))
 
     // Nothing is staged
-    expect(await execGit(['status'])).toMatchInlineSnapshot(`
-"On branch master
-Changes not staged for commit:
-  (use \\"git add <file>...\\" to update what will be committed)
-  (use \\"git checkout -- <file>...\\" to discard changes in working directory)
-
-	modified:   test.js
-
-no changes added to commit (use \\"git add\\" and/or \\"git commit -a\\")"
-`)
+    const status = await execGit(['status'])
+    expect(status).toMatch('modified:   test.js')
+    expect(status).toMatch('no changes added to commit')
 
     // File is pretty, and has been edited
     expect(await readFile('test.js')).toEqual(testJsFilePretty + appended)


### PR DESCRIPTION
This PR makes function task titles shorter by omitting the full list of staged filenames, instead passing them a single `[file]` as the argument. This means the task still shows the expected function, but is shorter; for example `eslint --fix [file] && git add [file]`.

The mechanism of creating the title is a bit complex, since we need to first create as long an array of `[file]` strings and evaluate the function task against it. This makes sure the output is the same as for the actual file list. After this, from a single command string multiple `[file]` entries are truncated into one, so for example `ng lint --file [file] --file [file] --file [file]` turns into `ng lint --file [file]`.

I also refactored away usages of `linter` to more generic `task` and `command`.

Fixes https://github.com/okonet/lint-staged/issues/674