### PR TITLE
build: Use semantic-release@16.0.0-beta to enable prerelease channels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ after_script: greenkeeper-lockfile-upload
 after_success:
   - bash <(curl -s https://codecov.io/bash)
   - yarn global add travis-deploy-once@4
-  - travis-deploy-once "yarn global add semantic-release && semantic-release"
+  - travis-deploy-once "yarn global add semantic-release@beta && semantic-release"
 
 notifications:
   email: false
@@ -30,4 +30,7 @@ branches:
   only:
     - master
     - next
+    - next-major
+    - beta
+    - alpha
     - /^greenkeeper/.*$/


### PR DESCRIPTION
This PR should enable pre-release channels as documented in https://github.com/semantic-release/semantic-release/blob/beta/docs/recipes/pre-releases.md#publishing-pre-releases