### PR TITLE
fix: always run non-git tasks in the current working directory

### DIFF
--- a/lib/makeCmdTasks.js
+++ b/lib/makeCmdTasks.js
@@ -28,13 +28,14 @@ const getTitleLength = (renderer, columns = process.stdout.columns) => {
  *
  * @param {object} options
  * @param {Array<string|Function>|string|Function} options.commands
+ * @param {string} options.cwd
  * @param {Array<string>} options.files
  * @param {string} options.gitDir
  * @param {string} options.renderer
  * @param {Boolean} shell
  * @param {Boolean} verbose
  */
-export const makeCmdTasks = async ({ commands, files, gitDir, renderer, shell, verbose }) => {
+export const makeCmdTasks = async ({ commands, cwd, files, gitDir, renderer, shell, verbose }) => {
   debugLog('Creating listr tasks for commands %o', commands)
   const commandArray = Array.isArray(commands) ? commands : [commands]
   const cmdTasks = []
@@ -61,7 +62,7 @@ export const makeCmdTasks = async ({ commands, files, gitDir, renderer, shell, v
 
       // Truncate title to single line based on renderer
       const title = cliTruncate(command, getTitleLength(renderer))
-      const task = resolveTaskFn({ command, files, gitDir, isFn, shell, verbose })
+      const task = resolveTaskFn({ command, cwd, files, gitDir, isFn, shell, verbose })
       cmdTasks.push({ title, command, task })
     }
   }

--- a/lib/resolveTaskFn.js
+++ b/lib/resolveTaskFn.js
@@ -68,20 +68,20 @@ const makeErr = (command, result, ctx) => {
  *
  * @param {Object} options
  * @param {string} options.command — Linter task
+ * @param {string} [options.cwd]
  * @param {String} options.gitDir - Current git repo path
  * @param {Boolean} options.isFn - Whether the linter task is a function
  * @param {Array<string>} options.files — Filepaths to run the linter task against
- * @param {Boolean} [options.relative] — Whether the filepaths should be relative
  * @param {Boolean} [options.shell] — Whether to skip parsing linter task for better shell support
  * @param {Boolean} [options.verbose] — Always show task verbose
  * @returns {function(): Promise<Array<string>>}
  */
 export const resolveTaskFn = ({
   command,
+  cwd = process.cwd(),
   files,
   gitDir,
   isFn,
-  relative,
   shell = false,
   verbose = false,
 }) => {
@@ -89,14 +89,15 @@ export const resolveTaskFn = ({
   debugLog('cmd:', cmd)
   debugLog('args:', args)
 
-  const execaOptions = { preferLocal: true, reject: false, shell }
-  if (relative) {
-    execaOptions.cwd = process.cwd()
-  } else if (/^git(\.exe)?/i.test(cmd) && gitDir !== process.cwd()) {
+  const execaOptions = {
     // Only use gitDir as CWD if we are using the git binary
     // e.g `npm` should run tasks in the actual CWD
-    execaOptions.cwd = gitDir
+    cwd: /^git(\.exe)?/i.test(cmd) ? gitDir : cwd,
+    preferLocal: true,
+    reject: false,
+    shell,
   }
+
   debugLog('execaOptions:', execaOptions)
 
   return async (ctx = getInitialState()) => {

--- a/lib/runAll.js
+++ b/lib/runAll.js
@@ -135,6 +135,7 @@ export const runAll = async (
     for (const task of chunkTasks) {
       const subTasks = await makeCmdTasks({
         commands: task.commands,
+        cwd,
         files: task.fileList,
         gitDir,
         renderer: listrOptions.renderer,

--- a/test/makeCmdTasks.spec.js
+++ b/test/makeCmdTasks.spec.js
@@ -43,6 +43,7 @@ describe('makeCmdTasks', () => {
     await taskPromise
     expect(execa).toHaveBeenCalledTimes(1)
     expect(execa).lastCalledWith('test', ['test.js'], {
+      cwd: process.cwd(),
       preferLocal: true,
       reject: false,
       shell: false,
@@ -52,6 +53,7 @@ describe('makeCmdTasks', () => {
     await taskPromise
     expect(execa).toHaveBeenCalledTimes(2)
     expect(execa).lastCalledWith('test2', ['test.js'], {
+      cwd: process.cwd(),
       preferLocal: true,
       reject: false,
       shell: false,

--- a/test/resolveTaskFn.spec.js
+++ b/test/resolveTaskFn.spec.js
@@ -21,6 +21,7 @@ describe('resolveTaskFn', () => {
     await taskFn()
     expect(execa).toHaveBeenCalledTimes(1)
     expect(execa).lastCalledWith('node', ['--arg=true', './myscript.js', 'test.js'], {
+      cwd: process.cwd(),
       preferLocal: true,
       reject: false,
       shell: false,
@@ -38,6 +39,7 @@ describe('resolveTaskFn', () => {
     await taskFn()
     expect(execa).toHaveBeenCalledTimes(1)
     expect(execa).lastCalledWith('node', ['--arg=true', './myscript.js', 'test.js'], {
+      cwd: process.cwd(),
       preferLocal: true,
       reject: false,
       shell: false,
@@ -56,6 +58,7 @@ describe('resolveTaskFn', () => {
     await taskFn()
     expect(execa).toHaveBeenCalledTimes(1)
     expect(execa).lastCalledWith('node --arg=true ./myscript.js test.js', {
+      cwd: process.cwd(),
       preferLocal: true,
       reject: false,
       shell: true,
@@ -73,6 +76,7 @@ describe('resolveTaskFn', () => {
     await taskFn()
     expect(execa).toHaveBeenCalledTimes(1)
     expect(execa).lastCalledWith('node --arg=true ./myscript.js test.js', {
+      cwd: process.cwd(),
       preferLocal: true,
       reject: false,
       shell: true,
@@ -90,6 +94,7 @@ describe('resolveTaskFn', () => {
     await taskFn()
     expect(execa).toHaveBeenCalledTimes(1)
     expect(execa).lastCalledWith('node --arg=true ./myscript.js test.js', {
+      cwd: process.cwd(),
       preferLocal: true,
       reject: false,
       shell: '/bin/bash',
@@ -121,23 +126,6 @@ describe('resolveTaskFn', () => {
     await taskFn()
     expect(execa).toHaveBeenCalledTimes(1)
     expect(execa).lastCalledWith('jest', ['test.js'], {
-      preferLocal: true,
-      reject: false,
-      shell: false,
-    })
-  })
-
-  it('should always pass `process.cwd()` as `cwd` to `execa()` when relative = true', async () => {
-    expect.assertions(2)
-    const taskFn = resolveTaskFn({
-      ...defaultOpts,
-      command: 'git diff',
-      relative: true,
-    })
-
-    await taskFn()
-    expect(execa).toHaveBeenCalledTimes(1)
-    expect(execa).lastCalledWith('git', ['diff', 'test.js'], {
       cwd: process.cwd(),
       preferLocal: true,
       reject: false,


### PR DESCRIPTION
I noticed that the `execa` task spawning linters wasn't getting passed the `cwd` option, this might explain difficulties with ESLint picking up configuration, for example. Previously tasks were always run in the `process.cwd()`, but it might be explicitly something else.