### PR TITLE
Add missing cwd option when calling execGit function

### DIFF
--- a/lib/resolveGitRepo.js
+++ b/lib/resolveGitRepo.js
@@ -54,7 +54,7 @@ export const resolveGitRepo = async (cwd = process.cwd()) => {
 
     // read the path of the current directory relative to the top-level directory
     // don't read the toplevel directly, it will lead to an posix conform path on non posix systems (cygwin)
-    const gitRel = normalize(await execGit(['rev-parse', '--show-prefix']))
+    const gitRel = normalize(await execGit(['rev-parse', '--show-prefix'], { cwd }))
     const gitDir = determineGitDir(normalize(cwd), gitRel)
     const gitConfigDir = normalize(await resolveGitConfigDir(gitDir))
 


### PR DESCRIPTION
I've found this issue when executing lintStaged from node v16. My current setup is as follows:

I have 2 different folders:
- `/path/to/project/git` => root folder of the git repository
- `/path/to/project` => root folder for the project, which is NOT a git repository

When executing lintStaged, the setup is as follows:
- Node JS process is executed with `process.cwd() == /path/to/project`
- Inside the JS file executed by Node, I call  `lintStaged({ cwd: '/path/to/project/git'})`
- I get the `Current directory is not a git directory!` error

After debugging the code, the issue seems to be that `resolveGitRepo()` is calling `execGit()` without passing the cwd parameter. Without this parameter, `execGit()` is forced to fall back to `process.cwd()`, which in my case is NOT a proper git directory.