### PR TITLE
fix: create fn title with mock file list of correct length

### DIFF
--- a/src/makeCmdTasks.js
+++ b/src/makeCmdTasks.js
@@ -28,7 +28,7 @@ module.exports = async function makeCmdTasks({ commands, files, gitDir, shell })
     // Create a matching command array with [file] in place of file names
     let mockCommands
     if (isFn) {
-      const mockFileList = Array(commands.length).fill('[file]')
+      const mockFileList = Array(files.length).fill('[file]')
       const resolved = command(mockFileList)
       mockCommands = Array.isArray(resolved) ? resolved : [resolved]
     }

--- a/src/makeCmdTasks.js
+++ b/src/makeCmdTasks.js
@@ -34,9 +34,13 @@ module.exports = async function makeCmdTasks({ commands, files, gitDir, shell })
     }
 
     commands.forEach((command, i) => {
-      // If command is a function, use the matching mock command as title,
-      // but since might include multiple [file] arguments, shorten to one
-      const title = isFn ? mockCommands[i].replace(/\[file\].*\[file\]/, '[file]') : command
+      let title = isFn ? '[Function]' : command
+      if (isFn && mockCommands[i]) {
+        // If command is a function, use the matching mock command as title,
+        // but since might include multiple [file] arguments, shorten to one
+        title = mockCommands[i].replace(/\[file\].*\[file\]/, '[file]')
+      }
+
       const task = { title, task: resolveTaskFn({ gitDir, isFn, command, files, shell }) }
       tasks.push(task)
     })


### PR DESCRIPTION
I made a mistake on https://github.com/okonet/lint-staged/pull/706 where the title for function tasks is generated by creating a mock array of filenames with the length of the matched functions, when it instead should be the the length of the staged files array. This causes failures with function linters in some situations.

Should fix the problem reported by @VitorLuizC in https://github.com/okonet/lint-staged/pull/706#issuecomment-538075240.