### PR TITLE
feat: Add --lint-all-files option

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Options:
   -r, --relative                     pass relative filepaths to tasks (default: false)
   -x, --shell                        skip parsing of tasks for better shell support (default:
                                      false)
+  --lint-all-files                   lint all files tracked by git, not just staged ones (default:
+                                     false)
   -v, --verbose                      show task output even when tasks succeed; by default only
                                      failed output is shown (default: false)
   -h, --help                         display help for command
@@ -90,6 +92,7 @@ Options:
 - **`--quiet`**: Supress all CLI output, except from tasks.
 - **`--relative`**: Pass filepaths relative to `process.cwd()` (where `lint-staged` runs) to tasks. Default is `false`.
 - **`--shell`**: By default linter commands will be parsed for speed and security. This has the side-effect that regular shell scripts might not work as expected. You can skip parsing of commands with this option.
+- **`--lint-all-files`**: By default linter commands will be executed on staged files, use this to have it run on all files tracked by git. Useful to verify that hooks weren't skipped or after introducing lint-staged to a repository.
 - **`--verbose`**: Show task output even when tasks succeed. By default only failed output is shown.
 
 ## Configuration
@@ -436,6 +439,7 @@ const success = await lintStaged({
   relative: false,
   shell: false
   stash: true,
+  lintAllFiles: false,
   verbose: false
 })
 ```
@@ -454,6 +458,7 @@ const success = await lintStaged({
   relative: false,
   shell: false,
   stash: true,
+  lintAllFiles: false,
   verbose: false
 })
 ```

--- a/bin/lint-staged.js
+++ b/bin/lint-staged.js
@@ -40,6 +40,7 @@ cmdline
   .option('-q, --quiet', 'disable lint-staged’s own console output', false)
   .option('-r, --relative', 'pass relative filepaths to tasks', false)
   .option('-x, --shell', 'skip parsing of tasks for better shell support', false)
+  .option('--lint-all-files', 'lint all files tracked by git, not just staged ones', false)
   .option(
     '-v, --verbose',
     'show task output even when tasks succeed; by default only failed output is shown',
@@ -81,6 +82,7 @@ const options = {
   quiet: !!cmdline.quiet,
   relative: !!cmdline.relative,
   shell: !!cmdline.shell,
+  lintAllFiles: !!cmdline.lintAllFiles,
   verbose: !!cmdline.verbose,
 }
 

--- a/lib/getStagedFiles.js
+++ b/lib/getStagedFiles.js
@@ -2,14 +2,19 @@
 
 const execGit = require('./execGit')
 
-module.exports = async function getStagedFiles(options) {
+const getGitParams = function (lintAllFiles) {
+  if (lintAllFiles === true) {
+    return ['ls-files', '-z']
+  } else {
+    return ['diff', '--staged', '--diff-filter=ACMR', '--name-only', '-z']
+  }
+}
+
+module.exports = async function getStagedFiles(options, lintAllFiles) {
   try {
     // Docs for --diff-filter option: https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---diff-filterACDMRTUXB82308203
     // Docs for -z option: https://git-scm.com/docs/git-diff#Documentation/git-diff.txt--z
-    const lines = await execGit(
-      ['diff', '--staged', '--diff-filter=ACMR', '--name-only', '-z'],
-      options
-    )
+    const lines = await execGit(getGitParams(lintAllFiles), options)
     // With `-z`, git prints `fileA\u0000fileB\u0000fileC\u0000` so we need to remove the last occurrence of `\u0000` before splitting
     // eslint-disable-next-line no-control-regex
     return lines ? lines.replace(/\u0000$/, '').split('\u0000') : []

--- a/lib/index.js
+++ b/lib/index.js
@@ -55,6 +55,7 @@ function loadConfig(configPath) {
  * @param {boolean} [options.relative] - Pass relative filepaths to tasks
  * @param {boolean} [options.shell] - Skip parsing of tasks for better shell support
  * @param {boolean} [options.stash] - Enable the backup stash, and revert in case of errors
+ * @param {boolean} [options.lintAllFiles] - Enable lint all files, not just staged ones
  * @param {boolean} [options.verbose] - Show task output even when tasks succeed; by default only failed output is shown
  * @param {Logger} [logger]
  *
@@ -73,6 +74,7 @@ module.exports = async function lintStaged(
     relative = false,
     shell = false,
     stash = true,
+    lintAllFiles = false,
     verbose = false,
   } = {},
   logger = console
@@ -116,6 +118,7 @@ module.exports = async function lintStaged(
           relative,
           shell,
           stash,
+          lintAllFiles,
           verbose,
         },
         logger

--- a/lib/runAll.js
+++ b/lib/runAll.js
@@ -66,6 +66,7 @@ const runAll = async (
     relative = false,
     shell = false,
     stash = true,
+    lintAllFiles = false,
     verbose = false,
   },
   logger = console
@@ -93,7 +94,7 @@ const runAll = async (
     logger.warn(skippingBackup(hasInitialCommit))
   }
 
-  const files = await getStagedFiles({ cwd: gitDir })
+  const files = await getStagedFiles({ cwd: gitDir }, lintAllFiles)
   if (!files) {
     if (!quiet) ctx.output.push(FAILED_GET_STAGED_FILES)
     ctx.errors.add(GetStagedFilesError)

--- a/test/getStagedFiles.spec.js
+++ b/test/getStagedFiles.spec.js
@@ -23,4 +23,10 @@ describe('getStagedFiles', () => {
     const staged = await getStagedFiles()
     expect(staged).toEqual(null)
   })
+
+  it('should call with ls-files when lintAllFiles is true', async () => {
+    execGit.mockImplementationOnce(async () => '')
+    await getStagedFiles(null, true)
+    expect(execGit).toHaveBeenLastCalledWith(['ls-files', '-z'], null)
+  })
 })


### PR DESCRIPTION
Add a --lint-all-files cmd line option to run lint-staged on all files tracked by git

Fixes #889