### PR TITLE
fix: await for dynamic import promise when loading JS config

### DIFF
--- a/lib/loadConfig.js
+++ b/lib/loadConfig.js
@@ -57,7 +57,13 @@ const resolveConfig = (configPath) => {
 /**
  * @param {string} [configPath]
  */
-export const loadConfig = (configPath) => {
+export const loadConfig = async (configPath) => {
   const explorer = lilconfig('lint-staged', { searchPlaces, loaders })
-  return configPath ? explorer.load(resolveConfig(configPath)) : explorer.search()
+  const result = await (configPath ? explorer.load(resolveConfig(configPath)) : explorer.search())
+  if (!result) return null
+
+  const { config, filepath } = result
+
+  // config is a promise when using the `dynamicImport` loader
+  return { config: await config, filepath }
 }


### PR DESCRIPTION
This PR fixes a regression introduced in [v12.1.0](https://github.com/okonet/lint-staged/releases/tag/v12.1.0) that breaks JS configuration loading. For some reason the tests pass, I assume this is because the code gets transpiled with Babel.