### PR TITLE
fix: add more tests for Node.js version requirements

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,7 @@
 environment:
   matrix:
     - nodejs_version: '14'
+    - nodejs_version: '13'
     - nodejs_version: '12'
     - nodejs_version: '10'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,10 +20,11 @@ jobs:
   test:
     strategy:
       matrix:
-        # Test with Node.js v10 (LTS), v12 (LTS), and v14 (latest)
+        # Test with Node.js v10 (last LTS version), v12 (current LTS), v13, and v14 (latest)
         node:
           - 10
           - 12
+          - 13
           - 14
         # Test with Ubuntu and macOS
         os:

--- a/bin/lint-staged.js
+++ b/bin/lint-staged.js
@@ -12,13 +12,6 @@ if (supportsColor) {
 process.on('SIGINT', () => {})
 
 const pkg = require('../package.json')
-require('please-upgrade-node')(
-  Object.assign({}, pkg, {
-    engines: {
-      node: '>=10.13.0', // First LTS release of 'Dubnium'
-    },
-  })
-)
 
 const cmdline = require('commander')
 const debugLib = require('debug')

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,7 @@ const debugLog = require('debug')('lint-staged')
 const stringifyObject = require('stringify-object')
 
 const { PREVENTED_EMPTY_COMMIT, GIT_ERROR, RESTORE_STASH_EXAMPLE } = require('./messages')
+const requireNodeVersion = require('./nodeVersion')
 const printTaskOutput = require('./printTaskOutput')
 const runAll = require('./runAll')
 const { ApplyEmptyCommitError, GetBackupStashError, GitError } = require('./symbols')
@@ -78,6 +79,8 @@ module.exports = async function lintStaged(
   logger = console
 ) {
   try {
+    await requireNodeVersion()
+
     debugLog('Loading config using `cosmiconfig`')
 
     const resolved = configObject
@@ -139,6 +142,11 @@ module.exports = async function lintStaged(
       return false
     }
   } catch (lintStagedError) {
+    if (lintStagedError.isNodeVersionError) {
+      logger.error(lintStagedError.message)
+      throw lintStagedError
+    }
+
     if (lintStagedError === errConfigNotFound) {
       logger.error(`${lintStagedError.message}.`)
     } else {

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -3,6 +3,13 @@
 const chalk = require('chalk')
 const { error, info, warning } = require('log-symbols')
 
+const wrongNodeVersion = (version, range) =>
+  chalk.redBright(
+    `${error} Your current Node.js v${version} doesn't satisfy the required range for ${chalk.bold(
+      'lint-staged'
+    )} (${range}). Please upgrade Node.js!`
+  )
+
 const NOT_GIT_REPO = chalk.redBright(`${error} Current directory is not a git directory!`)
 
 const FAILED_GET_STAGED_FILES = chalk.redBright(`${error} Failed to get staged files!`)
@@ -40,15 +47,16 @@ const RESTORE_STASH_EXAMPLE = `  Any lost modifications can be restored from a g
 `
 
 module.exports = {
-  NOT_GIT_REPO,
+  DEPRECATED_GIT_ADD,
   FAILED_GET_STAGED_FILES,
+  GIT_ERROR,
   NO_STAGED_FILES,
   NO_TASKS,
-  skippingBackup,
-  DEPRECATED_GIT_ADD,
-  TASK_ERROR,
-  SKIPPED_GIT_ERROR,
-  GIT_ERROR,
+  NOT_GIT_REPO,
   PREVENTED_EMPTY_COMMIT,
   RESTORE_STASH_EXAMPLE,
+  SKIPPED_GIT_ERROR,
+  skippingBackup,
+  TASK_ERROR,
+  wrongNodeVersion,
 }

--- a/lib/nodeVersion.js
+++ b/lib/nodeVersion.js
@@ -1,0 +1,30 @@
+const debugLog = require('debug')('lint-staged:node-version')
+const semverSatisfies = require('semver/functions/satisfies')
+
+const { wrongNodeVersion } = require('./messages')
+
+/**
+ * The required Node.js semver range
+ * - all versions after 12 are supported
+ * - all versions of v10 that are LTS, are supported
+ */
+const REQUIRED_NODE_VERSION = '>=12 || 10.13.0 - 10.20.1'
+
+const CURRENT_NODE_VERSION = process.version.replace('v', '')
+
+/**
+ * Show a helpful warning message about the required Node.js version.
+ * Do not declare in package.json because installing `lint-staged` shouldn't
+ * cause failures in CI or other environments where it's not actually used.
+ */
+const requireNodeVersion = async (version = CURRENT_NODE_VERSION) => {
+  debugLog('Detected Node.js v%s', version)
+  if (!semverSatisfies(version, REQUIRED_NODE_VERSION)) {
+    const message = wrongNodeVersion(version, REQUIRED_NODE_VERSION)
+    const error = new Error(message)
+    error.isNodeVersionError = true
+    throw error
+  }
+}
+
+module.exports = requireNodeVersion

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "debug": "^4.1.1",
     "dedent": "^0.7.0",
     "execa": "^4.0.1",
-    "listr2": "^2.0.2",
+    "listr2": "^2.0.4",
     "log-symbols": "^4.0.0",
     "micromatch": "^4.0.2",
     "normalize-path": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "log-symbols": "^4.0.0",
     "micromatch": "^4.0.2",
     "normalize-path": "^3.0.0",
-    "please-upgrade-node": "^3.2.0",
+    "semver": "^7.3.2",
     "string-argv": "0.3.1",
     "stringify-object": "^3.3.0"
   },

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -53,6 +53,11 @@ ERROR Please make sure you have created it correctly.
 See https://github.com/okonet/lint-staged#configuration.
 `;
 
+exports[`lintStaged should print helpful error message when wrong Node.js version 1`] = `
+"
+ERROR × Your current Node.js v9.0.0 doesn't satisfy the required range for lint-staged (MOCK RANGE). Please upgrade Node.js!"
+`;
+
 exports[`lintStaged should throw when invalid config is provided 2`] = `
 "
 ERROR Could not parse lint-staged config.

--- a/test/nodeVersion.spec.js
+++ b/test/nodeVersion.spec.js
@@ -1,0 +1,31 @@
+import requireNodeVersion from '../lib/nodeVersion'
+
+describe('requireNodeVersion', () => {
+  it('should pass using all tested Node.js versions', async () => {
+    await expect(requireNodeVersion()).resolves.toEqual(undefined)
+  })
+
+  it('should fail for Node.js v8.17.0', async () => {
+    await expect(requireNodeVersion('8.17.0')).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"× Your current Node.js v8.17.0 doesn't satisfy the required range for lint-staged (>=12 || 10.13.0 - 10.20.1). Please upgrade Node.js!"`
+    )
+  })
+
+  it('should fail for Node.js v9.11.2', async () => {
+    await expect(requireNodeVersion('9.11.2')).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"× Your current Node.js v9.11.2 doesn't satisfy the required range for lint-staged (>=12 || 10.13.0 - 10.20.1). Please upgrade Node.js!"`
+    )
+  })
+
+  it('should fail for Node.js v10.12.0', async () => {
+    await expect(requireNodeVersion('10.12.0')).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"× Your current Node.js v10.12.0 doesn't satisfy the required range for lint-staged (>=12 || 10.13.0 - 10.20.1). Please upgrade Node.js!"`
+    )
+  })
+
+  it('should fail for Node.js v11.15.0', async () => {
+    await expect(requireNodeVersion('11.15.0')).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"× Your current Node.js v11.15.0 doesn't satisfy the required range for lint-staged (>=12 || 10.13.0 - 10.20.1). Please upgrade Node.js!"`
+    )
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -3872,10 +3872,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
-listr2@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/listr2/-/listr2-2.0.2.tgz#35e11e742ee151a8c446d1649792cadf7eb1d780"
-  integrity sha512-HkbraLsbHRFtuT0p1g9KUiMoJeqlPdgsi4Q3mCvBlYnVK+2I1vPdCxBvJ+nAxwpL7SZiyaICWMvLOyMBtu+VKw==
+listr2@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/listr2/-/listr2-2.0.4.tgz#b39100b0a227ec5659dcf76ddc516211fc168d61"
+  integrity sha512-oJaAcplPsa72rKW0eg4P4LbEJjhH+UO2I8uqR/I2wzHrVg16ohSfUy0SlcHS21zfYXxtsUpL8YXGHjyfWMR0cg==
   dependencies:
     "@samverschueren/stream-to-observable" "^0.3.0"
     chalk "^4.0.0"


### PR DESCRIPTION
When failing, it prints out something like this (in the example the version requirements are wrong for demonstrative purposes):

```bash
❯ node bin/lint-staged.js
✖ Your current Node.js v12.16.3 doesn't satisfy the required range for lint-staged (>=10.13 | >=13.7). Please upgrade Node.js!
```