### PR TITLE
fix: only throw if no configurations were found

### DIFF
--- a/lib/getConfigGroups.js
+++ b/lib/getConfigGroups.js
@@ -56,10 +56,7 @@ export const getConfigGroups = async ({ configObject, configPath, files }, logge
     Object.entries(filesByDir).map(([dir, files]) => {
       // Discover config from the base directory of the file
       return loadConfig({ cwd: dir }, logger).then(({ config, filepath }) => {
-        if (!config) {
-          logger.error(`${ConfigNotFoundError.message}.`)
-          throw ConfigNotFoundError
-        }
+        if (!config) return
 
         if (filepath in configGroups) {
           // Re-use cached config and skip validation
@@ -72,6 +69,12 @@ export const getConfigGroups = async ({ configObject, configPath, files }, logge
       })
     })
   )
+
+  // Throw if no configurations were found
+  if (Object.keys(configGroups).length === 0) {
+    logger.error(`${ConfigNotFoundError.message}.`)
+    throw ConfigNotFoundError
+  }
 
   return configGroups
 }

--- a/test/getConfigGroups.spec.js
+++ b/test/getConfigGroups.spec.js
@@ -53,4 +53,19 @@ describe('getConfigGroups', () => {
       '/deeper/.lintstagedrc.json': { config, files: ['/deeper/foo.js', '/even/deeper/foo.js'] },
     })
   })
+
+  it('should find config for one file, and not care about other', async () => {
+    // '/foo.js'
+    loadConfig.mockResolvedValueOnce({})
+    // '/deeper/foo.js'
+    loadConfig.mockResolvedValueOnce({ config, filepath: '/deeper/.lintstagedrc.json' })
+
+    const configGroups = await getConfigGroups({
+      files: ['/foo.js', '/deeper/foo.js'],
+    })
+
+    expect(configGroups).toEqual({
+      '/deeper/.lintstagedrc.json': { config, files: ['/deeper/foo.js'] },
+    })
+  })
 })


### PR DESCRIPTION
Previously lint-staged would throw if any staged file was missing a config,
but it should be enough that at least one file has a matching config.

Fixes https://github.com/okonet/lint-staged/issues/1087