### PR TITLE
feat: add `--cwd` option for overriding task directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,38 +81,36 @@ See [Releases](https://github.com/okonet/lint-staged/releases).
 
 ## Command line flags
 
-```bash
+```
 ❯ npx lint-staged --help
 Usage: lint-staged [options]
 
 Options:
   -V, --version                      output the version number
-  --allow-empty                      allow empty commits when tasks revert all staged changes
-                                     (default: false)
+  --allow-empty                      allow empty commits when tasks revert all staged changes (default: false)
+  -p, --concurrent <number|boolean>  the number of tasks to run concurrently, or false for serial (default: true)
   -c, --config [path]                path to configuration file, or - to read from stdin
+  --cwd [path]                       run all tasks in specific directory, instead of the current
   -d, --debug                        print additional debug information (default: false)
-  --no-stash                         disable the backup stash, and do not revert in case of
-                                     errors
-  -p, --concurrent <parallel tasks>  the number of tasks to run concurrently, or false to run
-                                     tasks serially (default: true)
+  --no-stash                         disable the backup stash, and do not revert in case of errors
   -q, --quiet                        disable lint-staged’s own console output (default: false)
   -r, --relative                     pass relative filepaths to tasks (default: false)
-  -x, --shell [path]                 skip parsing of tasks for better shell support (default:
-                                     false)
-  -v, --verbose                      show task output even when tasks succeed; by default only
-                                     failed output is shown (default: false)
+  -x, --shell [path]                 skip parsing of tasks for better shell support (default: false)
+  -v, --verbose                      show task output even when tasks succeed; by default only failed output is shown
+                                     (default: false)
   -h, --help                         display help for command
 ```
 
 - **`--allow-empty`**: By default, when linter tasks undo all staged changes, lint-staged will exit with an error and abort the commit. Use this flag to allow creating empty git commits.
-- **`--config [path]`**: Manually specify a path to a config file or npm package name. Note: when used, lint-staged won't perform the config file search and will print an error if the specified file cannot be found. If '-' is provided as the filename then the config will be read from stdin, allowing piping in the config like `cat my-config.json | npx lint-staged --config -`.
-- **`--debug`**: Run in debug mode. When set, it does the following:
+- **`--concurrent [number|boolean]`**: Controls the concurrency of tasks being run by lint-staged. **NOTE**: This does NOT affect the concurrency of subtasks (they will always be run sequentially). Possible values are:
   - uses [debug](https://github.com/visionmedia/debug) internally to log additional information about staged files, commands being executed, location of binaries, etc. Debug logs, which are automatically enabled by passing the flag, can also be enabled by setting the environment variable `$DEBUG` to `lint-staged*`.
   - uses [`verbose` renderer](https://github.com/SamVerschueren/listr-verbose-renderer) for `listr`; this causes serial, uncoloured output to the terminal, instead of the default (beautified, dynamic) output.
-- **`--concurrent [number | (true/false)]`**: Controls the concurrency of tasks being run by lint-staged. **NOTE**: This does NOT affect the concurrency of subtasks (they will always be run sequentially). Possible values are:
   - `false`: Run all tasks serially
   - `true` (default) : _Infinite_ concurrency. Runs as many tasks in parallel as possible.
   - `{number}`: Run the specified number of tasks in parallel, where `1` is equivalent to `false`.
+- **`--config [path]`**: Manually specify a path to a config file or npm package name. Note: when used, lint-staged won't perform the config file search and will print an error if the specified file cannot be found. If '-' is provided as the filename then the config will be read from stdin, allowing piping in the config like `cat my-config.json | npx lint-staged --config -`.
+- **`--cwd [path]`**: By default tasks run in the current working directory. Use the `--cwd some/directory` to override this. The path can be absolute or relative to the current working directory.
+- **`--debug`**: Run in debug mode. When set, it does the following:
 - **`--no-stash`**: By default a backup stash will be created before running the tasks, and all task modifications will be reverted in case of an error. This option will disable creating the stash, and instead leave all modifications in the index when aborting the commit.
 - **`--quiet`**: Supress all CLI output, except from tasks.
 - **`--relative`**: Pass filepaths relative to `process.cwd()` (where `lint-staged` runs) to tasks. Default is `false`.

--- a/bin/lint-staged.js
+++ b/bin/lint-staged.js
@@ -26,14 +26,15 @@ const version = packageJson.version
 cmdline
   .version(version)
   .option('--allow-empty', 'allow empty commits when tasks revert all staged changes', false)
-  .option('-c, --config [path]', 'path to configuration file, or - to read from stdin')
-  .option('-d, --debug', 'print additional debug information', false)
-  .option('--no-stash', 'disable the backup stash, and do not revert in case of errors', false)
   .option(
-    '-p, --concurrent <parallel tasks>',
-    'the number of tasks to run concurrently, or false to run tasks serially',
+    '-p, --concurrent <number|boolean>',
+    'the number of tasks to run concurrently, or false for serial',
     true
   )
+  .option('-c, --config [path]', 'path to configuration file, or - to read from stdin')
+  .option('--cwd [path]', 'run all tasks in specific directory, instead of the current')
+  .option('-d, --debug', 'print additional debug information', false)
+  .option('--no-stash', 'disable the backup stash, and do not revert in case of errors', false)
   .option('-q, --quiet', 'disable lint-staged’s own console output', false)
   .option('-r, --relative', 'pass relative filepaths to tasks', false)
   .option('-x, --shell [path]', 'skip parsing of tasks for better shell support', false)
@@ -75,12 +76,13 @@ const options = {
   allowEmpty: !!cmdlineOptions.allowEmpty,
   concurrent: JSON.parse(cmdlineOptions.concurrent),
   configPath: cmdlineOptions.config,
+  cwd: cmdlineOptions.cwd,
   debug: !!cmdlineOptions.debug,
   maxArgLength: getMaxArgLength() / 2,
-  stash: !!cmdlineOptions.stash, // commander inverts `no-<x>` flags to `!x`
   quiet: !!cmdlineOptions.quiet,
   relative: !!cmdlineOptions.relative,
   shell: cmdlineOptions.shell /* Either a boolean or a string pointing to the shell */,
+  stash: !!cmdlineOptions.stash, // commander inverts `no-<x>` flags to `!x`
   verbose: !!cmdlineOptions.verbose,
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,7 +37,7 @@ const lintStaged = async (
     concurrent = true,
     config: configObject,
     configPath,
-    cwd = process.cwd(),
+    cwd,
     debug = false,
     maxArgLength,
     quiet = false,
@@ -48,7 +48,7 @@ const lintStaged = async (
   } = {},
   logger = console
 ) => {
-  await validateOptions({ shell }, logger)
+  await validateOptions({ cwd, shell }, logger)
 
   // Unset GIT_LITERAL_PATHSPECS to not mess with path interpretation
   debugLog('Unset GIT_LITERAL_PATHSPECS (was `%s`)', process.env.GIT_LITERAL_PATHSPECS)

--- a/lib/runAll.js
+++ b/lib/runAll.js
@@ -66,7 +66,7 @@ export const runAll = async (
     concurrent = true,
     configObject,
     configPath,
-    cwd = process.cwd(),
+    cwd,
     debug = false,
     maxArgLength,
     quiet = false,
@@ -77,7 +77,11 @@ export const runAll = async (
   },
   logger = console
 ) => {
-  debugLog('Running all linter scripts')
+  debugLog('Running all linter scripts...')
+
+  // Resolve relative CWD option
+  cwd = cwd ? path.resolve(cwd) : process.cwd()
+  debugLog('Using working directory `%s`', cwd)
 
   const ctx = getInitialState({ quiet })
 

--- a/lib/validateOptions.js
+++ b/lib/validateOptions.js
@@ -1,4 +1,5 @@
 import { constants, promises as fs } from 'fs'
+import path from 'path'
 
 import debug from 'debug'
 
@@ -10,12 +11,24 @@ const debugLog = debug('lint-staged:validateOptions')
 /**
  * Validate lint-staged options, either from the Node.js API or the command line flags.
  * @param {*} options
+ * @param {boolean|string} [options.cwd] - Current working directory
  * @param {boolean|string} [options.shell] - Skip parsing of tasks for better shell support
  *
  * @throws {InvalidOptionsError}
  */
 export const validateOptions = async (options = {}, logger) => {
   debugLog('Validating options...')
+
+  /** Ensure the passed cwd option exists; it might also be relative */
+  if (typeof options.cwd === 'string') {
+    try {
+      const resolved = path.resolve(options.cwd)
+      await fs.access(resolved, constants.F_OK)
+    } catch (error) {
+      logger.error(invalidOption('cwd', options.cwd, error.message))
+      throw InvalidOptionsError
+    }
+  }
 
   /** Ensure the passed shell option is executable */
   if (typeof options.shell === 'string') {


### PR DESCRIPTION
This PR exposes the `--cwd` option, previously only available in the Node.js API. It also adds a debug log output for the current value, and whether it was explicit or not.