### PR TITLE
Add support for .cjs configs

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30,7 +30,9 @@ function loadConfig(configPath) {
       '.lintstagedrc.yaml',
       '.lintstagedrc.yml',
       '.lintstagedrc.js',
+      '.lintstagedrc.cjs',
       'lint-staged.config.js',
+      'lint-staged.config.cjs',
     ],
   })
 


### PR DESCRIPTION
### Add support for `.cjs` files

#### Background
[cosmiconfig v7](https://github.com/davidtheclark/cosmiconfig/blob/master/CHANGELOG.md#700) added support for `.cjs` config files. This is useful in scenarios where the package is using es6 modules (e.g. package.json [`type` parameter is set to `module`](https://nodejs.org/api/esm.html#esm_package_json_type_field)) but the config files are still in common js. Unfortionaltly, a config file ending with `.cjs` is not current supported:

```shell
# ls lint-staged*
lint-staged.config.cjs
# npx lint-staged  -d
  lint-staged:bin Running `lint-staged@10.2.13` +0ms
  lint-staged:bin Options parsed from command-line: {
  allowEmpty: false,
  concurrent: true,
  configPath: undefined,
  debug: true,
  maxArgLength: 131072,
  stash: true,
  quiet: false,
  relative: false,
  shell: false,
  verbose: false
} +1ms
  lint-staged Loading config using `cosmiconfig` +0ms
Config could not be found.

Please make sure you have created it correctly.
See https://github.com/okonet/lint-staged#configuration.
```

#### Prior Art
By way of example, Prettier added similar support [here](https://github.com/prettier/prettier/pull/8890/files#diff-d566515bb6fb446710493e62794f89e8R45).