### PR TITLE
fix: canceling lint-staged via SIGINT restores state and cleans up

### DIFF
--- a/lib/runAll.js
+++ b/lib/runAll.js
@@ -119,6 +119,7 @@ const runAll = async (
     ctx,
     exitOnError: false,
     nonTTYRenderer: 'verbose',
+    registerSignalListeners: false,
     ...getRenderer({ debug, quiet }),
   }
 

--- a/test/index2.spec.js
+++ b/test/index2.spec.js
@@ -33,6 +33,7 @@ describe('lintStaged', () => {
         },
         "exitOnError": false,
         "nonTTYRenderer": "verbose",
+        "registerSignalListeners": false,
         "renderer": "silent",
       }
     `)
@@ -58,6 +59,7 @@ describe('lintStaged', () => {
         },
         "exitOnError": false,
         "nonTTYRenderer": "verbose",
+        "registerSignalListeners": false,
         "renderer": "verbose",
       }
     `)


### PR DESCRIPTION
When replacing listr with listr2, this was a change in default behaviour that was left unnoticed

Fixes https://github.com/okonet/lint-staged/issues/880