### PR TITLE
feat: sparse config

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Options:
   --allow-empty                      allow empty commits when tasks revert all staged changes
                                      (default: false)
   -c, --config [path]                path to configuration file, or - to read from stdin
+  --sparse-config                    read multiple configuration files from subdirectories, useful with monorepos (default: false)
   -d, --debug                        print additional debug information (default: false)
   --no-stash                         disable the backup stash, and do not revert in case of
                                      errors
@@ -650,6 +651,27 @@ If you wish to use `lint-staged` in a multi package monorepo, it is recommended 
 [`lerna`](https://github.com/lerna/lerna) can be used to execute the `precommit` script in all sub-packages.
 
 Example repo: [sudo-suhas/lint-staged-multi-pkg](https://github.com/sudo-suhas/lint-staged-multi-pkg).
+
+Or using `lint-staged` with `--sparse-config`. In sparse config mode, each git staged file will use the closest `lint-staged` configuration to run tasks.
+
+Assuming monorepo file structure as fllow:
+
+```
+-- monorepo
+ |- packages
+     |- foo
+        |- .lintstagedrc.json
+     |- bar
+        |- .lintstagedrc.json
+```
+
+if git staged files are 
+
+- packages/foo/index.js
+- packages/foo/lib.js
+- packages/bar/utils.js
+
+With `--sparse-config`, `packages/foo/index.js` and `packages/foo/lib.js` uses configuration from `packages/foo/.lintstagedrc.json`, while `packages/bar/utils.js` uses configuration from `packages/bar/.lintstagedrc.json`. If no `lint-staged` configuration can be found from file path, nothing happens.
 
 </details>
 

--- a/bin/lint-staged.js
+++ b/bin/lint-staged.js
@@ -27,7 +27,7 @@ cmdline
   .version(version)
   .option('--allow-empty', 'allow empty commits when tasks revert all staged changes', false)
   .option('-c, --config [path]', 'path to configuration file, or - to read from stdin')
-  .option('--sparse-config', 'use sparse config mode, mostly used in a monorepo', false)
+  .option('--sparse-config', 'read multiple configuration files from subdirectories, useful with monorepos', false)
   .option('-d, --debug', 'print additional debug information', false)
   .option('--no-stash', 'disable the backup stash, and do not revert in case of errors', false)
   .option(

--- a/bin/lint-staged.js
+++ b/bin/lint-staged.js
@@ -27,6 +27,7 @@ cmdline
   .version(version)
   .option('--allow-empty', 'allow empty commits when tasks revert all staged changes', false)
   .option('-c, --config [path]', 'path to configuration file, or - to read from stdin')
+  .option('--sparse-config', 'use sparse config mode, mostly used in a monorepo', false)
   .option('-d, --debug', 'print additional debug information', false)
   .option('--no-stash', 'disable the backup stash, and do not revert in case of errors', false)
   .option(
@@ -74,6 +75,7 @@ const options = {
   allowEmpty: !!cmdlineOptions.allowEmpty,
   concurrent: JSON.parse(cmdlineOptions.concurrent),
   configPath: cmdlineOptions.config,
+  sparseConfig: !!cmdlineOptions.sparseConfig,
   debug: !!cmdlineOptions.debug,
   maxArgLength: getMaxArgLength() / 2,
   stash: !!cmdlineOptions.stash, // commander inverts `no-<x>` flags to `!x`

--- a/bin/lint-staged.js
+++ b/bin/lint-staged.js
@@ -27,7 +27,11 @@ cmdline
   .version(version)
   .option('--allow-empty', 'allow empty commits when tasks revert all staged changes', false)
   .option('-c, --config [path]', 'path to configuration file, or - to read from stdin')
-  .option('--sparse-config', 'read multiple configuration files from subdirectories, useful with monorepos', false)
+  .option(
+    '--sparse-config',
+    'read multiple configuration files from subdirectories, useful with monorepos',
+    false
+  )
   .option('-d, --debug', 'print additional debug information', false)
   .option('--no-stash', 'disable the backup stash, and do not revert in case of errors', false)
   .option(

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 import debug from 'debug'
 import inspect from 'object-inspect'
 
-import { loadConfig } from './loadConfig.js'
+import { loadConfigAndValidateWithCache } from './loadConfig.js'
 import { PREVENTED_EMPTY_COMMIT, GIT_ERROR, RESTORE_STASH_EXAMPLE } from './messages.js'
 import { printTaskOutput } from './printTaskOutput.js'
 import { runAll } from './runAll.js'
@@ -11,7 +11,6 @@ import {
   GetBackupStashError,
   GitError,
 } from './symbols.js'
-import { validateConfig } from './validateConfig.js'
 import { validateOptions } from './validateOptions.js'
 
 const debugLog = debug('lint-staged')
@@ -60,23 +59,25 @@ const lintStaged = async (
 ) => {
   await validateOptions({ shell }, logger)
 
-  let inputConfig = configObject
+  const inputConfigInfo = configObject
+    ? {
+        config: configObject,
+        filepath: null,
+      }
+    : await loadConfigAndValidateWithCache({
+        ...(configPath ? { configPath } : { searchStartPath: cwd }),
+        logger,
+      })
 
-  if (!sparseConfig) {
-    if (!inputConfig) {
-      const loadedConfigInfo = await loadConfig({ configPath, logger })
-      inputConfig = loadedConfigInfo && loadedConfigInfo.config
-    }
-    if (!inputConfig) {
-      logger.error(`${ConfigNotFoundError.message}.`)
-      throw ConfigNotFoundError
-    }
+  if ((!inputConfigInfo || !inputConfigInfo.config) && !sparseConfig) {
+    logger.error(`${ConfigNotFoundError.message}.`)
+    throw ConfigNotFoundError
   }
 
-  let config
-  if (inputConfig) {
-    config = validateConfig(inputConfig, logger)
+  const config = inputConfigInfo && inputConfigInfo.config
+  const configFilepath = inputConfigInfo && inputConfigInfo.filepath
 
+  if (config) {
     if (debug) {
       // Log using logger to be able to test through `consolemock`.
       logger.log('Running lint-staged with the following config:')
@@ -98,6 +99,7 @@ const lintStaged = async (
         allowEmpty,
         concurrent,
         config,
+        configFilepath,
         sparseConfig,
         cwd,
         debug,

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,6 +27,7 @@ const debugLog = debug('lint-staged')
  * @param {boolean | number} [options.concurrent] - The number of tasks to run concurrently, or false to run tasks serially
  * @param {object}  [options.config] - Object with configuration for programmatic API
  * @param {string} [options.configPath] - Path to configuration file
+ * @param {boolean} [options.sparseConfig] - Enable sparse config mode
  * @param {Object} [options.cwd] - Current working directory
  * @param {boolean} [options.debug] - Enable debug mode
  * @param {number} [options.maxArgLength] - Maximum argument string length
@@ -45,6 +46,7 @@ const lintStaged = async (
     concurrent = true,
     config: configObject,
     configPath,
+    sparseConfig = false,
     cwd = process.cwd(),
     debug = false,
     maxArgLength,
@@ -58,23 +60,32 @@ const lintStaged = async (
 ) => {
   await validateOptions({ shell }, logger)
 
-  const inputConfig = configObject || (await loadConfig(configPath, logger))
+  let inputConfig = configObject
 
-  if (!inputConfig) {
-    logger.error(`${ConfigNotFoundError.message}.`)
-    throw ConfigNotFoundError
+  if (!sparseConfig) {
+    if (!inputConfig) {
+      const loadedConfigInfo = await loadConfig({ configPath, logger })
+      inputConfig = loadedConfigInfo && loadedConfigInfo.config
+    }
+    if (!inputConfig) {
+      logger.error(`${ConfigNotFoundError.message}.`)
+      throw ConfigNotFoundError
+    }
   }
 
-  const config = validateConfig(inputConfig, logger)
+  let config
+  if (inputConfig) {
+    config = validateConfig(inputConfig, logger)
 
-  if (debug) {
-    // Log using logger to be able to test through `consolemock`.
-    logger.log('Running lint-staged with the following config:')
-    logger.log(inspect(config, { indent: 2 }))
-  } else {
-    // We might not be in debug mode but `DEBUG=lint-staged*` could have
-    // been set.
-    debugLog('lint-staged config:\n%O', config)
+    if (debug) {
+      // Log using logger to be able to test through `consolemock`.
+      logger.log('Running lint-staged with the following config:')
+      logger.log(inspect(config, { indent: 2 }))
+    } else {
+      // We might not be in debug mode but `DEBUG=lint-staged*` could have
+      // been set.
+      debugLog('lint-staged config:\n%O', config)
+    }
   }
 
   // Unset GIT_LITERAL_PATHSPECS to not mess with path interpretation
@@ -87,6 +98,7 @@ const lintStaged = async (
         allowEmpty,
         concurrent,
         config,
+        sparseConfig,
         cwd,
         debug,
         maxArgLength,

--- a/lib/loadConfig.js
+++ b/lib/loadConfig.js
@@ -4,6 +4,8 @@ import debug from 'debug'
 import { lilconfig } from 'lilconfig'
 import YAML from 'yaml'
 
+import { validateConfig } from './validateConfig'
+
 const debugLog = debug('lint-staged:loadConfig')
 
 /**
@@ -58,7 +60,7 @@ const resolveConfig = (configPath) => {
 /**
  * @param {Object} opts
  * @param {string} [opts.configPath]
- * @param {string} [opt.searchStartPath]
+ * @param {string} [opts.searchStartPath]
  * @param {Logger} [opts.logger]
  * @returns {Object} `lint-staged` config info
  */
@@ -92,4 +94,41 @@ export const loadConfig = async ({ configPath, searchStartPath = process.cwd(), 
     logger.error(error)
     return null
   }
+}
+
+/**
+ * Cache for `loadConfig` results by searchStartPath.
+ */
+let searchStartPath2configInfo = {}
+
+export const clearLoadConfigCache = () => {
+  searchStartPath2configInfo = {}
+}
+
+/**
+ * @param {Object} opts
+ * @param {string} [opts.configPath]
+ * @param {string} [opts.searchStartPath]
+ * @param {Logger} [opts.logger]
+ * @returns {Object} validated `lint-staged` config info
+ */
+export const loadConfigAndValidateWithCache = async (opts) => {
+  const { searchStartPath } = opts
+  if (searchStartPath && searchStartPath2configInfo[searchStartPath]) {
+    return searchStartPath2configInfo[searchStartPath]
+  }
+
+  const configInfo = await loadConfig(opts)
+
+  let ret = configInfo
+
+  if (configInfo) {
+    configInfo.config = validateConfig(configInfo.config)
+  }
+
+  if (searchStartPath) {
+    searchStartPath2configInfo[searchStartPath] = ret
+  }
+
+  return ret
 }

--- a/lib/loadConfig.js
+++ b/lib/loadConfig.js
@@ -81,7 +81,7 @@ export const loadConfig = async ({ configPath, searchStartPath = process.cwd(), 
     const config = await result.config
     const filepath = result.filepath
 
-    debugLog('Successfully loaded config from `%s`:\n%O', result.filepath, config)
+    debugLog('Successfully loaded config from `%s`:\n%O', filepath, config)
 
     return {
       filepath,

--- a/lib/loadConfig.js
+++ b/lib/loadConfig.js
@@ -56,10 +56,13 @@ const resolveConfig = (configPath) => {
 }
 
 /**
- * @param {string} [configPath]
- * @param {Logger} [logger]
+ * @param {Object} opts
+ * @param {string} [opts.configPath]
+ * @param {string} [opt.searchStartPath]
+ * @param {Logger} [opts.logger]
+ * @returns {Object} `lint-staged` config info
  */
-export const loadConfig = async (configPath, logger) => {
+export const loadConfig = async ({ configPath, searchStartPath = process.cwd(), logger }) => {
   try {
     if (configPath) {
       debugLog('Loading configuration from `%s`...', configPath)
@@ -69,15 +72,21 @@ export const loadConfig = async (configPath, logger) => {
 
     const explorer = lilconfig('lint-staged', { searchPlaces, loaders })
 
-    const result = await (configPath ? explorer.load(resolveConfig(configPath)) : explorer.search())
+    const result = await (configPath
+      ? explorer.load(resolveConfig(configPath))
+      : explorer.search(searchStartPath))
     if (!result) return null
 
     // config is a promise when using the `dynamicImport` loader
     const config = await result.config
+    const filepath = result.filepath
 
     debugLog('Successfully loaded config from `%s`:\n%O', result.filepath, config)
 
-    return config
+    return {
+      filepath,
+      config,
+    }
   } catch (error) {
     debugLog('Failed to load configuration from `%s`', configPath)
     logger.error(error)

--- a/lib/makeCmdTasks.js
+++ b/lib/makeCmdTasks.js
@@ -29,12 +29,13 @@ const getTitleLength = (renderer, columns = process.stdout.columns) => {
  * @param {object} options
  * @param {Array<string|Function>|string|Function} options.commands
  * @param {Array<string>} options.files
+ * @param {string} options.cwd
  * @param {string} options.gitDir
  * @param {string} options.renderer
  * @param {Boolean} shell
  * @param {Boolean} verbose
  */
-export const makeCmdTasks = async ({ commands, files, gitDir, renderer, shell, verbose }) => {
+export const makeCmdTasks = async ({ commands, files, cwd, gitDir, renderer, shell, verbose }) => {
   debugLog('Creating listr tasks for commands %o', commands)
   const commandArray = Array.isArray(commands) ? commands : [commands]
   const cmdTasks = []
@@ -61,7 +62,7 @@ export const makeCmdTasks = async ({ commands, files, gitDir, renderer, shell, v
 
       // Truncate title to single line based on renderer
       const title = cliTruncate(command, getTitleLength(renderer))
-      const task = resolveTaskFn({ command, files, gitDir, isFn, shell, verbose })
+      const task = resolveTaskFn({ command, files, cwd, gitDir, isFn, shell, verbose })
       cmdTasks.push({ title, command, task })
     }
   }

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -63,3 +63,10 @@ export const RESTORE_STASH_EXAMPLE = `  Any lost modifications can be restored f
 `
 
 export const CONFIG_STDIN_ERROR = 'Error: Could not read config from stdin.'
+
+export const getMultiConfigFilesWarning = (configFiles) => {
+  return yellow(`${warning} Found multiple lint-staged config files but \`--sparse-config\` was not used.
+  Only the topmost config file will be used:
+    ${configFiles.map((f) => `- ${f}`).join('\n    ')}
+`)
+}

--- a/lib/resolveTaskFn.js
+++ b/lib/resolveTaskFn.js
@@ -93,7 +93,7 @@ export const resolveTaskFn = ({
 
   const execaOptions = { preferLocal: true, reject: false, shell }
   if (cwd) {
-    execaOptions.cwd
+    execaOptions.cwd = cwd
   } else if (relative) {
     execaOptions.cwd = process.cwd()
   } else if (/^git(\.exe)?/i.test(cmd) && gitDir !== process.cwd()) {

--- a/lib/resolveTaskFn.js
+++ b/lib/resolveTaskFn.js
@@ -68,6 +68,7 @@ const makeErr = (command, result, ctx) => {
  *
  * @param {Object} options
  * @param {string} options.command — Linter task
+ * @param {String} options.cwd - Linter task working directory
  * @param {String} options.gitDir - Current git repo path
  * @param {Boolean} options.isFn - Whether the linter task is a function
  * @param {Array<string>} options.files — Filepaths to run the linter task against
@@ -81,6 +82,7 @@ export const resolveTaskFn = ({
   files,
   gitDir,
   isFn,
+  cwd,
   relative,
   shell = false,
   verbose = false,
@@ -90,7 +92,9 @@ export const resolveTaskFn = ({
   debugLog('args:', args)
 
   const execaOptions = { preferLocal: true, reject: false, shell }
-  if (relative) {
+  if (cwd) {
+    execaOptions.cwd
+  } else if (relative) {
     execaOptions.cwd = process.cwd()
   } else if (/^git(\.exe)?/i.test(cmd) && gitDir !== process.cwd()) {
     // Only use gitDir as CWD if we are using the git binary

--- a/lib/runAll.js
+++ b/lib/runAll.js
@@ -1,5 +1,7 @@
 /** @typedef {import('./index').Logger} Logger */
 
+import path from 'path'
+
 import debug from 'debug'
 import { Listr } from 'listr2'
 
@@ -30,7 +32,8 @@ import {
   restoreOriginalStateSkipped,
   restoreUnstagedChangesSkipped,
 } from './state.js'
-import { GitRepoError, GetStagedFilesError, GitError } from './symbols.js'
+import { GitRepoError, GetStagedFilesError, ConfigNotFoundError, GitError } from './symbols.js'
+import { loadConfig } from './loadConfig.js'
 
 const debugLog = debug('lint-staged:runAll')
 
@@ -43,6 +46,7 @@ const createError = (ctx) => Object.assign(new Error('lint-staged failed'), { ct
  * @param {Object} [options.allowEmpty] - Allow empty commits when tasks revert all staged changes
  * @param {boolean | number} [options.concurrent] - The number of tasks to run concurrently, or false to run tasks serially
  * @param {Object} [options.config] - Task configuration
+ * @param {boolean} [options.sparseConfig] - Enable sparse config mode
  * @param {Object} [options.cwd] - Current working directory
  * @param {boolean} [options.debug] - Enable debug mode
  * @param {number} [options.maxArgLength] - Maximum argument string length
@@ -59,6 +63,7 @@ export const runAll = async (
     allowEmpty = false,
     concurrent = true,
     config,
+    sparseConfig = false,
     cwd = process.cwd(),
     debug = false,
     maxArgLength,
@@ -107,14 +112,40 @@ export const runAll = async (
     return ctx
   }
 
-  const stagedFileChunks = chunkFiles({ baseDir: gitDir, files, maxArgLength, relative })
-  const chunkCount = stagedFileChunks.length
-  if (chunkCount > 1) debugLog(`Chunked staged files into ${chunkCount} part`, chunkCount)
+  const configDir2config = {
+    [gitDir]: config,
+  }
+  const configDir2Files = {
+    [gitDir]: [],
+  }
+  if (sparseConfig) {
+    for (const file of files) {
+      const absoluteFilepath = path.resolve(gitDir, file)
+      const subConfigInfo = await loadConfig({
+        searchStartPath: path.dirname(absoluteFilepath),
+        logger,
+      })
+      if (!subConfigInfo) {
+        debugLog(`${ConfigNotFoundError.message} for ${file}.`)
+        continue
+      }
+      const configDir = path.dirname(subConfigInfo.filepath)
+      if (!configDir2config[configDir]) {
+        configDir2config[configDir] = subConfigInfo.config
+      }
+      if (!configDir2Files[configDir]) {
+        configDir2Files[configDir] = []
+      }
+      configDir2Files[configDir].push(file)
+    }
+  } else {
+    configDir2config[gitDir] = config
+    configDir2Files[gitDir] = files
+  }
 
   // lint-staged 10 will automatically add modifications to index
   // Warn user when their command includes `git add`
   let hasDeprecatedGitAdd = false
-
   const listrOptions = {
     ctx,
     exitOnError: false,
@@ -128,61 +159,86 @@ export const runAll = async (
   // Set of all staged files that matched a task glob. Values in a set are unique.
   const matchedFiles = new Set()
 
-  for (const [index, files] of stagedFileChunks.entries()) {
-    const chunkTasks = generateTasks({ config, cwd, gitDir, files, relative })
-    const chunkListrTasks = []
+  for (const [configDir, files] of Object.entries(configDir2Files)) {
+    if (!files.length) {
+      continue
+    }
+    const stagedFileChunks = chunkFiles({ baseDir: gitDir, files, maxArgLength, relative })
+    const chunkCount = stagedFileChunks.length
+    if (chunkCount > 1) debugLog(`Chunked staged files into ${chunkCount} part`, chunkCount)
 
-    for (const task of chunkTasks) {
-      const subTasks = await makeCmdTasks({
-        commands: task.commands,
-        files: task.fileList,
+    for (const [index, files] of stagedFileChunks.entries()) {
+      const chunkTasks = generateTasks({
+        config: configDir2config[configDir],
+        cwd: relative ? cwd : configDir,
         gitDir,
-        renderer: listrOptions.renderer,
-        shell,
-        verbose,
+        files,
+        relative,
       })
+      const chunkListrTasks = []
 
-      // Add files from task to match set
-      task.fileList.forEach((file) => {
-        matchedFiles.add(file)
-      })
+      for (const task of chunkTasks) {
+        const subTasks = await makeCmdTasks({
+          commands: task.commands,
+          files: task.fileList,
+          gitDir,
+          cwd: sparseConfig ? configDir : undefined,
+          renderer: listrOptions.renderer,
+          shell,
+          verbose,
+        })
 
-      hasDeprecatedGitAdd =
-        hasDeprecatedGitAdd || subTasks.some((subTask) => subTask.command === 'git add')
+        // Add files from task to match set
+        task.fileList.forEach((file) => {
+          matchedFiles.add(file)
+        })
 
-      chunkListrTasks.push({
-        title: `Running tasks for ${task.pattern}`,
-        task: async () =>
-          new Listr(subTasks, {
-            // In sub-tasks we don't want to run concurrently
-            // and we want to abort on errors
-            ...listrOptions,
-            concurrent: false,
-            exitOnError: true,
-          }),
+        hasDeprecatedGitAdd =
+          hasDeprecatedGitAdd || subTasks.some((subTask) => subTask.command === 'git add')
+
+        let title = `Running tasks for ${task.pattern}`
+
+        const configDirRelativeToGitDir = path.relative(gitDir, configDir)
+        if (configDirRelativeToGitDir) {
+          title += ` under ${configDirRelativeToGitDir}`
+        }
+
+        chunkListrTasks.push({
+          title,
+          task: async () =>
+            new Listr(subTasks, {
+              // In sub-tasks we don't want to run concurrently
+              // and we want to abort on errors
+              ...listrOptions,
+              concurrent: false,
+              exitOnError: true,
+            }),
+          skip: () => {
+            // Skip task when no files matched
+            if (task.fileList.length === 0) {
+              return `No staged files match ${task.pattern}`
+            }
+            return false
+          },
+        })
+      }
+
+      listrTasks.push({
+        // No need to show number of task chunks when there's only one
+        title:
+          chunkCount > 1
+            ? `Running tasks (chunk ${index + 1}/${chunkCount})...`
+            : 'Running tasks...',
+        task: () => new Listr(chunkListrTasks, { ...listrOptions, concurrent }),
         skip: () => {
-          // Skip task when no files matched
-          if (task.fileList.length === 0) {
-            return `No staged files match ${task.pattern}`
-          }
+          // Skip if the first step (backup) failed
+          if (ctx.errors.has(GitError)) return SKIPPED_GIT_ERROR
+          // Skip chunk when no every task is skipped (due to no matches)
+          if (chunkListrTasks.every((task) => task.skip())) return 'No tasks to run.'
           return false
         },
       })
     }
-
-    listrTasks.push({
-      // No need to show number of task chunks when there's only one
-      title:
-        chunkCount > 1 ? `Running tasks (chunk ${index + 1}/${chunkCount})...` : 'Running tasks...',
-      task: () => new Listr(chunkListrTasks, { ...listrOptions, concurrent }),
-      skip: () => {
-        // Skip if the first step (backup) failed
-        if (ctx.errors.has(GitError)) return SKIPPED_GIT_ERROR
-        // Skip chunk when no every task is skipped (due to no matches)
-        if (chunkListrTasks.every((task) => task.skip())) return 'No tasks to run.'
-        return false
-      },
-    })
   }
 
   if (hasDeprecatedGitAdd) {

--- a/lib/runAll.js
+++ b/lib/runAll.js
@@ -21,6 +21,7 @@ import {
   NO_TASKS,
   SKIPPED_GIT_ERROR,
   skippingBackup,
+  getMultiConfigFilesWarning,
 } from './messages.js'
 import { resolveGitRepo } from './resolveGitRepo.js'
 import {
@@ -34,8 +35,7 @@ import {
   restoreUnstagedChangesSkipped,
 } from './state.js'
 import { GitRepoError, GetStagedFilesError, ConfigNotFoundError, GitError } from './symbols.js'
-import { loadConfig } from './loadConfig.js'
-import { validateConfig } from './validateConfig.js'
+import { loadConfigAndValidateWithCache } from './loadConfig.js'
 
 const debugLog = debug('lint-staged:runAll')
 
@@ -48,6 +48,7 @@ const createError = (ctx) => Object.assign(new Error('lint-staged failed'), { ct
  * @param {Object} [options.allowEmpty] - Allow empty commits when tasks revert all staged changes
  * @param {boolean | number} [options.concurrent] - The number of tasks to run concurrently, or false to run tasks serially
  * @param {Object} [options.config] - Task configuration
+ * @param {string | null} [options.configFilepath] - The filepath of the configuration
  * @param {boolean} [options.sparseConfig] - Enable sparse config mode
  * @param {Object} [options.cwd] - Current working directory
  * @param {boolean} [options.debug] - Enable debug mode
@@ -65,6 +66,7 @@ export const runAll = async (
     allowEmpty = false,
     concurrent = true,
     config,
+    configFilepath,
     sparseConfig = false,
     cwd = process.cwd(),
     debug = false,
@@ -114,36 +116,62 @@ export const runAll = async (
     return ctx
   }
 
-  const configDir2config = {
-    [gitDir]: config,
+  const configDir2configInfo = {}
+  // passed config might be null in sparse config mode
+  if (config) {
+    configDir2configInfo[gitDir] = {
+      config,
+      filepath: configFilepath,
+    }
   }
+
   const configDir2Files = {
     [gitDir]: [],
   }
-  if (sparseConfig) {
-    for (const file of files) {
+  await Promise.all(
+    files.map(async (file) => {
       const absoluteFilepath = path.resolve(gitDir, file)
-      const subConfigInfo = await loadConfig({
+      const subConfigInfo = await loadConfigAndValidateWithCache({
         searchStartPath: path.dirname(absoluteFilepath),
         logger,
       })
-      if (!subConfigInfo) {
+      let subConfigUsed = false
+      if (subConfigInfo) {
+        const configDir = path.dirname(subConfigInfo.filepath)
+        if (!configDir2configInfo[configDir]) {
+          configDir2configInfo[configDir] = subConfigInfo
+        }
+        if (!configDir2Files[configDir]) {
+          configDir2Files[configDir] = []
+        }
+
+        if (sparseConfig) {
+          configDir2Files[configDir].push(file)
+          subConfigUsed = true
+        }
+      } else {
         debugLog(`${ConfigNotFoundError.message} for ${file}.`)
-        continue
       }
-      subConfigInfo.config = validateConfig(subConfigInfo.config)
-      const configDir = path.dirname(subConfigInfo.filepath)
-      if (!configDir2config[configDir]) {
-        configDir2config[configDir] = subConfigInfo.config
+
+      if (!subConfigUsed) {
+        configDir2Files[gitDir].push(file)
       }
-      if (!configDir2Files[configDir]) {
-        configDir2Files[configDir] = []
-      }
-      configDir2Files[configDir].push(file)
+    })
+  )
+
+  if (!sparseConfig) {
+    const configInfoList = Object.values(configDir2configInfo)
+    const configInfoWithFilepathList = configInfoList.filter((x) => x.filepath)
+    if (configInfoWithFilepathList.length > 1) {
+      // warn about a deeper config file existing
+      logger.warn(
+        getMultiConfigFilesWarning(
+          configInfoWithFilepathList.map(({ filepath }) => {
+            return normalize(path.relative(gitDir, filepath))
+          })
+        )
+      )
     }
-  } else {
-    configDir2config[gitDir] = config
-    configDir2Files[gitDir] = files
   }
 
   // lint-staged 10 will automatically add modifications to index
@@ -166,13 +194,17 @@ export const runAll = async (
     if (!files.length) {
       continue
     }
+    const configInfo = configDir2configInfo[configDir]
+    if (!configInfo || !configInfo.config) {
+      continue
+    }
     const stagedFileChunks = chunkFiles({ baseDir: gitDir, files, maxArgLength, relative })
     const chunkCount = stagedFileChunks.length
     if (chunkCount > 1) debugLog(`Chunked staged files into ${chunkCount} part`, chunkCount)
 
     for (const [index, files] of stagedFileChunks.entries()) {
       const chunkTasks = generateTasks({
-        config: configDir2config[configDir],
+        config: configInfo.config,
         cwd: relative ? cwd : configDir,
         gitDir,
         files,

--- a/lib/runAll.js
+++ b/lib/runAll.js
@@ -4,6 +4,7 @@ import path from 'path'
 
 import debug from 'debug'
 import { Listr } from 'listr2'
+import normalize from 'normalize-path'
 
 import { chunkFiles } from './chunkFiles.js'
 import { execGit } from './execGit.js'
@@ -200,7 +201,7 @@ export const runAll = async (
 
         const configDirRelativeToGitDir = path.relative(gitDir, configDir)
         if (configDirRelativeToGitDir) {
-          title += ` under ${configDirRelativeToGitDir}`
+          title += ` under ${normalize(configDirRelativeToGitDir)}`
         }
 
         chunkListrTasks.push({

--- a/lib/runAll.js
+++ b/lib/runAll.js
@@ -35,6 +35,7 @@ import {
 } from './state.js'
 import { GitRepoError, GetStagedFilesError, ConfigNotFoundError, GitError } from './symbols.js'
 import { loadConfig } from './loadConfig.js'
+import { validateConfig } from './validateConfig.js'
 
 const debugLog = debug('lint-staged:runAll')
 
@@ -130,6 +131,7 @@ export const runAll = async (
         debugLog(`${ConfigNotFoundError.message} for ${file}.`)
         continue
       }
+      subConfigInfo.config = validateConfig(subConfigInfo.config)
       const configDir = path.dirname(subConfigInfo.filepath)
       if (!configDir2config[configDir]) {
         configDir2config[configDir] = subConfigInfo.config

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -9,6 +9,7 @@ import { getStagedFiles } from '../lib/getStagedFiles'
 import lintStaged from '../lib/index'
 import { InvalidOptionsError } from '../lib/symbols'
 import { validateOptions } from '../lib/validateOptions'
+import { clearLoadConfigCache } from '../lib/loadConfig'
 
 import { replaceSerializer } from './utils/replaceSerializer'
 
@@ -39,6 +40,10 @@ describe('lintStaged', () => {
 
   beforeEach(() => {
     logger.clearHistory()
+  })
+
+  afterEach(() => {
+    clearLoadConfigCache()
   })
 
   it('should use lilconfig if no params are passed', async () => {

--- a/test/index2.spec.js
+++ b/test/index2.spec.js
@@ -8,12 +8,14 @@ jest.mock('../lib/resolveGitRepo')
 
 import lintStaged from '../lib/index'
 import { resolveGitRepo } from '../lib/resolveGitRepo'
+import { clearLoadConfigCache } from '../lib/loadConfig'
 
 resolveGitRepo.mockImplementation(async () => ({ gitDir: 'foo', gitConfigDir: 'bar' }))
 
 describe('lintStaged', () => {
   afterEach(() => {
     Listr.mockClear()
+    clearLoadConfigCache()
   })
 
   it('should pass quiet flag to Listr', async () => {

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -1057,6 +1057,23 @@ describe('lint-staged', () => {
     expect(await readFile('test.js')).toEqual(testJsFilePretty)
     expect(await readFile('test2.js')).toEqual(testJsFilePretty)
   })
+
+  it('should work when setup --sparse-config', async () => {
+    await fs.ensureFile(path.join(cwd, 'package-a/test.js'))
+    await writeFile('package-a/test.js', testJsFileUgly)
+    await fs.ensureFile(path.join(cwd, 'package-a/.lintstagedrc'))
+    await writeFile('package-a/.lintstagedrc', JSON.stringify(fixJsConfig.config))
+    await fs.ensureFile(path.join(cwd, 'package-b/test.js'))
+    await writeFile('package-b/test.js', testJsFileUgly)
+
+    await execGit(['add', '.'])
+
+    await gitCommit({ sparseConfig: true })
+    // test.js in package-a should be prettier
+    expect(await readFile('package-a/test.js')).toEqual(testJsFilePretty)
+    // test.js in package-b should not be prettier
+    expect(await readFile('package-b/test.js')).toEqual(testJsFileUgly)
+  })
 })
 
 describe('lintStaged', () => {

--- a/test/runAll.spec.js
+++ b/test/runAll.spec.js
@@ -250,10 +250,10 @@ describe('runAll', () => {
       LOG [STARTED] Running tasks...
       INFO [SKIPPED] Skipped because of previous git error.
       LOG [STARTED] Applying modifications...
-      INFO [SKIPPED]
+      INFO [SKIPPED] 
       [SKIPPED]   ✖ lint-staged failed due to a git error.
       LOG [STARTED] Cleaning up...
-      INFO [SKIPPED]
+      INFO [SKIPPED] 
       [SKIPPED]   ✖ lint-staged failed due to a git error."
     `)
   })

--- a/test/runAll.spec.js
+++ b/test/runAll.spec.js
@@ -116,7 +116,7 @@ describe('runAll', () => {
         const { searchStartPath } = params
         const actualLoadConfig = jest.requireActual('../lib/loadConfig').loadConfig
         if (searchStartPath) {
-          if (searchStartPath.endsWith('package/a')) {
+          if (searchStartPath.endsWith(path.join('package/a'))) {
             return {
               config: {
                 '*.js': mockTaskForPackageA,
@@ -124,7 +124,7 @@ describe('runAll', () => {
               filepath: path.join(searchStartPath, 'package.json'),
             }
           }
-          if (searchStartPath.endsWith('package/b')) {
+          if (searchStartPath.endsWith(path.join('package/b'))) {
             return {
               config: {
                 '*.js': mockTaskForPackageB,
@@ -250,10 +250,10 @@ describe('runAll', () => {
       LOG [STARTED] Running tasks...
       INFO [SKIPPED] Skipped because of previous git error.
       LOG [STARTED] Applying modifications...
-      INFO [SKIPPED] 
+      INFO [SKIPPED]
       [SKIPPED]   ✖ lint-staged failed due to a git error.
       LOG [STARTED] Cleaning up...
-      INFO [SKIPPED] 
+      INFO [SKIPPED]
       [SKIPPED]   ✖ lint-staged failed due to a git error."
     `)
   })

--- a/test/runAll.spec.js
+++ b/test/runAll.spec.js
@@ -9,7 +9,7 @@ import { GitWorkflow } from '../lib/gitWorkflow'
 import { resolveGitRepo } from '../lib/resolveGitRepo'
 import { runAll } from '../lib/runAll'
 import { GitError } from '../lib/symbols'
-import { loadConfig } from '../lib/loadConfig'
+import { loadConfigAndValidateWithCache } from '../lib/loadConfig'
 
 jest.mock('../lib/file')
 jest.mock('../lib/getStagedFiles')
@@ -112,9 +112,10 @@ describe('runAll', () => {
     const mockTaskForPackageA = jest.fn(() => ['echo "package A"'])
     const mockTaskForPackageB = jest.fn(() => ['echo "package B"'])
     beforeAll(() => {
-      loadConfig.mockImplementation((params) => {
+      loadConfigAndValidateWithCache.mockImplementation((params) => {
         const { searchStartPath } = params
-        const actualLoadConfig = jest.requireActual('../lib/loadConfig').loadConfig
+        const actualLoadConfig =
+          jest.requireActual('../lib/loadConfig').loadConfigAndValidateWithCache
         if (searchStartPath) {
           if (searchStartPath.endsWith(path.join('package/a'))) {
             return {
@@ -143,7 +144,7 @@ describe('runAll', () => {
     })
 
     afterAll(() => {
-      loadConfig.mockReset()
+      loadConfigAndValidateWithCache.mockReset()
     })
 
     it('should work with sparseConfig', async () => {


### PR DESCRIPTION
### Summary

Adding a new flag called `--sparse-config`. Mostly used in a monorepo.

Assuming monorepo file structure as follow:

```
-- monorepo
 |- packages
     |- foo
        |- .lintstagedrc.json
     |- bar
        |- .lintstagedrc.json
```

if git stage files are

- packages/foo/index.js
- packages/foo/lib.js
- packages/bar/utils.js

With `--sparse-config`, `packages/foo/index.js` and `packages/foo/lib.js` uses config file at `packages/foo/.lintstagedrc.json`. while `packages/bar/utils.js` uses config file at `packages/bar/.lintstagedrc.json`

If no lint-staged config can be loaded from staged file, nothing happens.

Outputs like

```
        LOG [STARTED] Preparing...
        LOG [SUCCESS] Preparing...
        LOG [STARTED] Running tasks...
        LOG [STARTED] Running tasks for *.js under package/a
        LOG [STARTED] echo \\"package A\\"
        LOG [SUCCESS] echo \\"package A\\"
        LOG [SUCCESS] Running tasks for *.js under package/a
        LOG [SUCCESS] Running tasks...
        LOG [STARTED] Running tasks...
        LOG [STARTED] Running tasks for *.js under package/b
        LOG [STARTED] echo \\"package B\\"
        LOG [SUCCESS] echo \\"package B\\"
        LOG [SUCCESS] Running tasks for *.js under package/b
        LOG [SUCCESS] Running tasks...
        LOG [STARTED] Applying modifications...
        LOG [SUCCESS] Applying modifications...
        LOG [STARTED] Cleaning up...
        LOG [SUCCESS] Cleaning up..."
```

### How is tested

Add test cases and tested in a local repo.

