### PR TITLE
fix(deps): remove enquirer because it's now optional by listr2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "colorette": "^2.0.16",
         "commander": "^8.3.0",
         "debug": "^4.3.3",
-        "enquirer": "^2.3.6",
         "execa": "^5.1.1",
         "lilconfig": "2.0.4",
         "listr2": "^3.13.5",
@@ -2608,6 +2607,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
       "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "devOptional": true,
       "engines": {
         "node": ">=6"
       }
@@ -3490,6 +3490,7 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
       "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "devOptional": true,
       "dependencies": {
         "ansi-colors": "^4.1.1"
       },
@@ -10741,7 +10742,8 @@
     "ansi-colors": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA=="
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "devOptional": true
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -11428,6 +11430,7 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
       "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "devOptional": true,
       "requires": {
         "ansi-colors": "^4.1.1"
       }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "colorette": "^2.0.16",
     "commander": "^8.3.0",
     "debug": "^4.3.3",
-    "enquirer": "^2.3.6",
     "execa": "^5.1.1",
     "lilconfig": "2.0.4",
     "listr2": "^3.13.5",


### PR DESCRIPTION
The `enquirer` dependency is unused by _lint-staged_, because we don't use interactive prompts. Previously it was removed but then restored because of an "unmet peer dependency warning", see https://github.com/okonet/lint-staged/pull/1050 and https://github.com/okonet/lint-staged/issues/1048.

Now [enquirer@3.13.4](https://github.com/cenk1cenk2/listr2/releases/tag/v3.13.4) has marked it as an optional peer dependency, so the warning is no longer emitted (see https://github.com/cenk1cenk2/listr2/issues/589), so we can safely remove it again.