### PR TITLE
fix: the shell option value should be optional instead of required

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Options:
                                      tasks serially (default: true)
   -q, --quiet                        disable lint-staged’s own console output (default: false)
   -r, --relative                     pass relative filepaths to tasks (default: false)
-  -x, --shell <path>                 skip parsing of tasks for better shell support (default:
+  -x, --shell [path]                 skip parsing of tasks for better shell support (default:
                                      false)
   -v, --verbose                      show task output even when tasks succeed; by default only
                                      failed output is shown (default: false)

--- a/bin/lint-staged.js
+++ b/bin/lint-staged.js
@@ -42,7 +42,7 @@ cmdline
   )
   .option('-q, --quiet', 'disable lint-staged’s own console output', false)
   .option('-r, --relative', 'pass relative filepaths to tasks', false)
-  .option('-x, --shell <path>', 'skip parsing of tasks for better shell support', false)
+  .option('-x, --shell [path]', 'skip parsing of tasks for better shell support', false)
   .option(
     '-v, --verbose',
     'show task output even when tasks succeed; by default only failed output is shown',


### PR DESCRIPTION
This fixes a bug introduced in #994 where any text after the `--shell` option was interpreted as its value, for example in `--shell  --relative` the value was `"--relative"` instead of implied `true`.