### PR TITLE
docs: fix & enhance "Use your own globs" example

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,8 +233,9 @@ const micromatch = require('micromatch')
 
 module.exports = {
   '*': (allFiles) => {
-    const match = micromatch(allFiles, ['*.js', '*.ts'])
-    return `eslint ${match.join(' ')}`
+    const codeFiles = micromatch(allFiles, ['**/*.js', '**/*.ts']);
+    const docFiles = micromatch(allFiles, ['**/*.md']);
+    return [`eslint ${codeFiles.join(' ')}`, `mdl ${docFiles.join(' ')}`];
   }
 }
 ```


### PR DESCRIPTION
**Fix:** `micromatch` treats path strings differently, so `*.js` matches only those js files which are in drive's root, given the config function gets array of _absolute_ paths as parameter. This PR fixes that.

**Enhance:** This PR also adds more clarification to the example by showing how multiple commands can be executed on different types of staged files.