### PR TITLE
feat: add --bail option for erroring when tasks modify staged files

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,20 +46,19 @@ $ npx lint-staged --help
 Usage: lint-staged [options]
 
 Options:
-  -V, --version                     output the version number
+  --bail                            Exit with status 1 if tasks modify any files
   -c, --config [path]               Path to configuration file
-  -r, --relative                    Pass relative filepaths to tasks
-  -x, --shell                       Skip parsing of tasks for better shell support
-  -q, --quiet                       Disable lint-staged’s own console output
   -d, --debug                       Enable debug mode
-  -p, --concurrent [parallel tasks] The number of tasks to run concurrently, or false to run tasks sequentially
   -h, --help                        output usage information
+  -p, --concurrent [parallel tasks] The number of tasks to run concurrently, or false to run tasks sequentially
+  -q, --quiet                       Disable lint-staged’s own console output
+  -r, --relative                    Pass relative filepaths to tasks
+  -V, --version                     output the version number
+  -x, --shell                       Skip parsing of tasks for better shell support
 ```
 
+- **`--bail`**: Configures lint-staged to exit with status 1 (error) when any tasks modify files. This will typically abort the commit. Useful when you want to manually review any changes by tasks before committing. Will leave any modifications as-is instead of reverting to the original state.
 - **`--config [path]`**: This can be used to manually specify the `lint-staged` config file location. However, if the specified file cannot be found, it will error out instead of performing the usual search. You may pass a npm package name for configuration also.
-- **`--relative`**: By default filepaths will be passed to the linter tasks as _absolute_. This flag makes them relative to `process.cwd()` (where `lint-staged` runs).
-- **`--shell`**: By default linter commands will be parsed for speed and security. This has the side-effect that regular shell scripts might not work as expected. You can skip parsing of commands with this option.
-- **`--quiet`**: By default `lint-staged` will print progress status to console while running linters. Use this flag to supress all output, except for linter scripts.
 - **`--debug`**: Enabling the debug mode does the following:
   - `lint-staged` uses the [debug](https://github.com/visionmedia/debug) module internally to log information about staged files, commands being executed, location of binaries, etc. Debug logs, which are automatically enabled by passing the flag, can also be enabled by setting the environment variable `$DEBUG` to `lint-staged*`.
   - Use the [`verbose` renderer](https://github.com/SamVerschueren/listr-verbose-renderer) for `listr`.
@@ -67,6 +66,9 @@ Options:
   - `false`: Run all tasks serially
   - `true` (default) : _Infinite_ concurrency. Runs as many tasks in parallel as possible.
   - `{number}`: Run the specified number of tasks in parallel, where `1` is equivalent to `false`.
+- **`--quiet`**: By default `lint-staged` will print progress status to console while running linters. Use this flag to supress all output, except for linter scripts.
+- **`--relative`**: By default filepaths will be passed to the linter tasks as _absolute_. This flag makes them relative to `process.cwd()` (where `lint-staged` runs).
+- **`--shell`**: By default linter commands will be parsed for speed and security. This has the side-effect that regular shell scripts might not work as expected. You can skip parsing of commands with this option.
 
 ## Configuration
 
@@ -398,12 +400,14 @@ Parameters to `lintStaged` are equivalent to their CLI counterparts:
 
 ```js
 const success = await lintStaged({
+  bail: false,
+  concurrent: true,
   configPath: './path/to/configuration/file',
+  debug: false,
   maxArgLength: null,
-  relative: false,
-  shell: false,
   quiet: false,
-  debug: false
+  relative: false,
+  shell: false
 })
 ```
 
@@ -411,14 +415,16 @@ You can also pass config directly with `config` option:
 
 ```js
 const success = await lintStaged({
+  bail: false,
   config: {
     '*.js': 'eslint --fix'
   },
+  concurrent: true,
+  debug: false,
   maxArgLength: null,
-  relative: false,
-  shell: false,
   quiet: false,
-  debug: false
+  relative: false,
+  shell: false
 })
 ```
 

--- a/bin/lint-staged
+++ b/bin/lint-staged
@@ -29,16 +29,17 @@ const debug = debugLib('lint-staged:bin')
 
 cmdline
   .version(pkg.version)
+  .option('--bail', 'Exit with status 1 if tasks modify any files')
   .option('-c, --config [path]', 'Path to configuration file')
-  .option('-r, --relative', 'Pass relative filepaths to tasks')
-  .option('-x, --shell', 'Skip parsing of tasks for better shell support')
-  .option('-q, --quiet', 'Disable lint-staged’s own console output')
   .option('-d, --debug', 'Enable debug mode')
   .option(
     '-p, --concurrent <parallel tasks>',
     'The number of tasks to run concurrently, or false to run tasks serially',
     true
   )
+  .option('-r, --relative', 'Pass relative filepaths to tasks')
+  .option('-x, --shell', 'Skip parsing of tasks for better shell support')
+  .option('-q, --quiet', 'Disable lint-staged’s own console output')
   .parse(process.argv)
 
 if (cmdline.debug) {
@@ -66,13 +67,14 @@ const getMaxArgLength = () => {
 }
 
 const options = {
+  bail: !!cmdline.bail,
   configPath: cmdline.config,
+  debug: !!cmdline.debug,
   maxArgLength: getMaxArgLength() / 2,
+  concurrent: cmdline.concurrent,
+  quiet: !!cmdline.quiet,
   relative: !!cmdline.relative,
   shell: !!cmdline.shell,
-  quiet: !!cmdline.quiet,
-  debug: !!cmdline.debug,
-  concurrent: cmdline.concurrent
 }
 
 debug('Options parsed from command-line:', options)

--- a/lib/gitWorkflow.js
+++ b/lib/gitWorkflow.js
@@ -103,7 +103,8 @@ class GitWorkflow {
    */
   async applyModifications() {
     let modifiedFiles = await this.execGit(['ls-files', '--modified'])
-    if (modifiedFiles) {
+    // modifications shouldn't be staged when --bail was used
+    if (modifiedFiles && !this.bail) {
       modifiedFiles = modifiedFiles.split('\n')
       debug('Detected files modified by tasks:')
       debug(modifiedFiles)
@@ -145,6 +146,7 @@ class GitWorkflow {
       }
     } catch (err) {} // eslint-disable-line no-empty
 
+    // Exit with error when modifications by tasks and --bail was used
     if (modifiedFiles && this.bail) {
       throw new Error('Exited because --bail was used and there were modifications by tasks')
     }

--- a/lib/gitWorkflow.js
+++ b/lib/gitWorkflow.js
@@ -15,18 +15,19 @@ const STASH = 'lint-staged automatic backup'
 const gitApplyArgs = ['apply', '-v', '--whitespace=nowarn', '--recount', '--unidiff-zero']
 
 class GitWorkflow {
-  constructor(cwd) {
-    this.execGit = (args, options = {}) => execGit(args, { ...options, cwd })
+  constructor({ bail, gitDir }) {
+    this.execGit = (args, options = {}) => execGit(args, { ...options, cwd: gitDir })
     this.unstagedDiff = null
-    this.cwd = cwd
+    this.gitDir = gitDir
+    this.bail = !!bail
 
     /**
      * These three files hold state about an ongoing git merge
      * Resolve paths during constructor
      */
-    this.mergeHeadFile = path.resolve(this.cwd, '.git', MERGE_HEAD)
-    this.mergeModeFile = path.resolve(this.cwd, '.git', MERGE_MODE)
-    this.mergeMsgFile = path.resolve(this.cwd, '.git', MERGE_MSG)
+    this.mergeHeadFile = path.resolve(this.gitDir, '.git', MERGE_HEAD)
+    this.mergeModeFile = path.resolve(this.gitDir, '.git', MERGE_MODE)
+    this.mergeMsgFile = path.resolve(this.gitDir, '.git', MERGE_MSG)
   }
 
   /**
@@ -139,9 +140,14 @@ class GitWorkflow {
       const backupStash = await this.getBackupStash()
       const output = await this.execGit(['show', '--format=%b', `${backupStash}^3`])
       const untrackedDiff = output.replace(/^\n*/, '') // remove empty lines from start of output
-      if (!untrackedDiff) return
-      await this.execGit([...gitApplyArgs], { input: `${untrackedDiff}\n` })
+      if (untrackedDiff) {
+        await this.execGit([...gitApplyArgs], { input: `${untrackedDiff}\n` })
+      }
     } catch (err) {} // eslint-disable-line no-empty
+
+    if (modifiedFiles && this.bail) {
+      throw new Error('Exited because --bail was used and there were modifications by tasks')
+    }
   }
 
   /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -42,28 +42,30 @@ function loadConfig(configPath) {
  * Root lint-staged function that is called from `bin/lint-staged`.
  *
  * @param {object} options
- * @param {string} [options.configPath] - Path to configuration file
+ * @param {object}  [options.bail] - Exit with status 1 if tasks modify any files
+ * @param {boolean | number} [options.concurrent] - The number of tasks to run concurrently, or false to run tasks serially
  * @param {object}  [options.config] - Object with configuration for programmatic API
+ * @param {string} [options.configPath] - Path to configuration file
+ * @param {boolean} [options.debug] - Enable debug mode
  * @param {number} [options.maxArgLength] - Maximum argument string length
+ * @param {boolean} [options.quiet] - Disable lint-staged’s own console output
  * @param {boolean} [options.relative] - Pass relative filepaths to tasks
  * @param {boolean} [options.shell] - Skip parsing of tasks for better shell support
- * @param {boolean} [options.quiet] - Disable lint-staged’s own console output
- * @param {boolean} [options.debug] - Enable debug mode
- * @param {boolean | number} [options.concurrent] - The number of tasks to run concurrently, or false to run tasks serially
  * @param {Logger} [logger]
  *
  * @returns {Promise<boolean>} Promise of whether the linting passed or failed
  */
 module.exports = async function lintStaged(
   {
-    configPath,
+    bail = false,
+    concurrent = true,
     config: configObject,
-    maxArgLength,
-    relative = false,
-    shell = false,
-    quiet = false,
+    configPath,
     debug = false,
-    concurrent = true
+    maxArgLength,
+    quiet = false,
+    relative = false,
+    shell = false
   } = {},
   logger = console
 ) {
@@ -90,7 +92,10 @@ module.exports = async function lintStaged(
     }
 
     try {
-      await runAll({ config, maxArgLength, relative, shell, quiet, debug, concurrent }, logger)
+      await runAll(
+        { bail, concurrent, config, debug, maxArgLength, quiet, relative, shell },
+        logger
+      )
       debugLog('tasks were executed successfully!')
       return true
     } catch (runAllError) {

--- a/lib/runAll.js
+++ b/lib/runAll.js
@@ -19,27 +19,29 @@ const debugLog = require('debug')('lint-staged:run')
  * Executes all tasks and either resolves or rejects the promise
  *
  * @param {object} options
+ * @param {object}  [options.bail] - Exit with status 1 if tasks modify any files
+ * @param {boolean | number} [options.concurrent] - The number of tasks to run concurrently, or false to run tasks serially
  * @param {Object} [options.config] - Task configuration
  * @param {Object} [options.cwd] - Current working directory
+ * @param {boolean} [options.debug] - Enable debug mode
  * @param {number} [options.maxArgLength] - Maximum argument string length
  * @param {boolean} [options.relative] - Pass relative filepaths to tasks
  * @param {boolean} [options.shell] - Skip parsing of tasks for better shell support
  * @param {boolean} [options.quiet] - Disable lint-staged’s own console output
- * @param {boolean} [options.debug] - Enable debug mode
- * @param {boolean | number} [options.concurrent] - The number of tasks to run concurrently, or false to run tasks serially
  * @param {Logger} logger
  * @returns {Promise}
  */
 module.exports = async function runAll(
   {
+    bail = false,
+    concurrent = true,
     config,
     cwd = process.cwd(),
     debug = false,
     maxArgLength,
     quiet = false,
     relative = false,
-    shell = false,
-    concurrent = true
+    shell = false
   },
   logger = console
 ) {
@@ -139,7 +141,7 @@ module.exports = async function runAll(
     return 'No tasks to run.'
   }
 
-  const git = new GitWorkflow(gitDir)
+  const git = new GitWorkflow({ bail, gitDir })
 
   const runner = new Listr(
     [
@@ -173,6 +175,19 @@ module.exports = async function runAll(
       logger.error(`
   ${symbols.error} ${chalk.red(`lint-staged failed due to a git error.
     Any lost modifications can be restored from a git stash:
+
+    > git stash list
+    stash@{0}: On master: automatic lint-staged backup
+    > git stash pop stash@{0}`)}
+`)
+    }
+
+    if (error.message.includes('--bail')) {
+      logger.error(`
+  ${
+    symbols.error
+  } ${chalk.red(`lint-staged failed because --bail was used and there were modifications by tasks.
+    Task modifications were left as staged. The original state before committing can be restored from a git stash:
 
     > git stash list
     stash@{0}: On master: automatic lint-staged backup

--- a/test/runAll.unmocked.spec.js
+++ b/test/runAll.unmocked.spec.js
@@ -613,7 +613,7 @@ describe('runAll', () => {
     `)
     expect(await execGit(['rev-list', '--count', 'HEAD'])).toEqual('1')
     expect(await readFile('test.js')).toEqual(testJsFilePretty)
-    expect(await execGit(['status', '--porcelain'])).toMatchInlineSnapshot(`"A  test.js"`)
+    expect(await execGit(['status', '--porcelain'])).toMatchInlineSnapshot(`"AM test.js"`)
     expect(await execGit(['stash', 'list'])).toMatchInlineSnapshot(
       `"stash@{0}: On master: lint-staged automatic backup"`
     )


### PR DESCRIPTION
This PR adds a `--bail` option that makes lint-staged exit with status 1 when tasks modify any files. In this case, the modifications are ~staged~ left as unstaged, and instead of restoring the original state lint-staged simply leaves modifications as-is, and also keeps the original backup stash instead of dropping it.

This is useful in situation where manual review of tasks' modifications is needed. The backup stash can be used to easily return to the original state before committing.

Fixes https://github.com/okonet/lint-staged/issues/730