### PR TITLE
Idea: reducing size of node_modules with postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "lint": "eslint .",
     "pretest": "npm run lint",
     "test": "jest --coverage",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "postinstall": "rimraf node_modules/rxjs/src node_modules/rxjs/bundles node_modules/rxjs/_esm5 node_modules/rxjs/_esm2015"
   },
   "dependencies": {
     "chalk": "^4.1.1",
@@ -39,6 +40,7 @@
     "micromatch": "^4.0.4",
     "normalize-path": "^3.0.0",
     "please-upgrade-node": "^3.2.0",
+    "rimraf": "^3.0.2",
     "string-argv": "0.3.1",
     "stringify-object": "^3.3.0"
   },


### PR DESCRIPTION
Looks like we can reduce the size of node_modules by ~40 percent

All we need is to delete necessary folders:
- node_modules/rxjs/src
- node_modules/rxjs/bundles
- node_modules/rxjs/_esm5 
- node_modules/rxjs/_esm2015

---

Without **postinstall** script we have

```
❯ npm install --only=prod --quite

added 105 packages, and audited 106 packages in 2s

17 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities

❯ du -sh node_modules
23M     node_modules
```

> **Pay attention to 23M**. This is size of node_modules.

With simple postinstall command, we have

```
❯ npm install --only=prod --quite

> lint-staged@0.0.0-development postinstall
> rimraf node_modules/rxjs/src node_modules/rxjs/bundles node_modules/rxjs/_esm5 node_modules/rxjs/_esm2015


added 105 packages, and audited 106 packages in 2s

17 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities

❯ du -sh node_modules
14M     node_modules
```

> **Pay attention to 14M**. This is size of node_modules.

cc @ai