### PR TITLE
WIP Setup GitHub Actions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,36 @@
+name: Node CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        node-version: [8.x, 10.x, 12.x]
+        os: [macos-latest, windows-latest, ubuntu-latest]
+      # temp during testing
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: yarn install #and test
+      run: |
+        yarn install
+        #yarn test
+      env:
+        CI: true
+    - name: yarn test
+      run: yarn test
+      env:
+        CI: true
+
+    - uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }} #See https://github.com/marketplace/actions/codecov

--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -1,0 +1,30 @@
+name: Node.js Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - run: yarn install
+      - run: yarn test
+
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+      - run: yarn global add semantic-release && semantic-release
+        # The above is expected to fail during testing because I don't have credentials ;)
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
This closes #503 (replaces)

Since GitHub Actions is now out of beta, I've redone my branch, squashed my commits, and this is ready for further discussion. I figured a pull request would be appropriate so that changes can be reviewed.

For the moment windows builds are not passing. With node 8.x this appears to be a dependency version issue (although it is odd that this does not affect macos or ubuntu using node 8.x). With newer versions of node (10.x and 12.x) there seem to be other issues that may need actual fixes to the code.

CodeCov is setup in `.github/workflows/nodejs.yml` however to run correctly it will need `CODECOV_TOKEN` per the documentation https://github.com/marketplace/actions/codecov

`.github/workflows/npmpublish.yml` is setup to only run when a release is tagged in GitHub. The idea is tagging a release in GitHub would trigger this workflow to publish the package to npm. I do not know the specifics of `yarn` and the `semantic-release` package being used, but I imagine this may need to be changed to something else.