### PR TITLE
Reduce dependencies size

### DIFF
--- a/bin/lint-staged.js
+++ b/bin/lint-staged.js
@@ -5,7 +5,7 @@
 const fs = require('fs')
 
 // Force colors for packages that depend on https://www.npmjs.com/package/supports-color
-const { supportsColor } = require('chalk')
+const supportsColor = require('supports-color')
 if (supportsColor && supportsColor.level) {
   process.env.FORCE_COLOR = supportsColor.level.toString()
 }

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -1,11 +1,11 @@
 'use strict'
 
-const chalk = require('chalk')
+const { red, redBright, yellow } = require('colorette')
 const { error, info, warning } = require('log-symbols')
 
-const NOT_GIT_REPO = chalk.redBright(`${error} Current directory is not a git directory!`)
+const NOT_GIT_REPO = redBright(`${error} Current directory is not a git directory!`)
 
-const FAILED_GET_STAGED_FILES = chalk.redBright(`${error} Failed to get staged files!`)
+const FAILED_GET_STAGED_FILES = redBright(`${error} Failed to get staged files!`)
 
 const NO_STAGED_FILES = `${info} No staged files found.`
 
@@ -13,10 +13,10 @@ const NO_TASKS = `${info} No staged files match any configured task.`
 
 const skippingBackup = (hasInitialCommit) => {
   const reason = hasInitialCommit ? '`--no-stash` was used' : 'there’s no initial commit yet'
-  return `${warning} ${chalk.yellow(`Skipping backup because ${reason}.\n`)}`
+  return `${warning} ${yellow(`Skipping backup because ${reason}.\n`)}`
 }
 
-const DEPRECATED_GIT_ADD = `${warning} ${chalk.yellow(
+const DEPRECATED_GIT_ADD = `${warning} ${yellow(
   `Some of your tasks use \`git add\` command. Please remove it from the config since all modifications made by tasks will be automatically added to the git commit index.`
 )}
 `
@@ -25,10 +25,10 @@ const TASK_ERROR = 'Skipped because of errors from tasks.'
 
 const SKIPPED_GIT_ERROR = 'Skipped because of previous git error.'
 
-const GIT_ERROR = `\n  ${error} ${chalk.red(`lint-staged failed due to a git error.`)}`
+const GIT_ERROR = `\n  ${error} ${red(`lint-staged failed due to a git error.`)}`
 
 const PREVENTED_EMPTY_COMMIT = `
-  ${warning} ${chalk.yellow(`lint-staged prevented an empty git commit.
+  ${warning} ${yellow(`lint-staged prevented an empty git commit.
   Use the --allow-empty option to continue, or check your task configuration`)}
 `
 

--- a/lib/resolveTaskFn.js
+++ b/lib/resolveTaskFn.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { redBright, dim } = require('chalk')
+const { redBright, dim } = require('colorette')
 const execa = require('execa')
 const debug = require('debug')('lint-staged:task')
 const { parseArgsStringToArgv } = require('string-argv')

--- a/lib/validateConfig.js
+++ b/lib/validateConfig.js
@@ -2,7 +2,7 @@
 
 'use strict'
 
-const chalk = require('chalk')
+const { bold } = require('colorette')
 const format = require('stringify-object')
 
 const debug = require('debug')('lint-staged:cfg')
@@ -25,13 +25,11 @@ const formatError = (helpMsg) => `● Validation Error:
 Please refer to https://github.com/okonet/lint-staged#configuration for more information...`
 
 const createError = (opt, helpMsg, value) =>
-  formatError(`Invalid value for '${chalk.bold(opt)}'.
+  formatError(`Invalid value for '${bold(opt)}'.
 
   ${helpMsg}.
- 
-  Configured value is: ${chalk.bold(
-    format(value, { inlineCharacterLimit: Number.POSITIVE_INFINITY })
-  )}`)
+
+  Configured value is: ${bold(format(value, { inlineCharacterLimit: Number.POSITIVE_INFINITY }))}`)
 
 /**
  * Runs config validation. Throws error if the config is not valid.

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "chalk": "^4.1.1",
     "cli-truncate": "^2.1.0",
+    "colorette": "^1.2.2",
     "commander": "^7.2.0",
     "cosmiconfig": "^7.0.0",
     "debug": "^4.3.1",
@@ -41,7 +41,8 @@
     "normalize-path": "^3.0.0",
     "please-upgrade-node": "^3.2.0",
     "string-argv": "0.3.1",
-    "stringify-object": "^3.3.0"
+    "stringify-object": "^3.3.0",
+    "supports-color": "^9.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3298,6 +3298,11 @@ has-flag@^4.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
+has-flag@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/has-flag/-/has-flag-5.0.0.tgz#36e12f0b14052d6ffc8007c6f768a87623f6f692"
+  integrity sha512-dmhh9fPE7WRat4yiFvyhXh7LytudXDcE89VEdR3sxfWQKtFPr7jpXip5H402aeFfA36ucqSKecGEapc7N44k+g==
+
 has-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
@@ -5692,6 +5697,13 @@ supports-color@^7.0.0, supports-color@^7.1.0:
   integrity sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
   dependencies:
     has-flag "^4.0.0"
+
+supports-color@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.npmjs.org/supports-color/-/supports-color-9.0.0.tgz#201a80bcefe03598cd2439f7a2ab9a855ab15570"
+  integrity sha512-8E5dgZd3FsJaYM+TEbKnwX4VWsP+0gDDsI2CKZQidScJv2QDbt0K8ZM6bHP1nq/pUrH6Nm/ZQvBFdvFVLRuuQQ==
+  dependencies:
+    has-flag "^5.0.0"
 
 supports-hyperlinks@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
See #978 

- [x] replace `chalk` with `colorette`
  - so far this doesn't bring much since other tools (e.g. `execa`) depend on `chalk`
- [ ] replace `cosmiconfig` with `lilconfig`