### PR TITLE
fix: using `--debug` option enables debug mode

### DIFF
--- a/bin/lint-staged.js
+++ b/bin/lint-staged.js
@@ -44,10 +44,13 @@ cmdline
   )
   .parse(process.argv)
 
-const debugLog = debug('lint-staged:bin')
-if (cmdline.debug) {
+const cmdlineOptions = cmdline.opts()
+
+if (cmdlineOptions.debug) {
   debug.enable('lint-staged*')
 }
+
+const debugLog = debug('lint-staged:bin')
 debugLog('Running `lint-staged@%s`', version)
 
 /**
@@ -67,8 +70,6 @@ const getMaxArgLength = () => {
       return 131072
   }
 }
-
-const cmdlineOptions = cmdline.opts()
 
 const options = {
   allowEmpty: !!cmdlineOptions.allowEmpty,

--- a/lib/index.js
+++ b/lib/index.js
@@ -58,7 +58,7 @@ const lintStaged = async (
 ) => {
   await validateOptions({ shell }, logger)
 
-  const inputConfig = configObject || (await loadConfig(configPath, logger))
+  const inputConfig = configObject || (await loadConfig({ configPath, cwd }, logger))
 
   if (!inputConfig) {
     logger.error(`${ConfigNotFoundError.message}.`)

--- a/lib/loadConfig.js
+++ b/lib/loadConfig.js
@@ -1,3 +1,5 @@
+/** @typedef {import('./index').Logger} Logger */
+
 import { pathToFileURL } from 'url'
 
 import debug from 'debug'
@@ -56,20 +58,23 @@ const resolveConfig = (configPath) => {
 }
 
 /**
- * @param {string} [configPath]
- * @param {Logger} [logger]
+ * @param {object} options
+ * @param {string} [options.configPath] - Explicit path to a config file
+ * @param {string} [options.cwd] - Current working directory
  */
-export const loadConfig = async (configPath, logger) => {
+export const loadConfig = async ({ configPath, cwd }, logger) => {
   try {
     if (configPath) {
       debugLog('Loading configuration from `%s`...', configPath)
     } else {
-      debugLog('Searching for configuration...')
+      debugLog('Searching for configuration from `%s`...', cwd)
     }
 
     const explorer = lilconfig('lint-staged', { searchPlaces, loaders })
 
-    const result = await (configPath ? explorer.load(resolveConfig(configPath)) : explorer.search())
+    const result = await (configPath
+      ? explorer.load(resolveConfig(configPath))
+      : explorer.search(cwd))
     if (!result) return null
 
     // config is a promise when using the `dynamicImport` loader
@@ -79,7 +84,7 @@ export const loadConfig = async (configPath, logger) => {
 
     return config
   } catch (error) {
-    debugLog('Failed to load configuration from `%s`', configPath)
+    debugLog('Failed to load configuration!')
     logger.error(error)
     return null
   }


### PR DESCRIPTION
This PR fixes the `--debug` option. Not sure when it broke, but this makes it work again:

<img width="682" alt="Screenshot 2022-01-02 at 17 17 25" src="https://user-images.githubusercontent.com/11628889/147880326-3bb39659-19c0-4844-a62e-9859b04c5404.png">
