### PR TITLE
fix: no longer include untracked files in backup stash

### DIFF
--- a/lib/gitWorkflow.js
+++ b/lib/gitWorkflow.js
@@ -193,8 +193,8 @@ class GitWorkflow {
       // Manually check and backup if necessary
       await this.backupMergeStatus()
 
-      // Save stash of entire original state, including unstaged and untracked changes
-      await this.execGit(['stash', 'save', '--include-untracked', STASH])
+      // Save stash of original state
+      await this.execGit(['stash', 'save', STASH])
       await this.execGit(['stash', 'apply', '--quiet', '--index', await this.getBackupStash()])
 
       // Restore meta information about ongoing git merge, cleared by `git stash`

--- a/lib/runAll.js
+++ b/lib/runAll.js
@@ -254,7 +254,7 @@ const runAll = async (
 
     > git stash list
     stash@{0}: On master: automatic lint-staged backup
-    > git stash pop stash@{0}\n`)
+    > git stash apply --index stash@{0}\n`)
       }
     }
 

--- a/test/runAll.unmocked.2.spec.js
+++ b/test/runAll.unmocked.2.spec.js
@@ -124,7 +124,7 @@ describe('runAll', () => {
 
           > git stash list
           stash@{0}: On master: automatic lint-staged backup
-          > git stash pop stash@{0}
+          > git stash apply --index stash@{0}
       "
     `)
   })

--- a/test/runAll.unmocked.spec.js
+++ b/test/runAll.unmocked.spec.js
@@ -428,7 +428,7 @@ describe('runAll', () => {
 
           > git stash list
           stash@{0}: On master: automatic lint-staged backup
-          > git stash pop stash@{0}
+          > git stash apply --index stash@{0}
       "
     `)
 


### PR DESCRIPTION
Since v10.1 having untracked files in the backup stash causes revert to fail, because the stash will not apply with the same files already on disk.

Fixes https://github.com/okonet/lint-staged/issues/826