### PR TITLE
feat: add ability to use function as config

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ going to execute `eslint` and if it exits with `0` code, it will execute `pretti
 
 ## Using JS functions to customize tasks
 
-When supplying configuration in JS format it is possible to define the task as a function, which will receive an array of staged filenames/paths and should return the complete command as a string. It is also possible to return an array of complete command strings, for example when the task supports only a single file input. The function can be either sync or async.
+When supplying configuration in JS format it is possible to define the config or task as a function, which will receive an array of staged filenames/paths and should return the complete command as a string. It is also possible to return an array of complete command strings, for example when the task supports only a single file input. The function can be either sync or async.
 
 ```ts
 type TaskFn = (filenames: string[]) => string | string[] | Promise<string | string[]>
@@ -238,6 +238,18 @@ module.exports = {
     return [`eslint ${codeFiles.join(' ')}`, `mdl ${docFiles.join(' ')}`];
   }
 }
+```
+Or,
+
+```js
+// lint-staged.config.js
+const micromatch = require('micromatch')
+
+module.exports = (allStagedFiles) => {
+    const codeFiles = micromatch(allStagedFiles, ['**/*.js', '**/*.ts']);
+    const docFiles = micromatch(allStagedFiles, ['**/*.md']);
+    return [`eslint ${codeFiles.join(' ')}`, `mdl ${docFiles.join(' ')}`];
+  }
 ```
 
 ### Example: Ignore files from match

--- a/README.md
+++ b/README.md
@@ -191,13 +191,21 @@ going to execute `eslint` and if it exits with `0` code, it will execute `pretti
 
 ## Using JS configuration file
 
