### PR TITLE
Add support for pre-commit

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,4 @@
+- id: lint-staged
+  name: lint-staged
+  entry: lint-staged
+  language: node


### PR DESCRIPTION
pre-commit (pre-commit.com) is a great way to implement precommit git hooks when working on mutli-language projects.
I took this implementation from [prettier's example](https://github.com/prettier/prettier/blob/master/.pre-commit-hooks.yaml) that offers support. Additional details below:

- pre-commit docs: https://pre-commit.com/#new-hooks

___Example when using `.pre-commit-config.yaml`__

```yaml
repos:
  - repo: https://github.com/pre-commit/pre-commit-hooks
    hooks:
      - id: trailing-whitespace
  - repo: https://github.com/okonet/lint-staged
    hooks:
      - id: lint-staged
```