### PR TITLE
fix: chunkFiles chunks normalized files even when maxArgLength is set

### DIFF
--- a/lib/chunkFiles.js
+++ b/lib/chunkFiles.js
@@ -48,5 +48,5 @@ module.exports = function chunkFiles({ files, baseDir, maxArgLength = null, rela
   )
   const chunkCount = Math.min(Math.ceil(fileListLength / maxArgLength), normalizedFiles.length)
   debug(`Creating ${chunkCount} chunks for maxArgLength of ${maxArgLength}`)
-  return chunkArray(files, chunkCount)
+  return chunkArray(normalizedFiles, chunkCount)
 }

--- a/test/chunkFiles.spec.js
+++ b/test/chunkFiles.spec.js
@@ -13,13 +13,13 @@ describe('chunkFiles', () => {
   })
 
   it('should not chunk short argument string', () => {
-    const chunkedFiles = chunkFiles({ baseDir, files, maxArgLength: 1000 })
+    const chunkedFiles = chunkFiles({ baseDir, files, maxArgLength: 1000, relative: true })
     expect(chunkedFiles).toEqual([files])
   })
 
   it('should chunk too long argument string', () => {
-    const chunkedFiles = chunkFiles({ baseDir, files, maxArgLength: 20 })
-    expect(chunkedFiles).toEqual(files.map((file) => [file]))
+    const chunkedFiles = chunkFiles({ baseDir, files, maxArgLength: 20, relative: false })
+    expect(chunkedFiles).toEqual(files.map((file) => [normalize(path.resolve(baseDir, file))]))
   })
 
   it('should take into account relative setting', () => {
@@ -30,8 +30,13 @@ describe('chunkFiles', () => {
     ])
   })
 
-  it('should resolve paths when relative: false', () => {
-    const chunkedFiles = chunkFiles({ baseDir, files, relative: false })
+  it('should resolve absolute paths by default', () => {
+    const chunkedFiles = chunkFiles({ baseDir, files })
+    expect(chunkedFiles).toEqual([files.map((file) => normalize(path.resolve(baseDir, file)))])
+  })
+
+  it('should resolve absolute paths by default even when maxArgLength is set', () => {
+    const chunkedFiles = chunkFiles({ baseDir, files, maxArgLength: 262144 })
     expect(chunkedFiles).toEqual([files.map((file) => normalize(path.resolve(baseDir, file)))])
   })
 })


### PR DESCRIPTION
The previous PR https://github.com/okonet/lint-staged/pull/857 only fixed the situation when `maxArgLength` was not set (when used throught the Node.js API).