### PR TITLE
Use machine output for listing partially staged files

### DIFF
--- a/lib/gitWorkflow.js
+++ b/lib/gitWorkflow.js
@@ -19,19 +19,20 @@ const MERGE_HEAD = 'MERGE_HEAD'
 const MERGE_MODE = 'MERGE_MODE'
 const MERGE_MSG = 'MERGE_MSG'
 
-// In git status, renames are presented as `from` -> `to`.
+// In git status machine output, renames are presented as `to`NUL`from`
 // When diffing, both need to be taken into account, but in some cases on the `to`.
-const RENAME = / -> /
+// eslint-disable-next-line no-control-regex
+const RENAME = /\x00/
 
 /**
- * From list of files, split renames and flatten into two files `from` -> `to`.
+ * From list of files, split renames and flatten into two files `to`NUL`from`.
  * @param {string[]} files
  * @param {Boolean} [includeRenameFrom=true] Whether or not to include the `from` renamed file, which is no longer on disk
  */
 const processRenames = (files, includeRenameFrom = true) =>
   files.reduce((flattened, file) => {
     if (RENAME.test(file)) {
-      const [from, to] = file.split(RENAME)
+      const [to, from] = file.split(RENAME)
       if (includeRenameFrom) flattened.push(from)
       flattened.push(to)
     } else {
@@ -158,15 +159,20 @@ class GitWorkflow {
    */
   async getPartiallyStagedFiles() {
     debug('Getting partially staged files...')
-    const status = await this.execGit(['status', '--porcelain'])
+    const status = await this.execGit(['status', '-z'])
+    /**
+     * See https://git-scm.com/docs/git-status#_short_format
+     * Entries returned in machine format are separated by a NUL character.
+     * The first letter of each entry represents current index status,
+     * and second the working tree. Index and working tree status codes are
+     * separated from the file name by a space. If an entry includes a
+     * renamed file, the file names are separated by a NUL character
+     * (e.g. `to`\0`from`)
+     */
     const partiallyStaged = status
-      .split('\n')
+      // eslint-disable-next-line no-control-regex
+      .split(/\x00(?=[ AMDRCU?!]{2} |$)/)
       .filter((line) => {
-        /**
-         * See https://git-scm.com/docs/git-status#_short_format
-         * The first letter of the line represents current index status,
-         * and second the working tree
-         */
         const [index, workingTree] = line
         return index !== ' ' && workingTree !== ' ' && index !== '?' && workingTree !== '?'
       })


### PR DESCRIPTION
When a partially staged file name contains one or more spaces or special characters, `git status --porcelain` escapes and quotes the file name (see https://github.com/okonet/lint-staged/blob/master/lib/gitWorkflow.js#L161). Consequently, `gitWorkflow.hideUnstagedChanges()` fails with a pathspec error since `execa` expects arguments to not be escaped or quoted:

```
[SUCCESS] Preparing...
[STARTED] Hiding unstaged changes to partially staged files...
[FAILED] error: pathspec '"src/file with spaces.ts"' did not match any file(s) known to git

  ✖ lint-staged failed due to a git error.
  Any lost modifications can be restored from a git stash:

    > git stash list
    stash@{0}: automatic lint-staged backup
    > git stash apply --index stash@{0}
```

This PR resolves the problem by using the machine output from `git-status` instead. Note: the order of renamed files in the status output is reversed and separated by a `NUL` character (instead of ` -> `) when machine output (`-z` option) is specified.