### PR TITLE
fix: remove nanoid devDependency to remove ExperimentalWarning

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "husky": "^4.2.5",
     "jest": "^26.0.1",
     "jest-snapshot-serializer-ansi": "^1.0.0",
-    "nanoid": "^3.1.7",
     "prettier": "^2.0.5"
   },
   "config": {

--- a/test/gitWorkflow.spec.js
+++ b/test/gitWorkflow.spec.js
@@ -1,40 +1,17 @@
 import fs from 'fs-extra'
-import { nanoid } from 'nanoid'
 import normalize from 'normalize-path'
-import os from 'os'
 import path from 'path'
 
 import execGitBase from '../lib/execGit'
 import { writeFile } from '../lib/file'
 import GitWorkflow from '../lib/gitWorkflow'
 import { getInitialState } from '../lib/state'
+import { createTempDir } from './utils/tempDir'
 
 jest.mock('../lib/file.js')
 jest.unmock('execa')
 
 jest.setTimeout(20000)
-
-const isAppveyor = !!process.env.APPVEYOR
-const osTmpDir = isAppveyor ? 'C:\\projects' : fs.realpathSync(os.tmpdir())
-
-/**
- * Create temporary directory and return its path
- * @returns {Promise<String>}
- */
-const createTempDir = async () => {
-  const dirname = path.resolve(osTmpDir, 'lint-staged-test', nanoid())
-  await fs.ensureDir(dirname)
-  return dirname
-}
-
-/**
- * Remove temporary directory
- * @param {String} dirname
- * @returns {Promise<Void>}
- */
-const removeTempDir = async (dirname) => {
-  await fs.remove(dirname)
-}
 
 let tmpDir, cwd
 
@@ -55,6 +32,8 @@ const initGitRepo = async () => {
   await execGit(['commit', '-m initial commit'])
 }
 
+const isAppveyor = !!process.env.APPVEYOR
+
 describe('gitWorkflow', () => {
   beforeEach(async () => {
     tmpDir = await createTempDir()
@@ -64,7 +43,7 @@ describe('gitWorkflow', () => {
 
   afterEach(async () => {
     if (!isAppveyor) {
-      await removeTempDir(tmpDir)
+      await fs.remove(tmpDir)
     }
   })
 

--- a/test/utils/tempDir.js
+++ b/test/utils/tempDir.js
@@ -1,0 +1,16 @@
+import fs from 'fs-extra'
+import os from 'os'
+import path from 'path'
+
+const osTmpDir = process.env.APPVEYOR ? 'C:\\projects' : fs.realpathSync(os.tmpdir())
+
+/**
+ * Create temporary random directory and return its path
+ * @returns {Promise<String>}
+ */
+export const createTempDir = async () => {
+  const random = Date.now().toString(36) + Math.random().toString(36).substr(2)
+  const dirname = path.resolve(osTmpDir, `lint-staged-${random}`)
+  await fs.ensureDir(dirname)
+  return dirname
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4078,11 +4078,6 @@ mute-stream@0.0.8:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
-nanoid@^3.1.7:
-  version "3.1.7"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.7.tgz#3705ccf590b6a51fbd1794fcf204ce7b5dc46c01"
-  integrity sha512-ruOwuatdEf4BxQmZopZqhIMudQ9V83aKocr+q2Y7KasnDNvo2OgbgZBYago5hSD0tCmoSl4flIw9ytDLIVM2IQ==
-
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"


### PR DESCRIPTION
nanoid contains conditional exports and emits a warning on Node.js >= 13.7: `ExperimentalWarning: Conditional exports is an experimental feature. This feature could change at any time`.

Fixes https://github.com/okonet/lint-staged/issues/872