### PR TITLE
feat: add support for `--all` flag

### DIFF
--- a/bin/lint-staged
+++ b/bin/lint-staged
@@ -34,6 +34,7 @@ cmdline
   .option('-x, --shell', 'Skip parsing of tasks for better shell support')
   .option('-q, --quiet', 'Disable lint-staged’s own console output')
   .option('-d, --debug', 'Enable debug mode')
+  .option('-a, --all', 'Lint all committed files, not just those with staged changes')
   .option(
     '-p, --concurrent <parallel tasks>',
     'The number of tasks to run concurrently, or false to run tasks serially',
@@ -53,6 +54,7 @@ lintStaged({
   shell: !!cmdline.shell,
   quiet: !!cmdline.quiet,
   debug: !!cmdline.debug,
+  all: !!cmdline.all,
   concurrent: cmdline.concurrent
 })
   .then(passed => {

--- a/src/getStagedFiles.js
+++ b/src/getStagedFiles.js
@@ -4,7 +4,12 @@ const execGit = require('./execGit')
 
 module.exports = async function getStagedFiles(options) {
   try {
-    const lines = await execGit(['diff', '--staged', '--diff-filter=ACMR', '--name-only'], options)
+    const lines = await execGit(
+      options.all
+        ? ['ls-tree', '-r', 'HEAD', '--name-only']
+        : ['diff', '--staged', '--diff-filter=ACMR', '--name-only'],
+      options
+    )
     return lines ? lines.split('\n') : []
   } catch (error) {
     return null

--- a/src/getStagedFiles.js
+++ b/src/getStagedFiles.js
@@ -2,7 +2,7 @@
 
 const execGit = require('./execGit')
 
-module.exports = async function getStagedFiles(options) {
+module.exports = async function getStagedFiles(options = {}) {
   try {
     const lines = await execGit(
       options.all

--- a/src/index.js
+++ b/src/index.js
@@ -61,6 +61,7 @@ module.exports = function lintStaged(
     shell = false,
     quiet = false,
     debug = false,
+    all = false,
     concurrent = true
   } = {},
   logger = console
@@ -85,7 +86,7 @@ module.exports = function lintStaged(
         debugLog('lint-staged config:\n%O', config)
       }
 
-      return runAll({ config, relative, shell, quiet, debug, concurrent }, logger)
+      return runAll({ config, relative, shell, quiet, debug, all, concurrent }, logger)
         .then(() => {
           debugLog('tasks were executed successfully!')
           return Promise.resolve(true)

--- a/src/runAll.js
+++ b/src/runAll.js
@@ -45,6 +45,7 @@ module.exports = async function runAll(
     quiet = false,
     relative = false,
     shell = false,
+    all = false,
     concurrent = true
   },
   logger = console
@@ -58,7 +59,7 @@ module.exports = async function runAll(
 
   debugLog('Resolved git directory to be `%s`', gitDir)
 
-  const files = await getStagedFiles({ cwd: gitDir })
+  const files = await getStagedFiles({ cwd: gitDir, all })
 
   if (!files) {
     throw new Error('Unable to get staged files!')

--- a/test/getStagedFiles.spec.js
+++ b/test/getStagedFiles.spec.js
@@ -4,9 +4,27 @@ import execGit from '../src/execGit'
 jest.mock('../src/execGit')
 
 describe('getStagedFiles', () => {
-  it('should return array of file names', async () => {
-    execGit.mockImplementationOnce(async () => 'foo.js\nbar.js')
+  it('should return array of only staged file names when all is not specified', async () => {
+    execGit.mockImplementationOnce(async cmd =>
+      cmd[0] === 'ls-tree' ? 'foo.js\nbar.js\nbaz.js' : 'foo.js\nbar.js'
+    )
     const staged = await getStagedFiles()
+    expect(staged).toEqual(['foo.js', 'bar.js'])
+  })
+
+  it('should return array of all file names when all is true', async () => {
+    execGit.mockImplementationOnce(async cmd =>
+      cmd[0] === 'ls-tree' ? 'foo.js\nbar.js\nbaz.js' : 'foo.js\nbar.js'
+    )
+    const staged = await getStagedFiles({ all: true })
+    expect(staged).toEqual(['foo.js', 'bar.js', 'baz.js'])
+  })
+
+  it('should return array of only staged file names when all is false', async () => {
+    execGit.mockImplementationOnce(async cmd =>
+      cmd[0] === 'ls-tree' ? 'foo.js\nbar.js\nbaz.js' : 'foo.js\nbar.js'
+    )
+    const staged = await getStagedFiles({ all: false })
     expect(staged).toEqual(['foo.js', 'bar.js'])
   })
 


### PR DESCRIPTION
Allows you to run your linters against all committed files, not just those with staged changes.

This makes it possible to use `lint-staged` to double-check your entire codebase in a CI job, instead of only checking files that have been changed. This also serves as a way to check which files match your `lint-staged` configuration, and keeps you from having to duplicate that configuration in another tool in order to run linters in CI.