### PR TITLE
fix: make sure deleted files aren't restored due to git bugs

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -1,18 +1,17 @@
 'use strict'
 
 const debug = require('debug')('lint-staged:file')
-const fs = require('fs')
-
-const fsPromises = fs.promises
+const fs = require('fs').promises
 
 /**
- * Check if a file exists. Returns the filepath if exists.
- * @param {String} filepath
+ * Check if a file exists. Returns the filename if exists.
+ * @param {String} filename
+ * @returns {String|Boolean}
  */
-const exists = async filepath => {
+const exists = async filename => {
   try {
-    await fsPromises.access(filepath)
-    return filepath
+    await fs.access(filename)
+    return filename
   } catch {
     return false
   }
@@ -22,12 +21,12 @@ const exists = async filepath => {
  * Read contents of a file to buffer
  * @param {String} filename
  * @param {Boolean} [rejectENOENT=false] — Whether to throw if the file doesn't exist
- * @returns {Promise<Buffer|Null>}
+ * @returns {Promise<Buffer>}
  */
 const readFile = async (filename, rejectENOENT = false) => {
   debug('Reading file `%s`', filename)
   try {
-    return await fsPromises.readFile(filename)
+    return await fs.readFile(filename)
   } catch (error) {
     if (!rejectENOENT && error.code === 'ENOENT') {
       debug("File `%s` doesn't exist, ignoring...", filename)
@@ -39,12 +38,12 @@ const readFile = async (filename, rejectENOENT = false) => {
 
 /**
  * Unlink a file if it exists
- * @param {*} filepath
+ * @param {String} filename
  */
-const unlink = async filepath => {
-  if (filepath) {
-    await fsPromises.access(filepath)
-    await fsPromises.unlink(filepath)
+const unlink = async filename => {
+  if (filename) {
+    await fs.access(filename)
+    await fs.unlink(filename)
   }
 }
 
@@ -55,7 +54,7 @@ const unlink = async filepath => {
  */
 const writeFile = async (filename, buffer) => {
   debug('Writing file `%s`', filename)
-  await fsPromises.writeFile(filename, buffer)
+  await fs.writeFile(filename, buffer)
 }
 
 module.exports = {

--- a/lib/file.js
+++ b/lib/file.js
@@ -20,30 +20,40 @@ const exists = async filename => {
 /**
  * Read contents of a file to buffer
  * @param {String} filename
- * @param {Boolean} [rejectENOENT=false] — Whether to throw if the file doesn't exist
+ * @param {Boolean} [ignoreENOENT=true] — Whether to throw if the file doesn't exist
  * @returns {Promise<Buffer>}
  */
-const readFile = async (filename, rejectENOENT = false) => {
+const readFile = async (filename, ignoreENOENT = true) => {
   debug('Reading file `%s`', filename)
   try {
     return await fs.readFile(filename)
   } catch (error) {
-    if (!rejectENOENT && error.code === 'ENOENT') {
+    if (ignoreENOENT && error.code === 'ENOENT') {
       debug("File `%s` doesn't exist, ignoring...", filename)
       return null // no-op file doesn't exist
+    } else {
+      throw error
     }
-    throw error
   }
 }
 
 /**
  * Unlink a file if it exists
  * @param {String} filename
+ * @param {Boolean} [ignoreENOENT=true] — Whether to throw if the file doesn't exist
  */
-const unlink = async filename => {
+const unlink = async (filename, ignoreENOENT = true) => {
   if (filename) {
-    await fs.access(filename)
-    await fs.unlink(filename)
+    debug('Unlinking file `%s`', filename)
+    try {
+      await fs.unlink(filename)
+    } catch (error) {
+      if (ignoreENOENT && error.code === 'ENOENT') {
+        debug("File `%s` doesn't exist, ignoring...", filename)
+      } else {
+        throw error
+      }
+    }
   }
 }
 

--- a/lib/file.js
+++ b/lib/file.js
@@ -7,7 +7,7 @@ const fsPromises = fs.promises
 
 /**
  * Check if a file exists. Returns the filepath if exists.
- * @param {string} filepath
+ * @param {String} filepath
  */
 const exists = async filepath => {
   try {
@@ -19,21 +19,23 @@ const exists = async filepath => {
 }
 
 /**
+ * Read contents of a file to buffer
  * @param {String} filename
+ * @param {Boolean} [rejectENOENT=false] — Whether to throw if the file doesn't exist
  * @returns {Promise<Buffer|Null>}
  */
-const readBufferFromFile = (filename, rejectENOENT = false) =>
-  new Promise(resolve => {
-    debug('Reading buffer from file `%s`', filename)
-    fs.readFile(filename, (error, buffer) => {
-      if (!rejectENOENT && error && error.code === 'ENOENT') {
-        debug("File `%s` doesn't exist, ignoring...", filename)
-        return resolve(null) // no-op file doesn't exist
-      }
-      debug('Done reading buffer from file `%s`!', filename)
-      resolve(buffer)
-    })
-  })
+const readFile = async (filename, rejectENOENT = false) => {
+  debug('Reading file `%s`', filename)
+  try {
+    return await fsPromises.readFile(filename)
+  } catch (error) {
+    if (!rejectENOENT && error.code === 'ENOENT') {
+      debug("File `%s` doesn't exist, ignoring...", filename)
+      return null // no-op file doesn't exist
+    }
+    throw error
+  }
+}
 
 /**
  * Unlink a file if it exists
@@ -47,22 +49,18 @@ const unlink = async filepath => {
 }
 
 /**
+ * Write buffer to file
  * @param {String} filename
  * @param {Buffer} buffer
- * @returns {Promise<Void>}
  */
-const writeBufferToFile = (filename, buffer) =>
-  new Promise(resolve => {
-    debug('Writing buffer to file `%s`', filename)
-    fs.writeFile(filename, buffer, () => {
-      debug('Done writing buffer to file `%s`!', filename)
-      resolve()
-    })
-  })
+const writeFile = async (filename, buffer) => {
+  debug('Writing file `%s`', filename)
+  await fsPromises.writeFile(filename, buffer)
+}
 
 module.exports = {
   exists,
-  readBufferFromFile,
+  readFile,
   unlink,
-  writeBufferToFile
+  writeFile
 }

--- a/lib/getStagedFiles.js
+++ b/lib/getStagedFiles.js
@@ -6,7 +6,7 @@ module.exports = async function getStagedFiles(options) {
   try {
     const lines = await execGit(['diff', '--staged', '--diff-filter=ACMR', '--name-only'], options)
     return lines ? lines.split('\n') : []
-  } catch (error) {
+  } catch {
     return null
   }
 }

--- a/lib/gitWorkflow.js
+++ b/lib/gitWorkflow.js
@@ -138,10 +138,7 @@ class GitWorkflow {
       const untrackedFiles = (await execGit(['ls-files', '--others', '--exclude-standard']))
         .split('\n')
         .map(file => path.resolve(this.gitDir, file))
-
-      for (const file of untrackedFiles) {
-        await unlink(file)
-      }
+      await Promise.all(untrackedFiles.map(unlink))
 
       // Get a diff of unstaged changes by diffing the saved stash against what's left on disk.
       await this.execGit([
@@ -237,9 +234,7 @@ class GitWorkflow {
     }
 
     // If stashing resurrected deleted files, clean them out
-    for (const file of this.deletedFiles) {
-      await unlink(file)
-    }
+    await Promise.all(this.deletedFiles.map(unlink))
   }
 
   /**
@@ -254,9 +249,7 @@ class GitWorkflow {
       debug('Done restoring original state!')
 
       // If stashing resurrected deleted files, clean them out
-      for (const file of this.deletedFiles) {
-        await unlink(file)
-      }
+      await Promise.all(this.deletedFiles.map(unlink))
 
       // Restore meta information about ongoing git merge
       await this.restoreMergeStatus()

--- a/lib/gitWorkflow.js
+++ b/lib/gitWorkflow.js
@@ -18,23 +18,6 @@ const PATCH_UNTRACKED = 'lint-staged_untracked.patch'
 const GIT_APPLY_ARGS = ['apply', '-v', '--whitespace=nowarn', '--recount', '--unidiff-zero']
 const GIT_DIFF_ARGS = ['--binary', '--unified=0', '--no-color', '--no-ext-diff', '--patch']
 
-/**
- * Delete untracked files using `git clean`
- * @param {Function} execGit function for executing git commands using execa
- * @returns {Promise<void>}
- */
-const cleanUntrackedFiles = async execGit => {
-  const untrackedFiles = await execGit(['ls-files', '--others', '--exclude-standard'])
-  if (untrackedFiles) {
-    debug('Detected unstaged, untracked files: ', untrackedFiles)
-    debug(
-      'This is probably due to a bug in git =< 2.13.0 where `git stash --keep-index` resurrects deleted files.'
-    )
-    debug('Deleting the files using `git clean`...')
-    await execGit(['clean', '--force', ...untrackedFiles.split('\n')])
-  }
-}
-
 const handleError = (error, ctx) => {
   ctx.gitError = true
   throw error
@@ -44,6 +27,7 @@ class GitWorkflow {
   constructor({ allowEmpty, gitConfigDir, gitDir, stagedFileChunks }) {
     this.execGit = (args, options = {}) => execGit(args, { ...options, cwd: gitDir })
     this.gitConfigDir = gitConfigDir
+    this.gitDir = gitDir
     this.unstagedDiff = null
     this.allowEmpty = allowEmpty
     this.stagedFileChunks = stagedFileChunks
@@ -135,6 +119,13 @@ class GitWorkflow {
       // Manually check and backup if necessary
       await this.backupMergeStatus()
 
+      // Get a list of unstaged deleted files, because certain bugs might cause them to reappear:
+      // - in git versions =< 2.13.0 the `--keep-index` flag resurrects deleted files
+      // - git stash can't infer RD or MD states correctly, and will lose the deletion
+      this.deletedFiles = (await this.execGit(['ls-files', '--deleted']))
+        .split('\n')
+        .map(file => path.resolve(this.gitDir, file))
+
       // Save stash of entire original state, including unstaged and untracked changes.
       // `--keep-index leaves only staged files on disk, for tasks.`
       await this.execGit(['stash', 'save', '--include-untracked', '--keep-index', STASH])
@@ -144,7 +135,13 @@ class GitWorkflow {
 
       // There is a bug in git =< 2.13.0 where `--keep-index` resurrects deleted files.
       // These files should be listed and deleted before proceeding.
-      await cleanUntrackedFiles(this.execGit)
+      const untrackedFiles = (await execGit(['ls-files', '--others', '--exclude-standard']))
+        .split('\n')
+        .map(file => path.resolve(this.gitDir, file))
+
+      for (const file of untrackedFiles) {
+        await unlink(file)
+      }
 
       // Get a diff of unstaged changes by diffing the saved stash against what's left on disk.
       await this.execGit([
@@ -238,6 +235,11 @@ class GitWorkflow {
       ctx.gitRestoreUntrackedError = true
       handleError(error, ctx)
     }
+
+    // If stashing resurrected deleted files, clean them out
+    for (const file of this.deletedFiles) {
+      await unlink(file)
+    }
   }
 
   /**
@@ -250,6 +252,11 @@ class GitWorkflow {
       await this.execGit(['reset', '--hard', 'HEAD'])
       await this.execGit(['stash', 'apply', '--quiet', '--index', backupStash])
       debug('Done restoring original state!')
+
+      // If stashing resurrected deleted files, clean them out
+      for (const file of this.deletedFiles) {
+        await unlink(file)
+      }
 
       // Restore meta information about ongoing git merge
       await this.restoreMergeStatus()
@@ -278,4 +285,3 @@ class GitWorkflow {
 }
 
 module.exports = GitWorkflow
-module.exports.cleanUntrackedFiles = cleanUntrackedFiles

--- a/lib/gitWorkflow.js
+++ b/lib/gitWorkflow.js
@@ -108,6 +108,18 @@ class GitWorkflow {
   }
 
   /**
+   * List and delete untracked files
+   */
+  async cleanUntrackedFiles() {
+    const lsFiles = await this.execGit(['ls-files', '--others', '--exclude-standard'])
+    const untrackedFiles = lsFiles
+      .split('\n')
+      .filter(Boolean)
+      .map(file => path.resolve(this.gitDir, file))
+    await Promise.all(untrackedFiles.map(file => unlink(file)))
+  }
+
+  /**
    * Create backup stashes, one of everything and one of only staged changes
    * Staged files are left in the index for running tasks
    */
@@ -136,11 +148,7 @@ class GitWorkflow {
 
       // There is a bug in git =< 2.13.0 where `--keep-index` resurrects deleted files.
       // These files should be listed and deleted before proceeding.
-      const untrackedFiles = (await execGit(['ls-files', '--others', '--exclude-standard']))
-        .split('\n')
-        .filter(Boolean)
-        .map(file => path.resolve(this.gitDir, file))
-      await Promise.all(untrackedFiles.map(file => unlink(file)))
+      await this.cleanUntrackedFiles()
 
       // Get a diff of unstaged changes by diffing the saved stash against what's left on disk.
       await this.execGit([

--- a/lib/gitWorkflow.js
+++ b/lib/gitWorkflow.js
@@ -140,7 +140,7 @@ class GitWorkflow {
         .split('\n')
         .filter(Boolean)
         .map(file => path.resolve(this.gitDir, file))
-      await Promise.all(untrackedFiles.map(unlink))
+      await Promise.all(untrackedFiles.map(file => unlink(file)))
 
       // Get a diff of unstaged changes by diffing the saved stash against what's left on disk.
       await this.execGit([
@@ -236,7 +236,7 @@ class GitWorkflow {
     }
 
     // If stashing resurrected deleted files, clean them out
-    await Promise.all(this.deletedFiles.map(unlink))
+    await Promise.all(this.deletedFiles.map(file => unlink(file)))
   }
 
   /**
@@ -251,7 +251,7 @@ class GitWorkflow {
       debug('Done restoring original state!')
 
       // If stashing resurrected deleted files, clean them out
-      await Promise.all(this.deletedFiles.map(unlink))
+      await Promise.all(this.deletedFiles.map(file => unlink(file)))
 
       // Restore meta information about ongoing git merge
       await this.restoreMergeStatus()

--- a/lib/gitWorkflow.js
+++ b/lib/gitWorkflow.js
@@ -4,7 +4,7 @@ const debug = require('debug')('lint-staged:git')
 const path = require('path')
 
 const execGit = require('./execGit')
-const { exists, readBufferFromFile, unlink, writeBufferToFile } = require('./file')
+const { exists, readFile, unlink, writeFile } = require('./file')
 
 const MERGE_HEAD = 'MERGE_HEAD'
 const MERGE_MODE = 'MERGE_MODE'
@@ -57,7 +57,7 @@ class GitWorkflow {
     const resolved = this.getHiddenFilepath(filename)
     const pathIfExists = await exists(resolved)
     if (!pathIfExists) return false
-    const buffer = await readBufferFromFile(pathIfExists)
+    const buffer = await readFile(pathIfExists)
     const patch = buffer.toString().trim()
     return patch.length ? filename : false
   }
@@ -81,9 +81,9 @@ class GitWorkflow {
   async backupMergeStatus() {
     debug('Backing up merge state...')
     await Promise.all([
-      readBufferFromFile(this.mergeHeadFilename).then(buffer => (this.mergeHeadBuffer = buffer)),
-      readBufferFromFile(this.mergeModeFilename).then(buffer => (this.mergeModeBuffer = buffer)),
-      readBufferFromFile(this.mergeMsgFilename).then(buffer => (this.mergeMsgBuffer = buffer))
+      readFile(this.mergeHeadFilename).then(buffer => (this.mergeHeadBuffer = buffer)),
+      readFile(this.mergeModeFilename).then(buffer => (this.mergeModeBuffer = buffer)),
+      readFile(this.mergeMsgFilename).then(buffer => (this.mergeMsgBuffer = buffer))
     ])
     debug('Done backing up merge state!')
   }
@@ -95,9 +95,9 @@ class GitWorkflow {
     debug('Restoring merge state...')
     try {
       await Promise.all([
-        this.mergeHeadBuffer && writeBufferToFile(this.mergeHeadFilename, this.mergeHeadBuffer),
-        this.mergeModeBuffer && writeBufferToFile(this.mergeModeFilename, this.mergeModeBuffer),
-        this.mergeMsgBuffer && writeBufferToFile(this.mergeMsgFilename, this.mergeMsgBuffer)
+        this.mergeHeadBuffer && writeFile(this.mergeHeadFilename, this.mergeHeadBuffer),
+        this.mergeModeBuffer && writeFile(this.mergeModeFilename, this.mergeModeBuffer),
+        this.mergeMsgBuffer && writeFile(this.mergeMsgFilename, this.mergeMsgBuffer)
       ])
       debug('Done restoring merge state!')
     } catch (error) {

--- a/lib/gitWorkflow.js
+++ b/lib/gitWorkflow.js
@@ -124,6 +124,7 @@ class GitWorkflow {
       // - git stash can't infer RD or MD states correctly, and will lose the deletion
       this.deletedFiles = (await this.execGit(['ls-files', '--deleted']))
         .split('\n')
+        .filter(Boolean)
         .map(file => path.resolve(this.gitDir, file))
 
       // Save stash of entire original state, including unstaged and untracked changes.
@@ -137,6 +138,7 @@ class GitWorkflow {
       // These files should be listed and deleted before proceeding.
       const untrackedFiles = (await execGit(['ls-files', '--others', '--exclude-standard']))
         .split('\n')
+        .filter(Boolean)
         .map(file => path.resolve(this.gitDir, file))
       await Promise.all(untrackedFiles.map(unlink))
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,7 @@ const errConfigNotFound = new Error('Config could not be found')
 function resolveConfig(configPath) {
   try {
     return require.resolve(configPath)
-  } catch (ignore) {
+  } catch {
     return configPath
   }
 }

--- a/lib/resolveGitRepo.js
+++ b/lib/resolveGitRepo.js
@@ -7,7 +7,7 @@ const path = require('path')
 const debugLog = require('debug')('lint-staged:resolveGitRepo')
 
 const execGit = require('./execGit')
-const { readBufferFromFile } = require('./file')
+const { readFile } = require('./file')
 
 /**
  * Resolve path to the .git directory, with special handling for
@@ -19,7 +19,7 @@ const resolveGitConfigDir = async gitDir => {
   // If .git is a directory, use it
   if (stats.isDirectory()) return defaultDir
   // Otherwise .git is a file containing path to real location
-  const file = (await readBufferFromFile(defaultDir)).toString()
+  const file = (await readFile(defaultDir)).toString()
   return path.resolve(gitDir, file.replace(/^gitdir: /, '')).trim()
 }
 

--- a/test/file.spec.js
+++ b/test/file.spec.js
@@ -1,0 +1,17 @@
+import { unlink, readFile } from '../lib/file'
+
+describe('unlink', () => {
+  it('should throw when second argument is false and file is not found', async () => {
+    await expect(unlink('example', false)).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"ENOENT: no such file or directory, unlink 'example'"`
+    )
+  })
+})
+
+describe('readFile', () => {
+  it('should throw when second argument is false and file is not found', async () => {
+    await expect(readFile('example', false)).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"ENOENT: no such file or directory, open 'example'"`
+    )
+  })
+})

--- a/test/file.spec.js
+++ b/test/file.spec.js
@@ -2,16 +2,12 @@ import { unlink, readFile } from '../lib/file'
 
 describe('unlink', () => {
   it('should throw when second argument is false and file is not found', async () => {
-    await expect(unlink('example', false)).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"ENOENT: no such file or directory, unlink 'example'"`
-    )
+    await expect(unlink('example', false)).rejects.toThrowError()
   })
 })
 
 describe('readFile', () => {
   it('should throw when second argument is false and file is not found', async () => {
-    await expect(readFile('example', false)).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"ENOENT: no such file or directory, open 'example'"`
-    )
+    await expect(readFile('example', false)).rejects.toThrowError()
   })
 })

--- a/test/file.spec.js
+++ b/test/file.spec.js
@@ -2,12 +2,12 @@ import { unlink, readFile } from '../lib/file'
 
 describe('unlink', () => {
   it('should throw when second argument is false and file is not found', async () => {
-    await expect(unlink('example', false)).rejects.toThrowError()
+    await expect(unlink('example', false)).rejects.toThrow('ENOENT')
   })
 })
 
 describe('readFile', () => {
   it('should throw when second argument is false and file is not found', async () => {
-    await expect(readFile('example', false)).rejects.toThrowError()
+    await expect(readFile('example', false)).rejects.toThrow('ENOENT')
   })
 })

--- a/test/gitWorkflow.spec.js
+++ b/test/gitWorkflow.spec.js
@@ -5,7 +5,7 @@ import path from 'path'
 import nanoid from 'nanoid'
 
 import execGitBase from '../lib/execGit'
-import GitWorkflow, { cleanUntrackedFiles } from '../lib/gitWorkflow'
+import GitWorkflow from '../lib/gitWorkflow'
 
 jest.unmock('execa')
 
@@ -63,16 +63,6 @@ describe('gitWorkflow', () => {
     if (!isAppveyor) {
       await removeTempDir(tmpDir)
     }
-  })
-
-  describe('cleanUntrackedFiles', () => {
-    it('should delete untracked, unstaged files', async () => {
-      const testFile = path.resolve(cwd, 'test.js')
-      await appendFile(testFile, 'test')
-      expect(await fs.exists(testFile)).toEqual(true)
-      await cleanUntrackedFiles(execGit)
-      expect(await fs.exists(testFile)).toEqual(false)
-    })
   })
 
   describe('hasPatch', () => {

--- a/test/gitWorkflow.spec.js
+++ b/test/gitWorkflow.spec.js
@@ -91,4 +91,19 @@ describe('gitWorkflow', () => {
       })
     })
   })
+
+  describe('cleanUntrackedFiles', () => {
+    it('should remove untracked files', async () => {
+      const tempFile = path.resolve(cwd, 'tempFile')
+      await fs.writeFile(tempFile, 'Hello')
+
+      const gitWorkflow = new GitWorkflow({
+        gitDir: cwd,
+        gitConfigDir: path.resolve(cwd, './.git')
+      })
+
+      await gitWorkflow.cleanUntrackedFiles()
+      await expect(fs.access(tempFile)).rejects.toThrow('ENOENT')
+    })
+  })
 })

--- a/test/runAll.unmocked.2.spec.js
+++ b/test/runAll.unmocked.2.spec.js
@@ -8,7 +8,7 @@ import nanoid from 'nanoid'
 jest.mock('../lib/file')
 
 import execGitBase from '../lib/execGit'
-import { readBufferFromFile, writeBufferToFile } from '../lib/file'
+import { readFile, writeFile } from '../lib/file'
 import runAll from '../lib/runAll'
 
 jest.unmock('execa')
@@ -89,8 +89,8 @@ describe('runAll', () => {
   })
 
   it.only('Should throw when restoring untracked files fails', async () => {
-    readBufferFromFile.mockImplementation(async () => Buffer.from('test'))
-    writeBufferToFile.mockImplementation(async () => Promise.reject('test'))
+    readFile.mockImplementation(async () => Buffer.from('test'))
+    writeFile.mockImplementation(async () => Promise.reject('test'))
 
     // Stage pretty file
     await appendFile('test.js', testJsFilePretty)

--- a/test/runAll.unmocked.spec.js
+++ b/test/runAll.unmocked.spec.js
@@ -609,7 +609,14 @@ describe('runAll', () => {
     await fs.remove(readmeFile) // Remove file from previous commit
     await appendFile('test.js', testJsFilePretty)
     await execGit(['add', 'test.js'])
-    await runAll({ cwd, config: { '*.{js,md}': 'prettier --list-different' } })
+
+    try {
+      await runAll({ cwd, config: { '*.{js,md}': 'prettier --list-different' } })
+    } catch (error) {
+      globalConsoleTemp.warn(error)
+      globalConsoleTemp.error(console.printHistory())
+    }
+
     const exists = await fs.exists(readmeFile)
     expect(exists).toEqual(false)
   })


### PR DESCRIPTION
Fixes https://github.com/okonet/lint-staged/issues/561

Currently, version 10 only fixes some of the issues with deleted files getting restored when running lint-staged. This PR adds yet more checks to fix the remaining issues. The issue itself seems to be with the way git tracks files, and you can read more [here in Stack Overflow](https://stackoverflow.com/questions/48446845/git-stash-restoring-index-state-of-deleted-and-renamed-files).

I also updated some eslint rules to take into account the Node.js version bump, and after that refactored the file api to use `fs.promises` to simplify the code.