### PR TITLE
feat: read config from stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Options:
   -V, --version                      output the version number
   --allow-empty                      allow empty commits when tasks revert all staged changes
                                      (default: false)
-  -c, --config [path]                path to configuration file
+  -c, --config [path]                path to configuration file, or - to read from stdin
   -d, --debug                        print additional debug information (default: false)
   --no-stash                         disable the backup stash, and do not revert in case of
                                      errors
@@ -78,7 +78,7 @@ Options:
 ```
 
 - **`--allow-empty`**: By default, when linter tasks undo all staged changes, lint-staged will exit with an error and abort the commit. Use this flag to allow creating empty git commits.
-- **`--config [path]`**: Manually specify a path to a config file or npm package name. Note: when used, lint-staged won't perform the config file search and print an error if the specified file cannot be found.
+- **`--config [path]`**: Manually specify a path to a config file or npm package name. Note: when used, lint-staged won't perform the config file search and print an error if the specified file cannot be found. If '-' is provided as the filename then the config will be read from stdin, allowing piping in the config like `cat my-config.json | npx lint-staged --config -`.
 - **`--debug`**: Run in debug mode. When set, it does the following:
   - uses [debug](https://github.com/visionmedia/debug) internally to log additional information about staged files, commands being executed, location of binaries, etc. Debug logs, which are automatically enabled by passing the flag, can also be enabled by setting the environment variable `$DEBUG` to `lint-staged*`.
   - uses [`verbose` renderer](https://github.com/SamVerschueren/listr-verbose-renderer) for `listr`; this causes serial, uncoloured output to the terminal, instead of the default (beautified, dynamic) output.

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -39,6 +39,8 @@ const RESTORE_STASH_EXAMPLE = `  Any lost modifications can be restored from a g
     > git stash apply --index stash@{0}
 `
 
+const CONFIG_STDIN_ERROR = 'Error: Could not read config from stdin.'
+
 module.exports = {
   NOT_GIT_REPO,
   FAILED_GET_STAGED_FILES,
@@ -51,4 +53,5 @@ module.exports = {
   GIT_ERROR,
   PREVENTED_EMPTY_COMMIT,
   RESTORE_STASH_EXAMPLE,
+  CONFIG_STDIN_ERROR,
 }


### PR DESCRIPTION
Went back and forth on whether to put the functionality in `bin/lint-staged.js` or `lib/index.js`. Decided on `bin/lint-staged.js` since it doesn't make full sense to include in the programmatic API since the library user can read the config from wherever they'd like and provide it as an object.