### PR TITLE
fix: Resolve config modules with ESM createRequire()

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,11 @@
 const config = {
   collectCoverage: true,
-  collectCoverageFrom: ['lib/**/*.js'],
+  collectCoverageFrom: [
+    'lib/**/*.js',
+    // Avoid ESM import.meta parse error.
+    // (Can't measure coverage anyway, it's always mocked)
+    '!lib/resolveConfig.js',
+  ],
   moduleDirectories: ['node_modules'],
   setupFiles: ['./testSetup.js'],
   snapshotSerializers: ['jest-snapshot-serializer-ansi'],

--- a/lib/loadConfig.js
+++ b/lib/loadConfig.js
@@ -6,6 +6,8 @@ import debug from 'debug'
 import { lilconfig } from 'lilconfig'
 import YAML from 'yaml'
 
+import { resolveConfig } from './resolveConfig'
+
 const debugLog = debug('lint-staged:loadConfig')
 
 /**
@@ -47,14 +49,6 @@ const loaders = {
   '.yaml': yamlParse,
   '.yml': yamlParse,
   noExt: yamlParse,
-}
-
-const resolveConfig = (configPath) => {
-  try {
-    return require.resolve(configPath)
-  } catch {
-    return configPath
-  }
 }
 
 /**

--- a/lib/loadConfig.js
+++ b/lib/loadConfig.js
@@ -6,7 +6,7 @@ import debug from 'debug'
 import { lilconfig } from 'lilconfig'
 import YAML from 'yaml'
 
-import { resolveConfig } from './resolveConfig'
+import { resolveConfig } from './resolveConfig.js'
 
 const debugLog = debug('lint-staged:loadConfig')
 

--- a/lib/resolveConfig.js
+++ b/lib/resolveConfig.js
@@ -1,0 +1,15 @@
+import { createRequire } from 'module'
+
+/**
+ * require() does not exist for ESM, so we must create it to use require.resolve().
+ * @see https://nodejs.org/api/module.html#modulecreaterequirefilename
+ */
+const require = createRequire(import.meta.url)
+
+export function resolveConfig(configPath) {
+  try {
+    return require.resolve(configPath)
+  } catch {
+    return configPath
+  }
+}

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -28,6 +28,16 @@ jest.mock('url', () => ({
 
 jest.mock('../lib/getStagedFiles')
 jest.mock('../lib/gitWorkflow')
+jest.mock('../lib/resolveConfig', () => ({
+  /** Unfortunately necessary due to non-ESM tests. */
+  resolveConfig: (configPath) => {
+    try {
+      return require.resolve(configPath)
+    } catch {
+      return configPath
+    }
+  },
+}))
 jest.mock('../lib/validateOptions', () => ({
   validateOptions: jest.fn().mockImplementation(async () => {}),
 }))

--- a/test/index2.spec.js
+++ b/test/index2.spec.js
@@ -4,6 +4,17 @@ import { Listr } from 'listr2'
 import makeConsoleMock from 'consolemock'
 
 jest.mock('listr2')
+jest.mock('../lib/resolveConfig', () => ({
+  /** Unfortunately necessary due to non-ESM tests. */
+  resolveConfig: (configPath) => {
+    try {
+      return require.resolve(configPath)
+    } catch {
+      return configPath
+    }
+  },
+}))
+
 jest.mock('../lib/resolveGitRepo')
 
 import lintStaged from '../lib/index'

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -7,6 +7,16 @@ import normalize from 'normalize-path'
 
 jest.unmock('lilconfig')
 jest.unmock('execa')
+jest.mock('../lib/resolveConfig', () => ({
+  /** Unfortunately necessary due to non-ESM tests. */
+  resolveConfig: (configPath) => {
+    try {
+      return require.resolve(configPath)
+    } catch {
+      return configPath
+    }
+  },
+}))
 
 import { execGit as execGitBase } from '../lib/execGit'
 import lintStaged from '../lib/index'

--- a/test/loadConfig.spec.js
+++ b/test/loadConfig.spec.js
@@ -1,3 +1,14 @@
+jest.mock('../lib/resolveConfig', () => ({
+  /** Unfortunately necessary due to non-ESM tests. */
+  resolveConfig: (configPath) => {
+    try {
+      return require.resolve(configPath)
+    } catch {
+      return configPath
+    }
+  },
+}))
+
 import { dynamicImport } from '../lib/loadConfig.js'
 
 describe('dynamicImport', () => {


### PR DESCRIPTION
ES modules do not have require() available, we must construct it first.
This fixes the CLI when passing `--config my-config-package`, broken in v12.0.0.

The tests didn't catch this because Jest still doesn't support mocking ESM, and there's really no way to write a test for this right now. I verified it locally like this:

### Broken
```js
// broken.mjs
console.log(require.resolve('react'))
```
```sh
$ node -v
v14.18.1

$ node ./broken.mjs
file:///path/to/broken.mjs:1
console.log(require.resolve('react'))
            ^

ReferenceError: require is not defined in ES module scope, you can use import instead
    at file:///Users/daniel/code/front-end-shared-config/resolve-config.mjs:1:13
    at ModuleJob.run (internal/modules/esm/module_job.js:183:25)
    at async Loader.import (internal/modules/esm/loader.js:178:24)
    at async Object.loadESM (internal/process/esm_loader.js:68:5)
```

### Fixed
```js
// fixed.mjs
import { createRequire } from 'module'

const require = createRequire(import.meta.url)

console.log(require.resolve('react'))
```
```sh
$ node ./fixed.mjs
/path/to/node_modules/react/index.js
```
