### PR TITLE
fix: concurrent option is not working correctly

### DIFF
--- a/bin/lint-staged.js
+++ b/bin/lint-staged.js
@@ -76,7 +76,7 @@ const getMaxArgLength = () => {
 
 const options = {
   allowEmpty: !!cmdline.allowEmpty,
-  concurrent: cmdline.concurrent,
+  concurrent: JSON.parse(cmdline.concurrent),
   configPath: cmdline.config,
   debug: !!cmdline.debug,
   maxArgLength: getMaxArgLength() / 2,


### PR DESCRIPTION
Hello.

The value of `--concurrent` CLI option is passed as string like `'true'` and `'2'`.
And tasks run serially when this option is set (even `--concurrent true`).

This is because the code to assign concurrency looks like this.
```ts
// node_modules/listr2/dist/listr.js:34-40 
this.concurrency = 1;
if (this.options.concurrent === true) {
    this.concurrency = Infinity;
}
else if (typeof this.options.concurrent === 'number') {
    this.concurrency = this.options.concurrent;
}
```

I have fixed this behavior.
Please review this PR, thanks.


before → after.
![image](https://user-images.githubusercontent.com/46585162/107056874-24bf0600-6816-11eb-854f-c391a93db5f3.png)
