### PR TITLE
fix: search all configs regardless of staged files

### DIFF
--- a/lib/getConfigGroups.js
+++ b/lib/getConfigGroups.js
@@ -99,13 +99,6 @@ export const getConfigGroups = async (
   // Discover configs from the base directory of each file
   await Promise.all(Object.entries(filesByDir).map(([dir, files]) => searchConfig(dir, files)))
 
-  // Throw if no configurations were found
-  if (Object.keys(configGroups).length === 0) {
-    debugLog('Found no config groups!')
-    logger.error(`${ConfigNotFoundError.message}.`)
-    throw ConfigNotFoundError
-  }
-
   debugLog('Grouped staged files into %d groups!', Object.keys(configGroups).length)
 
   return configGroups

--- a/lib/getStagedFiles.js
+++ b/lib/getStagedFiles.js
@@ -3,6 +3,7 @@ import path from 'path'
 import normalize from 'normalize-path'
 
 import { execGit } from './execGit.js'
+import { parseGitZOutput } from './parseGitZOutput.js'
 
 export const getStagedFiles = async ({ cwd = process.cwd() } = {}) => {
   try {
@@ -14,15 +15,7 @@ export const getStagedFiles = async ({ cwd = process.cwd() } = {}) => {
 
     if (!lines) return []
 
-    // With `-z`, git prints `fileA\u0000fileB\u0000fileC\u0000` so we need to
-    // remove the last occurrence of `\u0000` before splitting
-    return (
-      lines
-        // eslint-disable-next-line no-control-regex
-        .replace(/\u0000$/, '')
-        .split('\u0000')
-        .map((file) => normalize(path.resolve(cwd, file)))
-    )
+    return parseGitZOutput(lines).map((file) => normalize(path.resolve(cwd, file)))
   } catch {
     return null
   }

--- a/lib/loadConfig.js
+++ b/lib/loadConfig.js
@@ -13,7 +13,7 @@ const debugLog = debug('lint-staged:loadConfig')
  * The list of files `lint-staged` will read configuration
  * from, in the declared order.
  */
-const searchPlaces = [
+export const searchPlaces = [
   'package.json',
   '.lintstagedrc',
   '.lintstagedrc.json',

--- a/lib/parseGitZOutput.js
+++ b/lib/parseGitZOutput.js
@@ -1,0 +1,9 @@
+/**
+ * Return array of strings split from the output of `git <something> -z`.
+ * With `-z`, git prints `fileA\u0000fileB\u0000fileC\u0000` so we need to
+ * remove the last occurrence of `\u0000` before splitting
+ */
+export const parseGitZOutput = (input) =>
+  input
+    .replace(/\u0000$/, '') // eslint-disable-line no-control-regex
+    .split('\u0000')

--- a/lib/runAll.js
+++ b/lib/runAll.js
@@ -35,7 +35,8 @@ import {
   restoreOriginalStateSkipped,
   restoreUnstagedChangesSkipped,
 } from './state.js'
-import { GitRepoError, GetStagedFilesError, GitError } from './symbols.js'
+import { GitRepoError, GetStagedFilesError, GitError, ConfigNotFoundError } from './symbols.js'
+import { searchConfigs } from './searchConfigs.js'
 
 const debugLog = debug('lint-staged:runAll')
 
@@ -121,7 +122,19 @@ export const runAll = async (
 
   const configGroups = await getConfigGroups({ configObject, configPath, cwd, files }, logger)
 
-  const hasMultipleConfigs = Object.keys(configGroups).length > 1
+  const hasExplicitConfig = configObject || configPath
+  const foundConfigs = hasExplicitConfig ? null : await searchConfigs(gitDir, logger)
+  const numberOfConfigs = hasExplicitConfig ? 1 : Object.keys(foundConfigs).length
+
+  // Throw if no configurations were found
+  if (numberOfConfigs === 0) {
+    ctx.errors.add(ConfigNotFoundError)
+    throw createError(ctx, ConfigNotFoundError)
+  }
+
+  debugLog('Found %d configs:\n%O', numberOfConfigs, foundConfigs)
+
+  const hasMultipleConfigs = numberOfConfigs > 1
 
   // lint-staged 10 will automatically add modifications to index
   // Warn user when their command includes `git add`

--- a/lib/searchConfigs.js
+++ b/lib/searchConfigs.js
@@ -1,0 +1,74 @@
+/** @typedef {import('./index').Logger} Logger */
+
+import { basename, join } from 'path'
+
+import normalize from 'normalize-path'
+
+import { execGit } from './execGit.js'
+import { loadConfig, searchPlaces } from './loadConfig.js'
+import { validateConfig } from './validateConfig.js'
+
+const EXEC_GIT = ['ls-files', '-z', '--full-name']
+
+const filterPossibleConfigFiles = (file) => searchPlaces.includes(basename(file))
+
+const numberOfLevels = (file) => file.split('/').length
+
+const sortDeepestParth = (a, b) => (numberOfLevels(a) > numberOfLevels(b) ? -1 : 1)
+
+/**
+ * Search all config files from the git repository
+ *
+ * @param {string} gitDir
+ * @param {Logger} logger
+ * @returns {Promise<{ [key: string]: * }>} found configs with filepath as key, and config as value
+ */
+export const searchConfigs = async (gitDir = process.cwd(), logger) => {
+  /** Get all possible config files known to git */
+  const cachedFiles = (await execGit(EXEC_GIT, { cwd: gitDir }))
+    // eslint-disable-next-line no-control-regex
+    .replace(/\u0000$/, '')
+    .split('\u0000')
+    .filter(filterPossibleConfigFiles)
+
+  /** Get all possible config files from uncommitted files */
+  const otherFiles = (
+    await execGit([...EXEC_GIT, '--others', '--exclude-standard'], { cwd: gitDir })
+  )
+    // eslint-disable-next-line no-control-regex
+    .replace(/\u0000$/, '')
+    .split('\u0000')
+    .filter(filterPossibleConfigFiles)
+
+  /** Sort possible config files so that deepest is first */
+  const possibleConfigFiles = [...cachedFiles, ...otherFiles]
+    .map((file) => join(gitDir, file))
+    .map((file) => normalize(file))
+    .sort(sortDeepestParth)
+
+  /** Create object with key as config file, and value as null */
+  const configs = possibleConfigFiles.reduce(
+    (acc, configPath) => Object.assign(acc, { [configPath]: null }),
+    {}
+  )
+
+  /** Load and validate all configs to the above object */
+  await Promise.all(
+    possibleConfigFiles
+      .map((configPath) => loadConfig({ configPath }, logger))
+      .map((promise) =>
+        promise.then(({ config, filepath }) => {
+          if (config) {
+            configs[filepath] = validateConfig(config, filepath, logger)
+          }
+        })
+      )
+  )
+
+  /** Get validated configs from the above object, without any `null` values (not found) */
+  const foundConfigs = Object.entries(configs)
+    .filter(([, value]) => !!value)
+    .reduce((acc, [key, value]) => ({ ...acc, [key]: value }), {})
+
+  return foundConfigs
+}

--- a/lib/searchConfigs.js
+++ b/lib/searchConfigs.js
@@ -6,6 +6,7 @@ import normalize from 'normalize-path'
 
 import { execGit } from './execGit.js'
 import { loadConfig, searchPlaces } from './loadConfig.js'
+import { parseGitZOutput } from './parseGitZOutput.js'
 import { validateConfig } from './validateConfig.js'
 
 const EXEC_GIT = ['ls-files', '-z', '--full-name']
@@ -25,20 +26,14 @@ const sortDeepestParth = (a, b) => (numberOfLevels(a) > numberOfLevels(b) ? -1 :
  */
 export const searchConfigs = async (gitDir = process.cwd(), logger) => {
   /** Get all possible config files known to git */
-  const cachedFiles = (await execGit(EXEC_GIT, { cwd: gitDir }))
-    // eslint-disable-next-line no-control-regex
-    .replace(/\u0000$/, '')
-    .split('\u0000')
-    .filter(filterPossibleConfigFiles)
+  const cachedFiles = parseGitZOutput(await execGit(EXEC_GIT, { cwd: gitDir })).filter(
+    filterPossibleConfigFiles
+  )
 
   /** Get all possible config files from uncommitted files */
-  const otherFiles = (
+  const otherFiles = parseGitZOutput(
     await execGit([...EXEC_GIT, '--others', '--exclude-standard'], { cwd: gitDir })
-  )
-    // eslint-disable-next-line no-control-regex
-    .replace(/\u0000$/, '')
-    .split('\u0000')
-    .filter(filterPossibleConfigFiles)
+  ).filter(filterPossibleConfigFiles)
 
   /** Sort possible config files so that deepest is first */
   const possibleConfigFiles = [...cachedFiles, ...otherFiles]

--- a/test/getConfigGroups.spec.js
+++ b/test/getConfigGroups.spec.js
@@ -30,12 +30,6 @@ describe('getConfigGroups', () => {
     )
   })
 
-  it('should throw when config not found', async () => {
-    await expect(
-      getConfigGroups({ files: ['/foo.js'] })
-    ).rejects.toThrowErrorMatchingInlineSnapshot(`"Configuration could not be found"`)
-  })
-
   it('should find config files for all staged files', async () => {
     // Base cwd
     loadConfig.mockResolvedValueOnce({ config, filepath: '/.lintstagedrc.json' })

--- a/test/parseGitZOutput.spec.js
+++ b/test/parseGitZOutput.spec.js
@@ -1,0 +1,13 @@
+import { parseGitZOutput } from '../lib/parseGitZOutput'
+
+describe('parseGitZOutput', () => {
+  it('should split string from `git -z` control character', () => {
+    const input = 'a\u0000b\u0000c'
+    expect(parseGitZOutput(input)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('should remove trailing `git -z` control character', () => {
+    const input = 'a\u0000'
+    expect(parseGitZOutput(input)).toEqual(['a'])
+  })
+})


### PR DESCRIPTION
This PR searches for all configurations inside the git repo, instead of only those matching the staged files. It's currently only used for the `hasMultipleConfigs` check, but in the future it will also be used to fix "parent directory" globs, which are currently not working.

Without this fix, `hasMultipleConfigs` would be `false` if you only staged files matching a single config, and thus the CWD would be wrong.