### PR TITLE
Fix root-dir-only example

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Linter commands work on a subset of all staged files, defined by a _glob pattern
   - **`"*.js"`** will match all JS files, like `/test.js` and `/foo/bar/test.js`
   - **`"!(*test).js"`**. will match all JS files, except those ending in `test.js`, so `foo.js` but not `foo.test.js`
 - If the glob pattern does contain a slash (`/`), it will match for paths as well:
-  - **`"/*.js"`** will match all JS files in the git repo root, so `/test.js` but not `/foo/bar/test.js`
+  - **`"./*.js"`** will match all JS files in the git repo root, so `/test.js` but not `/foo/bar/test.js`
   - **`"foo/**/\*.js"`** will match all JS files inside the`/foo`directory, so`/foo/bar/test.js`but not`/test.js`
 
 When matching, `lint-staged` will do the following


### PR DESCRIPTION
In the README, an example is given for how to match only files in the root directory of the repository.  One crucial character is missing, however, preventing the example from working.  Specifically, the example needs to begin with `./` (not just `/`) in order to be interpreted as a relative path but not to trigger setting micromatch's `matchBase` option.  Without that dot, the path is interpreted as an absolute one and fails to match as a relative path.