### PR TITLE
fix: exec fail when monorepo has a large of changes

### DIFF
--- a/lib/execGit.js
+++ b/lib/execGit.js
@@ -1,6 +1,8 @@
 import debug from 'debug'
 import execa from 'execa'
 
+import { existFile } from './file.js'
+
 const debugLog = debug('lint-staged:execGit')
 
 /**
@@ -23,5 +25,45 @@ export const execGit = async (cmd, options = {}) => {
     return stdout
   } catch ({ all }) {
     throw new Error(all)
+  }
+}
+
+export const reliableExecGit = (gitDir, gitLockPath, retryCount) => {
+  let count = retryCount
+
+  return async function fn(cmd, options = {}) {
+    {
+      const timeout = 5000 // 5s
+      const deadlineTime = Date.now() + timeout
+
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        const lock = await existFile(gitLockPath)
+
+        if (!lock) {
+          break
+        }
+
+        if (Date.now() > deadlineTime) {
+          throw new Error('execute git command timeout')
+        }
+      }
+    }
+
+    try {
+      return await execGit(cmd, {
+        ...options,
+        cwd: gitDir,
+      })
+    } catch (error) {
+      if (--count === 1) {
+        throw error
+      }
+
+      // 1s => 2s => 3s ...
+      await new Promise((r) => setTimeout(r, (retryCount - count) * 1000))
+
+      return await fn(cmd, options)
+    }
   }
 }

--- a/lib/file.js
+++ b/lib/file.js
@@ -1,4 +1,4 @@
-import { promises as fs } from 'fs'
+import { promises as fs, constants } from 'fs'
 
 import debug from 'debug'
 
@@ -50,4 +50,19 @@ export const unlink = async (filename, ignoreENOENT = true) => {
 export const writeFile = async (filename, buffer) => {
   debugLog('Writing file `%s`', filename)
   await fs.writeFile(filename, buffer)
+}
+
+/**
+ * Check file exist
+ * @param {String} filename
+ * @returns {Promise<boolean>}
+ */
+export const existFile = async (filename) => {
+  debugLog('Check file exists `%s`', filename)
+  try {
+    await fs.access(filename, constants.F_OK)
+    return true
+  } catch {
+    return false
+  }
 }

--- a/lib/gitWorkflow.js
+++ b/lib/gitWorkflow.js
@@ -2,7 +2,7 @@ import path from 'path'
 
 import debug from 'debug'
 
-import { execGit } from './execGit.js'
+import { execGit, reliableExecGit } from './execGit.js'
 import { readFile, unlink, writeFile } from './file.js'
 import {
   GitError,
@@ -67,6 +67,7 @@ const handleError = (error, ctx, symbol) => {
 export class GitWorkflow {
   constructor({ allowEmpty, gitConfigDir, gitDir, matchedFileChunks }) {
     this.execGit = (args, options = {}) => execGit(args, { ...options, cwd: gitDir })
+    this.reliableExecGit = reliableExecGit(gitDir, path.resolve(gitConfigDir, 'index.lock'), 3)
     this.deletedFiles = []
     this.gitConfigDir = gitConfigDir
     this.gitDir = gitDir
@@ -220,8 +221,8 @@ export class GitWorkflow {
       // Save stash of all staged files.
       // The `stash create` command creates a dangling commit without removing any files,
       // and `stash store` saves it as an actual stash.
-      const hash = await this.execGit(['stash', 'create'])
-      await this.execGit(['stash', 'store', '--quiet', '--message', STASH, hash])
+      const hash = await this.reliableExecGit(['stash', 'create'])
+      await this.reliableExecGit(['stash', 'store', '--quiet', '--message', STASH, hash])
 
       debugLog('Done backing up original state!')
     } catch (error) {
@@ -235,7 +236,7 @@ export class GitWorkflow {
   async hideUnstagedChanges(ctx) {
     try {
       const files = processRenames(this.partiallyStagedFiles, false)
-      await this.execGit(['checkout', '--force', '--', ...files])
+      await this.reliableExecGit(['checkout', '--force', '--', ...files])
     } catch (error) {
       /**
        * `git checkout --force` doesn't throw errors, so it shouldn't be possible to get here.
@@ -329,7 +330,7 @@ export class GitWorkflow {
   async cleanup(ctx) {
     try {
       debugLog('Dropping backup stash...')
-      await this.execGit(['stash', 'drop', '--quiet', await this.getBackupStash(ctx)])
+      await this.reliableExecGit(['stash', 'drop', '--quiet', await this.getBackupStash(ctx)])
       debugLog('Done dropping backup stash!')
     } catch (error) {
       handleError(error, ctx)


### PR DESCRIPTION
Fixed: https://github.com/okonet/lint-staged/issues/929

The reason for this error is that some of git's operations are locked(`.git/index.loack`). e.g: 
* `git stash create`
* `git stash store`
* `git stash drop`
* `git checkout`

And in monorepo we often have an operation `recursive`, such as `pnpm run lint -r` in pnpm

Then lint-staged will perform the above git operation in each packages, resulting in an `lint-staged failed due to a git error.`