### PR TITLE
fix: use verbose renderer when TERM=dumb

### DIFF
--- a/bin/lint-staged
+++ b/bin/lint-staged
@@ -3,10 +3,9 @@
 'use strict'
 
 // Force colors for packages that depend on https://www.npmjs.com/package/supports-color
-// but do this only in TTY mode
-if (process.stdout.isTTY) {
-  // istanbul ignore next
-  process.env.FORCE_COLOR = '1'
+const { supportsColor } = require('chalk')
+if (supportsColor) {
+  process.env.FORCE_COLOR = supportsColor.level.toString()
 }
 
 // Do not terminate main Listr process on SIGINT

--- a/bin/lint-staged.js
+++ b/bin/lint-staged.js
@@ -35,7 +35,7 @@ cmdline
     '-p, --concurrent <parallel tasks>',
     'the number of tasks to run concurrently, or false to run tasks serially',
     true
-    )
+  )
   .option('-q, --quiet', 'disable lint-staged’s own console output', false)
   .option('-r, --relative', 'pass relative filepaths to tasks', false)
   .option('-x, --shell', 'skip parsing of tasks for better shell support', false)
@@ -73,7 +73,7 @@ const options = {
   maxArgLength: getMaxArgLength() / 2,
   quiet: !!cmdline.quiet,
   relative: !!cmdline.relative,
-  shell: !!cmdline.shell,
+  shell: !!cmdline.shell
 }
 
 debug('Options parsed from command-line:', options)

--- a/lib/runAll.js
+++ b/lib/runAll.js
@@ -15,6 +15,14 @@ const resolveGitRepo = require('./resolveGitRepo')
 
 const debugLog = require('debug')('lint-staged:run')
 
+const getRenderer = ({ debug, quiet }) => {
+  if (quiet) return 'silent'
+  // Better support for dumb terminals: https://en.wikipedia.org/wiki/Computer_terminal#Dumb_terminals
+  const isDumbTerminal = process.env.TERM === 'dumb'
+  if (debug || isDumbTerminal) return 'verbose'
+  return 'update'
+}
+
 /**
  * Executes all tasks and either resolves or rejects the promise
  *
@@ -74,7 +82,7 @@ module.exports = async function runAll(
   const listrOptions = {
     dateFormat: false,
     exitOnError: false,
-    renderer: (quiet && 'silent') || (debug && 'verbose') || 'update'
+    renderer: getRenderer({ debug, quiet })
   }
 
   const listrTasks = []

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "funding": {
     "url": "https://opencollective.com/lint-staged"
   },
-  "bin": "./bin/lint-staged",
+  "bin": "./bin/lint-staged.js",
   "main": "./lib/index.js",
   "files": [
     "bin",
@@ -30,7 +30,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "./bin/lint-staged"
+      "pre-commit": "./bin/lint-staged.js"
     }
   },
   "dependencies": {


### PR DESCRIPTION
This PR adds detection for the `TERM=dumb` env variable and sets cli-output to use the verbose renderer, instead of the default dynamic one.

Fixes https://github.com/okonet/lint-staged/issues/781