### PR TITLE
normalize joined defaultDir path when resolving git config dir

### DIFF
--- a/lib/resolveGitRepo.js
+++ b/lib/resolveGitRepo.js
@@ -16,7 +16,7 @@ const fsLstat = promisify(fs.lstat)
  * submodules and worktrees
  */
 const resolveGitConfigDir = async gitDir => {
-  const defaultDir = path.resolve(gitDir, '.git')
+  const defaultDir = normalize(path.join(gitDir, '.git'))
   const stats = await fsLstat(defaultDir)
   // If .git is a directory, use it
   if (stats.isDirectory()) return defaultDir


### PR DESCRIPTION
Replace `path.resolve` with `path.join` for better behavior with paths in msys, and normalized the path also for better behavior in msys.