### PR TITLE
fix: read version number from lint-staged package.json (#1043)

### DIFF
--- a/bin/lint-staged.js
+++ b/bin/lint-staged.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
 import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
 
 import cmdline from 'commander'
 import debug from 'debug'
@@ -17,7 +19,8 @@ if (supportsColor.stdout) {
 // Do not terminate main Listr process on SIGINT
 process.on('SIGINT', () => {})
 
-const packageJson = JSON.parse(fs.readFileSync('package.json'))
+const packageJsonPath = path.join(fileURLToPath(import.meta.url), '../../package.json')
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath))
 const version = packageJson.version
 
 cmdline


### PR DESCRIPTION
I think the current code is reading package.json from the current working directory.

If the package.json did not have a version number, it would cause lint-staged to crash.