### PR TITLE
fix: handles symlink .git paths

### DIFF
--- a/lib/resolveGitRepo.js
+++ b/lib/resolveGitRepo.js
@@ -14,7 +14,9 @@ const debugLog = debug('lint-staged:resolveGitRepo')
  * submodules and worktrees
  */
 const resolveGitConfigDir = async (gitDir) => {
-  const defaultDir = normalize(path.join(gitDir, '.git'))
+  // Get the real path in case it's a symlink
+  const realpath = await fs.realpath(path.join(gitDir, '.git'))
+  const defaultDir = normalize(realpath)
   const stats = await fs.lstat(defaultDir)
   // If .git is a directory, use it
   if (stats.isDirectory()) return defaultDir

--- a/lib/resolveGitRepo.js
+++ b/lib/resolveGitRepo.js
@@ -15,8 +15,7 @@ const debugLog = debug('lint-staged:resolveGitRepo')
  */
 const resolveGitConfigDir = async (gitDir) => {
   // Get the real path in case it's a symlink
-  const realpath = await fs.realpath(path.join(gitDir, '.git'))
-  const defaultDir = normalize(realpath)
+  const defaultDir = normalize(await fs.realpath(path.join(gitDir, '.git')))
   const stats = await fs.lstat(defaultDir)
   // If .git is a directory, use it
   if (stats.isDirectory()) return defaultDir


### PR DESCRIPTION
We're using [git-repo](https://gerrit.googlesource.com/git-repo/) and it creates .git directories as symlinks.
Current .git path resolution doesn't recognize it and throws an error.