### PR TITLE
Fix untracked file handling

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,8 +2,9 @@
   "extends": ["okonet/node"],
   "rules": {
     "no-console": "off",
-    "node/no-unsupported-features": ["error", "8.12.0"],
-    "node/no-unsupported-features/es-syntax": ["error", { "version": ">=8.12.0" }],
+    "node/no-unsupported-features/node-builtins": "off",
+    "node/no-unsupported-features/es-syntax": ["error", { "version": ">=10.13.0" }],
+    "node/no-unsupported-features/es-builtins": ["error", { "version": ">=10.13.0" }],
     "prettier/prettier": "off",
     "require-atomic-updates": "off"
   }

--- a/lib/file.js
+++ b/lib/file.js
@@ -3,11 +3,26 @@
 const debug = require('debug')('lint-staged:file')
 const fs = require('fs')
 
+const fsPromises = fs.promises
+
+/**
+ * Check if a file exists. Returns the filepath if exists.
+ * @param {string} filepath
+ */
+const exists = async filepath => {
+  try {
+    await fsPromises.access(filepath)
+    return filepath
+  } catch {
+    return false
+  }
+}
+
 /**
  * @param {String} filename
  * @returns {Promise<Buffer|Null>}
  */
-module.exports.readBufferFromFile = (filename, rejectENOENT = false) =>
+const readBufferFromFile = (filename, rejectENOENT = false) =>
   new Promise(resolve => {
     debug('Reading buffer from file `%s`', filename)
     fs.readFile(filename, (error, buffer) => {
@@ -21,11 +36,22 @@ module.exports.readBufferFromFile = (filename, rejectENOENT = false) =>
   })
 
 /**
+ * Unlink a file if it exists
+ * @param {*} filepath
+ */
+const unlink = async filepath => {
+  if (filepath) {
+    await fsPromises.access(filepath)
+    await fsPromises.unlink(filepath)
+  }
+}
+
+/**
  * @param {String} filename
  * @param {Buffer} buffer
  * @returns {Promise<Void>}
  */
-module.exports.writeBufferToFile = (filename, buffer) =>
+const writeBufferToFile = (filename, buffer) =>
   new Promise(resolve => {
     debug('Writing buffer to file `%s`', filename)
     fs.writeFile(filename, buffer, () => {
@@ -33,3 +59,10 @@ module.exports.writeBufferToFile = (filename, buffer) =>
       resolve()
     })
   })
+
+module.exports = {
+  exists,
+  readBufferFromFile,
+  unlink,
+  writeBufferToFile
+}

--- a/lib/gitWorkflow.js
+++ b/lib/gitWorkflow.js
@@ -4,13 +4,16 @@ const debug = require('debug')('lint-staged:git')
 const path = require('path')
 
 const execGit = require('./execGit')
-const { readBufferFromFile, writeBufferToFile } = require('./file')
+const { exists, readBufferFromFile, unlink, writeBufferToFile } = require('./file')
 
 const MERGE_HEAD = 'MERGE_HEAD'
 const MERGE_MODE = 'MERGE_MODE'
 const MERGE_MSG = 'MERGE_MSG'
 
 const STASH = 'lint-staged automatic backup'
+
+const PATCH_UNSTAGED = 'lint-staged_unstaged.patch'
+const PATCH_UNTRACKED = 'lint-staged_untracked.patch'
 
 const GIT_APPLY_ARGS = ['apply', '-v', '--whitespace=nowarn', '--recount', '--unidiff-zero']
 const GIT_DIFF_ARGS = ['--binary', '--unified=0', '--no-color', '--no-ext-diff', '--patch']
@@ -40,6 +43,7 @@ const handleError = (error, ctx) => {
 class GitWorkflow {
   constructor({ allowEmpty, gitConfigDir, gitDir, stagedFileChunks }) {
     this.execGit = (args, options = {}) => execGit(args, { ...options, cwd: gitDir })
+    this.gitConfigDir = gitConfigDir
     this.unstagedDiff = null
     this.allowEmpty = allowEmpty
     this.stagedFileChunks = stagedFileChunks
@@ -51,6 +55,27 @@ class GitWorkflow {
     this.mergeHeadFilename = path.resolve(gitConfigDir, MERGE_HEAD)
     this.mergeModeFilename = path.resolve(gitConfigDir, MERGE_MODE)
     this.mergeMsgFilename = path.resolve(gitConfigDir, MERGE_MSG)
+  }
+
+  /**
+   * Get absolute path to file hidden inside .git
+   * @param {string} filename
+   */
+  getHiddenFilepath(filename) {
+    return path.resolve(this.gitConfigDir, `./${filename}`)
+  }
+
+  /**
+   * Check if patch file exists and has content.
+   * @param {string} filename
+   */
+  async hasPatch(filename) {
+    const resolved = this.getHiddenFilepath(filename)
+    const pathIfExists = await exists(resolved)
+    if (!pathIfExists) return false
+    const buffer = await readBufferFromFile(pathIfExists)
+    const patch = buffer.toString().trim()
+    return patch.length ? filename : false
   }
 
   /**
@@ -122,9 +147,10 @@ class GitWorkflow {
       await cleanUntrackedFiles(this.execGit)
 
       // Get a diff of unstaged changes by diffing the saved stash against what's left on disk.
-      this.unstagedDiff = await this.execGit([
+      await this.execGit([
         'diff',
         ...GIT_DIFF_ARGS,
+        `--output=${this.getHiddenFilepath(PATCH_UNSTAGED)}`,
         await this.getBackupStash(ctx),
         '-R' // Show diff in reverse
       ])
@@ -167,10 +193,11 @@ class GitWorkflow {
     // Restore unstaged changes by applying the diff back. If it at first fails,
     // this is probably because of conflicts between task modifications.
     // 3-way merge usually fixes this, and in case it doesn't we should just give up and throw.
-    if (this.unstagedDiff) {
+    if (await this.hasPatch(PATCH_UNSTAGED)) {
       debug('Restoring unstaged changes...')
+      const unstagedPatch = this.getHiddenFilepath(PATCH_UNSTAGED)
       try {
-        await this.execGit(GIT_APPLY_ARGS, { input: `${this.unstagedDiff}\n` })
+        await this.execGit([...GIT_APPLY_ARGS, unstagedPatch])
       } catch (error) {
         debug('Error while restoring changes:')
         debug(error)
@@ -178,7 +205,7 @@ class GitWorkflow {
 
         try {
           // Retry with `--3way` if normal apply fails
-          await this.execGit([...GIT_APPLY_ARGS, '--3way'], { input: `${this.unstagedDiff}\n` })
+          await this.execGit([...GIT_APPLY_ARGS, '--3way', unstagedPatch])
         } catch (error2) {
           debug('Error while restoring unstaged changes using 3-way merge:')
           debug(error2)
@@ -196,14 +223,17 @@ class GitWorkflow {
     // See https://stackoverflow.com/a/52357762
     try {
       const backupStash = await this.getBackupStash(ctx)
-      const output = await this.execGit([
+      const untrackedPatch = this.getHiddenFilepath(PATCH_UNTRACKED)
+      await this.execGit([
         'show',
         ...GIT_DIFF_ARGS,
         '--format=%b',
+        `--output=${untrackedPatch}`,
         `${backupStash}^3`
       ])
-      const untrackedDiff = output.trim()
-      if (untrackedDiff) await this.execGit([...GIT_APPLY_ARGS], { input: `${untrackedDiff}\n` })
+      if (await this.hasPatch(PATCH_UNTRACKED)) {
+        await this.execGit([...GIT_APPLY_ARGS, untrackedPatch])
+      }
     } catch (error) {
       ctx.gitRestoreUntrackedError = true
       handleError(error, ctx)
@@ -234,6 +264,10 @@ class GitWorkflow {
   async dropBackup(ctx) {
     try {
       debug('Dropping backup stash...')
+      await Promise.all([
+        exists(this.getHiddenFilepath(PATCH_UNSTAGED)).then(unlink),
+        exists(this.getHiddenFilepath(PATCH_UNTRACKED)).then(unlink)
+      ])
       const backupStash = await this.getBackupStash(ctx)
       await this.execGit(['stash', 'drop', '--quiet', backupStash])
       debug('Done dropping backup stash!')

--- a/lib/gitWorkflow.js
+++ b/lib/gitWorkflow.js
@@ -167,6 +167,9 @@ class GitWorkflow {
       handleError(new Error('Prevented an empty git commit!'), ctx)
     }
 
+    // Restore unstaged changes by applying the diff back. If it at first fails,
+    // this is probably because of conflicts between task modifications.
+    // 3-way merge usually fixes this, and in case it doesn't we should just give up and throw.
     if (this.unstagedDiff) {
       debug('Restoring unstaged changes...')
       try {
@@ -197,11 +200,18 @@ class GitWorkflow {
     // See https://stackoverflow.com/a/52357762
     try {
       const backupStash = await this.getBackupStash(ctx)
-      const output = await this.execGit(['show', '--format=%b', `${backupStash}^3`])
-      const untrackedDiff = typeof output === 'string' && output.trim() // remove empty lines from start of output
-      if (!untrackedDiff) return
-      await this.execGit([...gitApplyArgs], { input: `${untrackedDiff}\n` })
-    } catch (err) {} // eslint-disable-line no-empty
+      const output = await this.execGit(['show', '--no-color', '--format=%b', `${backupStash}^3`])
+      const untrackedDiff = output.trim()
+      if (untrackedDiff) await this.execGit([...gitApplyArgs], { input: `${untrackedDiff}\n` })
+    } catch (error) {
+      if (
+        !error.message ||
+        !error.message.includes('unknown revision or path not in the working tree')
+      ) {
+        ctx.gitRestoreUntrackedError = true
+        handleError(error, ctx)
+      }
+    }
   }
 
   /**

--- a/lib/gitWorkflow.js
+++ b/lib/gitWorkflow.js
@@ -12,7 +12,8 @@ const MERGE_MSG = 'MERGE_MSG'
 
 const STASH = 'lint-staged automatic backup'
 
-const gitApplyArgs = ['apply', '-v', '--whitespace=nowarn', '--recount', '--unidiff-zero']
+const GIT_APPLY_ARGS = ['apply', '-v', '--whitespace=nowarn', '--recount', '--unidiff-zero']
+const GIT_DIFF_ARGS = ['--binary', '--unified=0', '--no-color', '--no-ext-diff', '--patch']
 
 /**
  * Delete untracked files using `git clean`
@@ -123,11 +124,7 @@ class GitWorkflow {
       // Get a diff of unstaged changes by diffing the saved stash against what's left on disk.
       this.unstagedDiff = await this.execGit([
         'diff',
-        '--binary',
-        '--unified=0',
-        '--no-color',
-        '--no-ext-diff',
-        '--patch',
+        ...GIT_DIFF_ARGS,
         await this.getBackupStash(ctx),
         '-R' // Show diff in reverse
       ])
@@ -173,7 +170,7 @@ class GitWorkflow {
     if (this.unstagedDiff) {
       debug('Restoring unstaged changes...')
       try {
-        await this.execGit(gitApplyArgs, { input: `${this.unstagedDiff}\n` })
+        await this.execGit(GIT_APPLY_ARGS, { input: `${this.unstagedDiff}\n` })
       } catch (error) {
         debug('Error while restoring changes:')
         debug(error)
@@ -181,7 +178,7 @@ class GitWorkflow {
 
         try {
           // Retry with `--3way` if normal apply fails
-          await this.execGit([...gitApplyArgs, '--3way'], { input: `${this.unstagedDiff}\n` })
+          await this.execGit([...GIT_APPLY_ARGS, '--3way'], { input: `${this.unstagedDiff}\n` })
         } catch (error2) {
           debug('Error while restoring unstaged changes using 3-way merge:')
           debug(error2)
@@ -196,21 +193,20 @@ class GitWorkflow {
     }
 
     // Restore untracked files by reading from the third commit associated with the backup stash
-    // Git will return with error code if the commit doesn't exist
     // See https://stackoverflow.com/a/52357762
     try {
       const backupStash = await this.getBackupStash(ctx)
-      const output = await this.execGit(['show', '--no-color', '--format=%b', `${backupStash}^3`])
+      const output = await this.execGit([
+        'show',
+        ...GIT_DIFF_ARGS,
+        '--format=%b',
+        `${backupStash}^3`
+      ])
       const untrackedDiff = output.trim()
-      if (untrackedDiff) await this.execGit([...gitApplyArgs], { input: `${untrackedDiff}\n` })
+      if (untrackedDiff) await this.execGit([...GIT_APPLY_ARGS], { input: `${untrackedDiff}\n` })
     } catch (error) {
-      if (
-        !error.message ||
-        !error.message.includes('unknown revision or path not in the working tree')
-      ) {
-        ctx.gitRestoreUntrackedError = true
-        handleError(error, ctx)
-      }
+      ctx.gitRestoreUntrackedError = true
+      handleError(error, ctx)
     }
   }
 

--- a/lib/runAll.js
+++ b/lib/runAll.js
@@ -57,6 +57,12 @@ module.exports = async function runAll(
   if (!files) throw new Error('Unable to get staged files!')
   debugLog('Loaded list of staged files in git:\n%O', files)
 
+  // If there are no files avoid executing any lint-staged logic
+  if (files.length === 0) {
+    logger.log('No staged files found.')
+    return 'No tasks to run.'
+  }
+
   const stagedFileChunks = chunkFiles({ files, gitDir, maxArgLength, relative })
   const chunkCount = stagedFileChunks.length
   if (chunkCount > 1) debugLog(`Chunked staged files into ${chunkCount} part`, chunkCount)

--- a/test/__snapshots__/runAll.spec.js.snap
+++ b/test/__snapshots__/runAll.spec.js.snap
@@ -18,7 +18,7 @@ LOG Cleaning up... [completed]"
 
 exports[`runAll should resolve the promise with no files 1`] = `
 "
-LOG No staged files match any of provided globs."
+LOG No staged files found."
 `;
 
 exports[`runAll should skip applying unstaged modifications if there are errors during linting 1`] = `
@@ -85,5 +85,5 @@ LOG {
 
 exports[`runAll should use an injected logger 1`] = `
 "
-LOG No staged files match any of provided globs."
+LOG No staged files found."
 `;

--- a/test/gitWorkflow.spec.js
+++ b/test/gitWorkflow.spec.js
@@ -5,7 +5,7 @@ import path from 'path'
 import nanoid from 'nanoid'
 
 import execGitBase from '../lib/execGit'
-import { cleanUntrackedFiles } from '../lib/gitWorkflow'
+import GitWorkflow, { cleanUntrackedFiles } from '../lib/gitWorkflow'
 
 jest.unmock('execa')
 
@@ -72,6 +72,23 @@ describe('gitWorkflow', () => {
       expect(await fs.exists(testFile)).toEqual(true)
       await cleanUntrackedFiles(execGit)
       expect(await fs.exists(testFile)).toEqual(false)
+    })
+  })
+
+  describe('dropBackup', () => {
+    it('should handle errors', async () => {
+      const gitWorkflow = new GitWorkflow({
+        gitDir: cwd,
+        gitConfigDir: path.resolve(cwd, './.git')
+      })
+      const ctx = {}
+      await expect(gitWorkflow.dropBackup(ctx)).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"lint-staged automatic backup is missing!"`
+      )
+      expect(ctx).toEqual({
+        gitError: true,
+        gitGetBackupStashError: true
+      })
     })
   })
 })

--- a/test/gitWorkflow.spec.js
+++ b/test/gitWorkflow.spec.js
@@ -75,6 +75,16 @@ describe('gitWorkflow', () => {
     })
   })
 
+  describe('hasPatch', () => {
+    it('should return false when patch file not found', async () => {
+      const gitWorkflow = new GitWorkflow({
+        gitDir: cwd,
+        gitConfigDir: path.resolve(cwd, './.git')
+      })
+      expect(await gitWorkflow.hasPatch('foo')).toEqual(false)
+    })
+  })
+
   describe('dropBackup', () => {
     it('should handle errors', async () => {
       const gitWorkflow = new GitWorkflow({

--- a/test/runAll.unmocked.spec.js
+++ b/test/runAll.unmocked.spec.js
@@ -670,10 +670,11 @@ describe('runAll', () => {
       LOG Running tasks for *.js [completed]
       LOG Running tasks... [completed]
       LOG Applying modifications... [started]
-      LOG Applying modifications... [completed]
+      LOG Applying modifications... [failed]
+      LOG → lint-staged automatic backup is missing!
       LOG Cleaning up... [started]
-      LOG Cleaning up... [failed]
-      LOG → lint-staged automatic backup is missing!"
+      LOG Cleaning up... [skipped]
+      LOG → Skipped because of previous git error."
     `)
   })
 

--- a/test/runAll.unmocked.spec.js
+++ b/test/runAll.unmocked.spec.js
@@ -82,11 +82,6 @@ describe('runAll', () => {
     )
     await removeTempDir(nonGitDir)
   })
-
-  it('should short-circuit with no staged files', async () => {
-    const status = await runAll({ config: { '*.js': 'echo success' }, cwd })
-    expect(status).toEqual('No tasks to run.')
-  })
 })
 
 const globalConsoleTemp = console
@@ -117,6 +112,11 @@ describe('runAll', () => {
 
   afterAll(() => {
     console = globalConsoleTemp
+  })
+
+  it('should exit early with no staged files', async () => {
+    const status = await runAll({ config: { '*.js': 'echo success' }, cwd })
+    expect(status).toEqual('No tasks to run.')
   })
 
   it('Should commit entire staged file when no errors from linter', async () => {


### PR DESCRIPTION
This PR adds missing error handling to the untracked files restoration, and uses the same diff arguments as for the unstaged diff.

These omissions when combined possibly lead to new untracked files getting lost when running _lint-staged_. The test didn't detect this because one reason might be the missing `--binary` flag.

~~The test coverage dropped significantly because now when the backup stash is missing, `runAll` fails earlier. Not sure how to test the last error handler at this point.~~

Fixes https://github.com/okonet/lint-staged/issues/779