### PR TITLE
fix: add `--` to `git add` command to denote pathspec starting

### DIFF
--- a/lib/gitWorkflow.js
+++ b/lib/gitWorkflow.js
@@ -238,7 +238,7 @@ class GitWorkflow {
     await Promise.all(
       // stagedFileChunks includes staged files that lint-staged originally detected.
       // Add only these files so any 3rd-party edits to other files won't be included in the commit.
-      this.stagedFileChunks.map(stagedFiles => this.execGit(['add', ...stagedFiles]))
+      this.stagedFileChunks.map(stagedFiles => this.execGit(['add', '--', ...stagedFiles]))
     )
     debug('Done adding task modifications to index!')
 

--- a/test/runAll.unmocked.spec.js
+++ b/test/runAll.unmocked.spec.js
@@ -1038,6 +1038,14 @@ describe('runAll', () => {
     expect(await readFile('test.js')).toEqual(testJsFilePretty) // file was still fixed
     expect(await readFile('test2.js')).toEqual(testJsFileUnfixable)
   })
+
+  it('should handle files that begin with dash', async () => {
+    await appendFile('--looks-like-flag.js', testJsFileUgly)
+    await execGit(['add', '--', '--looks-like-flag.js'])
+    await expect(gitCommit(fixJsConfig)).resolves.toEqual(undefined)
+    expect(await execGit(['rev-list', '--count', 'HEAD'])).toEqual('2')
+    expect(await readFile('--looks-like-flag.js')).toEqual(testJsFilePretty)
+  })
 })
 
 describe('runAll', () => {


### PR DESCRIPTION
Without the -- denoter some paths might be interpreted as flags.

Fixes https://github.com/okonet/lint-staged/issues/820