### PR TITLE
Use /usr/bin/env sh instead of direct path

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 . "$(dirname "$0")/_/husky.sh"
 
 node bin/lint-staged.js

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ All examples assume you've already set up lint-staged in the `package.json` file
 In `.husky/pre-commit`
 
 ```shell
-#!/bin/sh
+#!/usr/bin/env sh
 . "$(dirname "$0")/_/husky.sh"
 
 npx lint-staged


### PR DESCRIPTION
This ensures the shell scripts work across different UNIX operating system: https://en.wikipedia.org/wiki/Shebang_(Unix)#Program_location

For example, I'm using NixOS and unfortunately `sh` is not located at `/bin/sh`