### PR TITLE
fix: replace fs.promises with util.promisify to suppress ExperimentalWarning on Node.js v10

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -1,7 +1,13 @@
 'use strict'
 
 const debug = require('debug')('lint-staged:file')
-const fs = require('fs').promises
+const fs = require('fs')
+const { promisify } = require('util')
+
+const fsAccess = promisify(fs.access)
+const fsReadFile = promisify(fs.readFile)
+const fsUnlink = promisify(fs.unlink)
+const fsWriteFile = promisify(fs.writeFile)
 
 /**
  * Check if a file exists. Returns the filename if exists.
@@ -10,7 +16,7 @@ const fs = require('fs').promises
  */
 const exists = async filename => {
   try {
-    await fs.access(filename)
+    await fsAccess(filename)
     return filename
   } catch {
     return false
@@ -26,7 +32,7 @@ const exists = async filename => {
 const readFile = async (filename, ignoreENOENT = true) => {
   debug('Reading file `%s`', filename)
   try {
-    return await fs.readFile(filename)
+    return await fsReadFile(filename)
   } catch (error) {
     if (ignoreENOENT && error.code === 'ENOENT') {
       debug("File `%s` doesn't exist, ignoring...", filename)
@@ -46,7 +52,7 @@ const unlink = async (filename, ignoreENOENT = true) => {
   if (filename) {
     debug('Unlinking file `%s`', filename)
     try {
-      await fs.unlink(filename)
+      await fsUnlink(filename)
     } catch (error) {
       if (ignoreENOENT && error.code === 'ENOENT') {
         debug("File `%s` doesn't exist, ignoring...", filename)
@@ -64,7 +70,7 @@ const unlink = async (filename, ignoreENOENT = true) => {
  */
 const writeFile = async (filename, buffer) => {
   debug('Writing file `%s`', filename)
-  await fs.writeFile(filename, buffer)
+  await fsWriteFile(filename, buffer)
 }
 
 module.exports = {

--- a/lib/resolveGitRepo.js
+++ b/lib/resolveGitRepo.js
@@ -1,13 +1,15 @@
 'use strict'
 
 const normalize = require('normalize-path')
-const fs = require('fs').promises
-const path = require('path')
-
 const debugLog = require('debug')('lint-staged:resolveGitRepo')
+const fs = require('fs')
+const path = require('path')
+const { promisify } = require('util')
 
 const execGit = require('./execGit')
 const { readFile } = require('./file')
+
+const fsLstat = promisify(fs.lstat)
 
 /**
  * Resolve path to the .git directory, with special handling for
@@ -15,7 +17,7 @@ const { readFile } = require('./file')
  */
 const resolveGitConfigDir = async gitDir => {
   const defaultDir = path.resolve(gitDir, '.git')
-  const stats = await fs.lstat(defaultDir)
+  const stats = await fsLstat(defaultDir)
   // If .git is a directory, use it
   if (stats.isDirectory()) return defaultDir
   // Otherwise .git is a file containing path to real location
@@ -26,7 +28,7 @@ const resolveGitConfigDir = async gitDir => {
 /**
  * Resolve git directory and possible submodule paths
  */
-module.exports = async function resolveGitRepo(cwd) {
+const resolveGitRepo = async cwd => {
   try {
     debugLog('Resolving git repo from `%s`', cwd)
     // git cli uses GIT_DIR to fast track its response however it might be set to a different path
@@ -46,3 +48,5 @@ module.exports = async function resolveGitRepo(cwd) {
     return { error, gitDir: null, gitConfigDir: null }
   }
 }
+
+module.exports = resolveGitRepo


### PR DESCRIPTION
This PR fixes https://github.com/okonet/lint-staged/issues/785 by removing usages of `fs.promises` and instead wrapping the older individual callback methods of `fs` with `util.promisify`.

Apparently the Node.js LTS 10.X docs state that `fs.promises` is stable, but the _ExperimentalWarning_ has only been removed in v12.