### PR TITLE
chore: don't use `touch` on windows

### DIFF
--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -29,7 +29,7 @@ import lintStaged from '../lib/index'
 
 import { replaceSerializer } from './utils/replaceSerializer'
 import { createTempDir } from './utils/tempDir'
-import { isWindowsActions, normalizeWindowsNewlines } from './utils/crossPlatform'
+import { isWindows, isWindowsActions, normalizeWindowsNewlines } from './utils/crossPlatform'
 
 jest.setTimeout(20000)
 jest.retryTimes(2)
@@ -97,7 +97,7 @@ const appendFile = async (filename, content, dir = cwd) => {
 const writeFile = async (filename, content, dir = cwd) => {
   const filepath = path.isAbsolute(filename) ? filename : path.join(dir, filename)
   await ensureDir(filepath)
-  fs.writeFile(filepath, content)
+  await fs.writeFile(filepath, content)
 }
 
 // Wrap execGit to always pass `gitOps`
@@ -449,9 +449,10 @@ describe('lint-staged', () => {
     // The task creates a git lock file and runs `git add` to simulate failure
     await expect(
       gitCommit({
+        shell: isWindows,
         config: {
           '*.js': (files) => [
-            `touch ${cwd}/.git/index.lock`,
+            `${isWindows ? 'type nul >' : 'touch'} ${cwd}/.git/index.lock`,
             `prettier --write ${files.join(' ')}`,
             `git add ${files.join(' ')}`,
           ],

--- a/test/utils/crossPlatform.js
+++ b/test/utils/crossPlatform.js
@@ -1,3 +1,7 @@
+import os from 'os'
+
+export const isWindows = os.platform() === 'win32'
+
 /** Whether the current environment is a GitHub Actions runner under Windows */
 export const isWindowsActions = () => {
   const { GITHUB_ACTIONS, RUNNER_OS } = process.env


### PR DESCRIPTION
Apparently, `touch` is one of the numerous tools that GitHub installs in its actions image. But it is generally not available on Windows systems.

Plus, there was a missing await in a write file function that caused issues at least on my desktop Windows 11.