### PR TITLE
fix: always search config from `cwd` first

### DIFF
--- a/lib/getConfigGroups.js
+++ b/lib/getConfigGroups.js
@@ -13,9 +13,13 @@ import { validateConfig } from './validateConfig.js'
  * @param {Object} [options.configObject] - Explicit config object from the js API
  * @param {string} [options.configPath] - Explicit path to a config file
  * @param {string} [options.cwd] - Current working directory
+ * @param {string} [options.files] - List of staged files
  * @param {Logger} logger
  */
-export const getConfigGroups = async ({ configObject, configPath, files }, logger = console) => {
+export const getConfigGroups = async (
+  { configObject, configPath, cwd, files },
+  logger = console
+) => {
   // Return explicit config object from js API
   if (configObject) {
     const config = validateConfig(configObject, 'config object', logger)
@@ -52,23 +56,24 @@ export const getConfigGroups = async ({ configObject, configPath, files }, logge
   // { '.lintstagedrc.json': { config: {...}, files: [...] } }
   const configGroups = {}
 
-  await Promise.all(
-    Object.entries(filesByDir).map(([dir, files]) => {
-      // Discover config from the base directory of the file
-      return loadConfig({ cwd: dir }, logger).then(({ config, filepath }) => {
-        if (!config) return
+  const searchConfig = async (cwd, files = []) => {
+    const { config, filepath } = await loadConfig({ cwd }, logger)
+    if (!config) return
 
-        if (filepath in configGroups) {
-          // Re-use cached config and skip validation
-          configGroups[filepath].files.push(...files)
-          return
-        }
+    if (filepath in configGroups) {
+      // Re-use cached config and skip validation
+      configGroups[filepath].files.push(...files)
+    } else {
+      const validatedConfig = validateConfig(config, filepath, logger)
+      configGroups[filepath] = { config: validatedConfig, files }
+    }
+  }
 
-        const validatedConfig = validateConfig(config, filepath, logger)
-        configGroups[filepath] = { config: validatedConfig, files }
-      })
-    })
-  )
+  // Start by searching from cwd
+  await searchConfig(cwd)
+
+  // Discover configs from the base directory of each file
+  await Promise.all(Object.entries(filesByDir).map(([dir, files]) => searchConfig(dir, files)))
 
   // Throw if no configurations were found
   if (Object.keys(configGroups).length === 0) {

--- a/lib/getConfigGroups.js
+++ b/lib/getConfigGroups.js
@@ -2,9 +2,14 @@
 
 import path from 'path'
 
+import debug from 'debug'
+import objectInspect from 'object-inspect'
+
 import { loadConfig } from './loadConfig.js'
 import { ConfigNotFoundError } from './symbols.js'
 import { validateConfig } from './validateConfig.js'
+
+const debugLog = debug('lint-staged:getConfigGroups')
 
 /**
  * Return matched files grouped by their configuration.
@@ -20,14 +25,20 @@ export const getConfigGroups = async (
   { configObject, configPath, cwd, files },
   logger = console
 ) => {
+  debugLog('Grouping configuration files...')
+
   // Return explicit config object from js API
   if (configObject) {
+    debugLog('Using single direct configuration object...')
+
     const config = validateConfig(configObject, 'config object', logger)
     return { '': { config, files } }
   }
 
   // Use only explicit config path instead of discovering multiple
   if (configPath) {
+    debugLog('Using single configuration path...')
+
     const { config, filepath } = await loadConfig({ configPath }, logger)
 
     if (!config) {
@@ -38,6 +49,8 @@ export const getConfigGroups = async (
     const validatedConfig = validateConfig(config, filepath, logger)
     return { [configPath]: { config: validatedConfig, files } }
   }
+
+  debugLog('Grouping staged files by their directories...')
 
   // Group files by their base directory
   const filesByDir = files.reduce((acc, file) => {
@@ -52,18 +65,29 @@ export const getConfigGroups = async (
     return acc
   }, {})
 
+  debugLog('Grouped staged files into %d directories:', Object.keys(filesByDir).length)
+  debugLog(objectInspect(filesByDir, { indent: 2 }))
+
   // Group files by their discovered config
   // { '.lintstagedrc.json': { config: {...}, files: [...] } }
   const configGroups = {}
 
+  debugLog('Searching config files...')
+
   const searchConfig = async (cwd, files = []) => {
     const { config, filepath } = await loadConfig({ cwd }, logger)
-    if (!config) return
+    if (!config) {
+      debugLog('Found no config from "%s"!', cwd)
+      return
+    }
 
     if (filepath in configGroups) {
+      debugLog('Found existing config "%s" from "%s"!', filepath, cwd)
       // Re-use cached config and skip validation
       configGroups[filepath].files.push(...files)
     } else {
+      debugLog('Found new config "%s" from "%s"!', filepath, cwd)
+
       const validatedConfig = validateConfig(config, filepath, logger)
       configGroups[filepath] = { config: validatedConfig, files }
     }
@@ -77,9 +101,12 @@ export const getConfigGroups = async (
 
   // Throw if no configurations were found
   if (Object.keys(configGroups).length === 0) {
+    debugLog('Found no config groups!')
     logger.error(`${ConfigNotFoundError.message}.`)
     throw ConfigNotFoundError
   }
+
+  debugLog('Grouped staged files into %d groups!', Object.keys(configGroups).length)
 
   return configGroups
 }

--- a/lib/runAll.js
+++ b/lib/runAll.js
@@ -114,7 +114,7 @@ export const runAll = async (
     return ctx
   }
 
-  const configGroups = await getConfigGroups({ configObject, configPath, files }, logger)
+  const configGroups = await getConfigGroups({ configObject, configPath, cwd, files }, logger)
 
   // lint-staged 10 will automatically add modifications to index
   // Warn user when their command includes `git add`

--- a/test/getConfigGroups.spec.js
+++ b/test/getConfigGroups.spec.js
@@ -37,6 +37,8 @@ describe('getConfigGroups', () => {
   })
 
   it('should find config files for all staged files', async () => {
+    // Base cwd
+    loadConfig.mockResolvedValueOnce({ config, filepath: '/.lintstagedrc.json' })
     // '/foo.js' and '/bar.js'
     loadConfig.mockResolvedValueOnce({ config, filepath: '/.lintstagedrc.json' })
     // '/deeper/foo.js'
@@ -55,6 +57,8 @@ describe('getConfigGroups', () => {
   })
 
   it('should find config for one file, and not care about other', async () => {
+    // Base cwd
+    loadConfig.mockResolvedValueOnce({})
     // '/foo.js'
     loadConfig.mockResolvedValueOnce({})
     // '/deeper/foo.js'

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -32,6 +32,7 @@ import { createTempDir } from './utils/tempDir'
 import { isWindowsActions, normalizeWindowsNewlines } from './utils/crossPlatform'
 
 jest.setTimeout(20000)
+jest.retryTimes(2)
 
 // Replace path like `../../git/lint-staged` with `<path>/lint-staged`
 const replaceConfigPathSerializer = replaceSerializer(


### PR DESCRIPTION
This PR makes lint-staged always search for a configuration file from the `cwd`, even if no staged files are inside this. This fixes https://github.com/okonet/lint-staged/issues/1092.