### PR TITLE
docs: add funding property to package.json linking to Open Collective

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "Suhas Karanth <sudo.suhas@gmail.com>",
     "Iiro Jäppinen <iiro@jappinen.fi> (https://iiro.fi)"
   ],
+  "funding": {
+    "url": "https://opencollective.com/lint-staged"
+  },
   "main": "./src/index.js",
   "bin": "./bin/lint-staged",
   "files": [


### PR DESCRIPTION
This PR adds the npm funding property, which will show a notification when using `npm install`. It also enables the `npm fund lint-staged` command, opening the Open Collective link in the default browser.