### PR TITLE
Unbreak windows by correctly normalizing cwd

### DIFF
--- a/lib/resolveGitRepo.js
+++ b/lib/resolveGitRepo.js
@@ -56,7 +56,7 @@ const resolveGitRepo = async (cwd = process.cwd()) => {
     // read the path of the current directory relative to the top-level directory
     // don't read the toplevel directly, it will lead to an posix conform path on non posix systems (cygwin)
     const gitRel = normalize(await execGit(['rev-parse', '--show-prefix']))
-    const gitDir = determineGitDir(cwd, gitRel)
+    const gitDir = determineGitDir(normalize(cwd), gitRel)
     const gitConfigDir = normalize(await resolveGitConfigDir(gitDir))
 
     debugLog('Resolved git directory to be `%s`', gitDir)


### PR DESCRIPTION
Normalizing the cwd should unbreak non cygwin builds again. Fixes hopefully #1027 .
Tested on win git-bash, win git-cmd, and cygwin, also still works on linux