-Writing `lint-staged.config.js` file (or, other JS file which needs to be mentioned in CLI command through `c` flag) is the most powerful way to configure `lint-staged`. From the configuration file, you can export a function which gets an array of all staged file paths as parameter and returns command(s) as string or array of string. This function can be either sync or async. Signature of this function:
+Writing the configuration file in JavaScript is the most powerful way to configure _lint-staged_ (`lint-staged.config.js`, [similar](https://github.com/okonet/lint-staged/README.md#configuration), or passed via `--config`). From the configuration file, you can export either a single function, or an object.
+
+If the `exports` value is a function, it will receive an array of all staged filenames. You can then build your own matchers for the files, and return a command string, or an array or command strings. These strings are considered complete and should include the filename arguments, if wanted.
+
+If the `exports` value is an object, its keys should be glob matches (like in the normal non-js config format). The values can either be like in the normal config, or individual functions like described above. Instead of receiving all matched files, the functions in the exported object will only receive the staged files matching the corresponding glob key.
+
+### Function signature
+
+The function can also be async:
 
 ```ts
 (filenames: string[]) => string | string[] | Promise<string | string[]>
 ```
 
-### Example:
+### Example: Export a function to build your own matchers
 
 ```js
 // lint-staged.config.js
@@ -214,7 +222,6 @@ module.exports = (allStagedFiles) => {
   }
 ```
 
-You can also supply configuration as an object to enjoy in-built filter mechanism like other configuration methods. One extra advantage in the case of JS config is that it is possible to define the task as a function, which has signature of the above function (The only difference is that task functions don't receive array of all staged file paths as parameter unless they have `*` filter pattern).
 
 ### Example: Wrap filenames in single quotes and run once per file
 
@@ -245,7 +252,7 @@ module.exports = {
 ```
 
 ### Example: Use your own globs
-It's better to use function-based configuration if your use case is this.
+It's better to use the [function-based configuration (seen above)](https://github.com/okonet/lint-staged/README.md#example-export-a-function-to-build-your-own-matchers), if your use case is this.
 
 ```js
 // lint-staged.config.js

--- a/lib/formatConfig.js
+++ b/lib/formatConfig.js
@@ -1,0 +1,7 @@
+module.exports = function formatConfig(config) {
+  if (typeof config === 'function') {
+    return { '*': config }
+  }
+
+  return config
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,6 +37,14 @@ function loadConfig(configPath) {
   return configPath ? explorer.load(resolveConfig(configPath)) : explorer.search()
 }
 
+function formatConfig(config) {
+  if (typeof config === 'function') {
+    return { '*': config }
+  }
+
+  return config
+}
+
 /**
  * @typedef {(...any) => void} LogFunction
  * @typedef {{ error: LogFunction, log: LogFunction, warn: LogFunction }} Logger
@@ -88,7 +96,8 @@ module.exports = async function lintStaged(
     debugLog('Successfully loaded config from `%s`:\n%O', resolved.filepath, resolved.config)
     // resolved.config is the parsed configuration object
     // resolved.filepath is the path to the config file that was found
-    const config = validateConfig(resolved.config)
+    const formattedConfig = formatConfig(resolved.config)
+    const config = validateConfig(formattedConfig)
     if (debug) {
       // Log using logger to be able to test through `consolemock`.
       logger.log('Running lint-staged with the following config:')

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,6 +9,7 @@ const { PREVENTED_EMPTY_COMMIT, GIT_ERROR, RESTORE_STASH_EXAMPLE } = require('./
 const printTaskOutput = require('./printTaskOutput')
 const runAll = require('./runAll')
 const { ApplyEmptyCommitError, GetBackupStashError, GitError } = require('./symbols')
+const formatConfig = require('./formatConfig')
 const validateConfig = require('./validateConfig')
 
 const errConfigNotFound = new Error('Config could not be found')
@@ -35,14 +36,6 @@ function loadConfig(configPath) {
   })
 
   return configPath ? explorer.load(resolveConfig(configPath)) : explorer.search()
-}
-
-function formatConfig(config) {
-  if (typeof config === 'function') {
-    return { '*': config }
-  }
-
-  return config
 }
 
 /**

--- a/test/__snapshots__/validateConfig.spec.js.snap
+++ b/test/__snapshots__/validateConfig.spec.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`validateConfig should not throw and should print nothing for function config 1`] = `""`;
+
 exports[`validateConfig should not throw and should print nothing for function task 1`] = `""`;
 
 exports[`validateConfig should not throw and should print nothing for valid config 1`] = `""`;

--- a/test/formatConfig.spec.js
+++ b/test/formatConfig.spec.js
@@ -1,0 +1,17 @@
+import formatConfig from '../lib/formatConfig'
+
+describe('formatConfig', () => {
+  it('Object config should return as is', () => {
+    const simpleConfig = {
+      '*.js': ['eslint --fix', 'git add'],
+    }
+    expect(formatConfig(simpleConfig)).toEqual(simpleConfig)
+  })
+
+  it('Function config should be converted to object', () => {
+    const functionConfig = (stagedFiles) => [`eslint --fix ${stagedFiles}', 'git add`]
+    expect(formatConfig(functionConfig)).toEqual({
+      '*': functionConfig,
+    })
+  })
+})

--- a/test/validateConfig.spec.js
+++ b/test/validateConfig.spec.js
@@ -2,6 +2,8 @@ import makeConsoleMock from 'consolemock'
 
 import validateConfig from '../lib/validateConfig'
 
+import formatConfig from '../lib/formatConfig'
+
 describe('validateConfig', () => {
   const originalConsole = global.console
   beforeAll(() => {
@@ -38,7 +40,7 @@ describe('validateConfig', () => {
 
   it('should not throw and should print nothing for function config', () => {
     const functionConfig = (stagedFiles) => [`eslint ${stagedFiles.join(' ')}`]
-    expect(() => validateConfig(functionConfig)).not.toThrow()
+    expect(() => validateConfig(formatConfig(functionConfig))).not.toThrow()
     expect(console.printHistory()).toMatchSnapshot()
   })
 

--- a/test/validateConfig.spec.js
+++ b/test/validateConfig.spec.js
@@ -36,6 +36,12 @@ describe('validateConfig', () => {
     expect(console.printHistory()).toMatchSnapshot()
   })
 
+  it('should not throw and should print nothing for function config', () => {
+    const functionConfig = (stagedFiles) => [`eslint ${stagedFiles.join(' ')}`]
+    expect(() => validateConfig(functionConfig)).not.toThrow()
+    expect(console.printHistory()).toMatchSnapshot()
+  })
+
   it('should not throw and should print nothing for function task', () => {
     expect(() =>
       validateConfig({


### PR DESCRIPTION
This PR adds an ability to use a function as config. This function will get an array of all staged files as parameter which can be used with own globs. Currently, we need to pass such function as value of `'*'` in config object which doesn't feel good.

This can be further optimized by not using `micromatch` internally when a function config is detected.