### PR TITLE
docs: use bibliography-style links in related posts section of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ This project contains a script that will run arbitrary shell tasks with a list o
 
 ## Related blogs posts and talks
 
-- [Make Linting Great Again](https://medium.com/@okonetchnikov/make-linting-great-again-f3890e1ad6b8#.8qepn2b5l)
-- [Running Jest Tests Before Each Git Commit](https://benmccormick.org/2017/02/26/running-jest-tests-before-each-git-commit/)
-- [AgentConf: Make Linting Great Again](https://www.youtube.com/watch?v=-mhY7e-EsC4)
-- [SurviveJS Interview](https://survivejs.com/blog/lint-staged-interview/)
+- [Introductory Medium post - Andrey Okonetchnikov, 2016](https://medium.com/@okonetchnikov/make-linting-great-again-f3890e1ad6b8#.8qepn2b5l)
+- [Running Jest Tests Before Each Git Commit - Ben McCormick, 2017](https://benmccormick.org/2017/02/26/running-jest-tests-before-each-git-commit/)
+- [AgentConf presentation - Andrey Okonetchnikov, 2018](https://www.youtube.com/watch?v=-mhY7e-EsC4)
+- [SurviveJS interview - Juho Vepsäläinen and Andrey Okonetchnikov, 2018](https://survivejs.com/blog/lint-staged-interview/)
 
 > If you've written one, please submit a PR with the link to it!
 


### PR DESCRIPTION
This effectively removes political references.

Closes #931

---

The link to Ben McCormick's blog post is left as is (title, title-case) in an effort to minimize disruption there.  Sentence-case is used for the others as a subtle indicator of being a description and not a title.  Author(s) and date are added to all for the sake of consistency.