### PR TITLE
Husky to simple-git-hooks migration in mrm

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The fastest way to start using lint-staged is to run following command in your t
 npx mrm lint-staged
 ```
 
-It will install and configure [husky](https://github.com/typicode/husky) and lint-staged depending on code quality tools from `package.json` dependencies so please make sure you install (`npm install --save-dev`) and configure all code quality tools like [Prettier](https://prettier.io), [ESlint](https://eslint.org) prior that.
+It will install and configure [simple-git-hooks](https://github.com/toplenboren/simple-git-hooks) and lint-staged depending on code quality tools from `package.json` dependencies so please make sure you install (`npm install --save-dev`) and configure all code quality tools like [Prettier](https://prettier.io), [ESlint](https://eslint.org) prior that.
 
 Don't forget to commit changes to `package.json` to share this setup with your team!
 


### PR DESCRIPTION
`mrm` [recently migrarted](https://github.com/sapegin/mrm/pull/149) from `husky` to [`simple-git-hooks`](https://github.com/toplenboren/simple-git-hooks). I updated the text according to these changes.

This `mrm` migration brought  these benefits to users:
* `simple-git-hooks` has 0 dependencies and took 10 KB of `node_modules` space compared to 1 MB of husky 4.
* `simple-git-hooks` doesn’t read config on every `pre-commit` hook call which increases the performance. It uses the husky 5 model when you need explicitly to call a script on config changes. But it is a good trade-off for `lint-staged` case. It should give around a 0.5 second performance boost for `pre-commit`.

Comparison with husky 5:
1. We can start having all husky 5 benefits (performance, small size) without waiting for MIT license for husky 5.
2. `simple-git-hooks` is smaller than husky 5.
3. husky 5 [requires](https://github.com/typicode/husky/issues/868) extra scripts in `package.json`.
4. husky 5 [requires](https://typicode.github.io/husky/#/?id=yarn-v2) an extra `pinst` dependency for Yarn 2. `simple-git-hooks` has [out-of-the box](https://github.com/toplenboren/simple-git-hooks/issues/30) Yarn 2 support.

I already tested `simple-git-hooks` on Autoprefixer, PostCSS, Browserslist, and my commercial projects (with a big team). Everything works great. Other people [reported](https://twitter.com/smithua/status/1372490975029911559) about successful migration too. @toplenboren `simple-git-hooks` maintainer is always open for the changes and answers quickly.