### PR TITLE
ci: Separate release and tests tasks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,12 +21,12 @@ jobs:
     strategy:
       matrix:
         # Test with Node.js v10 (LTS), v12 (LTS), and v13 (latest)
-        node: 
+        node:
           - 10
           - 12
           - 13
         # Test with Ubuntu and macOS
-        os: 
+        os:
           - ubuntu-latest
     name: Node.js v${{ matrix.node }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -76,15 +76,3 @@ jobs:
           name: coverage
       # Run codecov.io
       - uses: codecov/codecov-action@v1
-
-  release:
-    name: Release
-    runs-on: ubuntu-latest
-    needs: test
-    steps:
-      # Release using semantic-release.
-      # While this runs on all branches, it will only release latest from master
-      - uses: codfish/semantic-release-action@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Release
+
+on: [push]
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Install dependencies
+        run: npm ci
+      - name: Release
+        uses: codfish/semantic-release-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,10 @@
 name: Release
 
-on: [push]
+on:
+  push:
+    # Run on pushes only to master
+    branches:
+      - master
 
 jobs:
   release:
@@ -14,7 +18,7 @@ jobs:
         with:
           node-version: 12
       - name: Install dependencies
-        run: npm ci
+        run: yarn install
       - name: Release
         uses: codfish/semantic-release-action@v1
         env:


### PR DESCRIPTION
This should fix failing releases since the release job didn't include checkout task. I also think it's better to have it in a separate file since it's separate from tests. Thoughts?