### PR TITLE
fix: use config directory as cwd, when multiple configs present

### DIFF
--- a/lib/runAll.js
+++ b/lib/runAll.js
@@ -80,7 +80,8 @@ export const runAll = async (
   debugLog('Running all linter scripts...')
 
   // Resolve relative CWD option
-  cwd = cwd ? path.resolve(cwd) : process.cwd()
+  const hasExplicitCwd = !!cwd
+  cwd = hasExplicitCwd ? path.resolve(cwd) : process.cwd()
   debugLog('Using working directory `%s`', cwd)
 
   const ctx = getInitialState({ quiet })
@@ -120,6 +121,8 @@ export const runAll = async (
 
   const configGroups = await getConfigGroups({ configObject, configPath, cwd, files }, logger)
 
+  const hasMultipleConfigs = Object.keys(configGroups).length > 1
+
   // lint-staged 10 will automatically add modifications to index
   // Warn user when their command includes `git add`
   let hasDeprecatedGitAdd = false
@@ -138,7 +141,13 @@ export const runAll = async (
   const matchedFiles = new Set()
 
   for (const [configPath, { config, files }] of Object.entries(configGroups)) {
+    const relativeConfig = normalize(path.relative(cwd, configPath))
     const stagedFileChunks = chunkFiles({ baseDir: gitDir, files, maxArgLength, relative })
+
+    // Use actual cwd if it's specified, or there's only a single config file.
+    // Otherwise use the directory of the config file for each config group,
+    // to make sure tasks are separated from each other.
+    const groupCwd = hasMultipleConfigs && !hasExplicitCwd ? path.dirname(configPath) : cwd
 
     const chunkCount = stagedFileChunks.length
     if (chunkCount > 1) {
@@ -146,13 +155,11 @@ export const runAll = async (
     }
 
     for (const [index, files] of stagedFileChunks.entries()) {
-      const relativeConfig = normalize(path.relative(cwd, configPath))
-
       const chunkListrTasks = await Promise.all(
-        generateTasks({ config, cwd, files, relative }).map((task) =>
+        generateTasks({ config, cwd: groupCwd, files, relative }).map((task) =>
           makeCmdTasks({
             commands: task.commands,
-            cwd,
+            cwd: groupCwd,
             files: task.fileList,
             gitDir,
             renderer: listrOptions.renderer,
@@ -161,7 +168,14 @@ export const runAll = async (
           }).then((subTasks) => {
             // Add files from task to match set
             task.fileList.forEach((file) => {
-              matchedFiles.add(file)
+              // Make sure relative files are normalized to the
+              // group cwd, because other there might be identical
+              // relative filenames in the entire set.
+              const normalizedFile = path.isAbsolute(file)
+                ? file
+                : normalize(path.join(groupCwd, file))
+
+              matchedFiles.add(normalizedFile)
             })
 
             hasDeprecatedGitAdd =


### PR DESCRIPTION
This PR makes tasks run in the directory of the config file, when there are multiple configuration files.

In the case of only a single configuration file, tasks will still run in the current working directory, so this shouldn't really be a breaking change.

I also added some debug logging to `getConfigGroups`.

What do you think, @okonet?