### PR TITLE
Force update rendering for forced colors and ensure quiet rendering when requested

### DIFF
--- a/lib/getRenderer.js
+++ b/lib/getRenderer.js
@@ -1,11 +1,3 @@
-export const getRenderer = (options, env = process.env) => {
-  const mainRendererOptions = getMainRendererOptions(options, env)
-  return {
-    ...mainRendererOptions,
-    nonTTYRenderer: getFallbackRenderer(mainRendererOptions, env),
-  }
-}
-
 const getMainRendererOptions = ({ debug, quiet }, env) => {
   if (quiet) return { renderer: 'silent' }
   // Better support for dumb terminals: https://en.wikipedia.org/wiki/Computer_terminal#Dumb_terminals
@@ -25,4 +17,12 @@ const getFallbackRenderer = ({ renderer }, { FORCE_COLOR }) => {
   }
 
   return 'verbose'
+}
+
+export const getRenderer = (options, env = process.env) => {
+  const mainRendererOptions = getMainRendererOptions(options, env)
+  return {
+    ...mainRendererOptions,
+    nonTTYRenderer: getFallbackRenderer(mainRendererOptions, env),
+  }
 }

--- a/lib/getRenderer.js
+++ b/lib/getRenderer.js
@@ -1,7 +1,28 @@
-export const getRenderer = ({ debug, quiet }, env = process.env) => {
+export const getRenderer = (options, env = process.env) => {
+  const mainRendererOptions = getMainRendererOptions(options, env)
+  return {
+    ...mainRendererOptions,
+    nonTTYRenderer: getFallbackRenderer(mainRendererOptions, env),
+  }
+}
+
+const getMainRendererOptions = ({ debug, quiet }, env) => {
   if (quiet) return { renderer: 'silent' }
   // Better support for dumb terminals: https://en.wikipedia.org/wiki/Computer_terminal#Dumb_terminals
   const isDumbTerminal = env.TERM === 'dumb'
   if (debug || isDumbTerminal || env.NODE_ENV === 'test') return { renderer: 'verbose' }
   return { renderer: 'update', rendererOptions: { dateFormat: false } }
+}
+
+const getFallbackRenderer = ({ renderer }, { FORCE_COLOR }) => {
+  if (renderer === 'silent') {
+    return 'silent'
+  }
+
+  // If colors are being forced, then also force non-fallback rendering
+  if (Number(FORCE_COLOR) > 0) {
+    return renderer
+  }
+
+  return 'verbose'
 }

--- a/lib/runAll.js
+++ b/lib/runAll.js
@@ -143,7 +143,6 @@ export const runAll = async (
   const listrOptions = {
     ctx,
     exitOnError: false,
-    nonTTYRenderer: 'verbose',
     registerSignalListeners: false,
     ...getRenderer({ debug, quiet }),
   }

--- a/test/getRenderer.spec.js
+++ b/test/getRenderer.spec.js
@@ -1,28 +1,61 @@
 import { getRenderer } from '../lib/getRenderer'
 
 describe('getRenderer', () => {
-  it('should return silent renderer when quiet', () => {
-    expect(getRenderer({ quiet: true }, {})).toEqual({ renderer: 'silent' })
+  it('should return silent renderers when quiet', () => {
+    expect(getRenderer({ quiet: true }, {})).toEqual({
+      renderer: 'silent',
+      nonTTYRenderer: 'silent',
+    })
   })
 
-  it('should return verbose renderer when NODE_ENV=test', () => {
-    expect(getRenderer({}, { NODE_ENV: 'test' })).toEqual({ renderer: 'verbose' })
+  it('should return verbose renderers when NODE_ENV=test', () => {
+    expect(getRenderer({}, { NODE_ENV: 'test' })).toEqual({
+      renderer: 'verbose',
+      nonTTYRenderer: 'verbose',
+    })
   })
 
-  it('should return test renderer when TERM=dumb', () => {
-    expect(getRenderer({}, { TERM: 'dumb' })).toEqual({ renderer: 'verbose' })
+  it('should return test renderers when TERM=dumb', () => {
+    expect(getRenderer({}, { TERM: 'dumb' })).toEqual({
+      renderer: 'verbose',
+      nonTTYRenderer: 'verbose',
+    })
   })
 
-  it('should return verbose renderer when debug', () => {
-    expect(getRenderer({ debug: true }, {})).toEqual({ renderer: 'verbose' })
+  it('should return verbose renderers when debug', () => {
+    expect(getRenderer({ debug: true }, {})).toEqual({
+      renderer: 'verbose',
+      nonTTYRenderer: 'verbose',
+    })
   })
 
-  it('should return update renderer by default', () => {
+  it('should return update main renderer and verbose fallback renderer by default', () => {
     expect(getRenderer({}, {})).toEqual({
       renderer: 'update',
       rendererOptions: {
         dateFormat: false,
       },
+      nonTTYRenderer: 'verbose',
+    })
+  })
+
+  it('should return update main renderer and verbose fallback renderer when colors are not forced', () => {
+    expect(getRenderer({}, { FORCE_COLOR: '0' })).toEqual({
+      renderer: 'update',
+      rendererOptions: {
+        dateFormat: false,
+      },
+      nonTTYRenderer: 'verbose',
+    })
+  })
+
+  it('should return update renderers when colors are forced', () => {
+    expect(getRenderer({}, { FORCE_COLOR: '1' })).toEqual({
+      renderer: 'update',
+      rendererOptions: {
+        dateFormat: false,
+      },
+      nonTTYRenderer: 'update',
     })
   })
 })

--- a/test/index2.spec.js
+++ b/test/index2.spec.js
@@ -43,7 +43,7 @@ describe('lintStaged', () => {
           "shouldBackup": true,
         },
         "exitOnError": false,
-        "nonTTYRenderer": "verbose",
+        "nonTTYRenderer": "silent",
         "registerSignalListeners": false,
         "renderer": "silent",
       }


### PR DESCRIPTION
I was kind of on the fence for whether forcing animation/update should be determined by `FORCE_COLOR` or a new command line flag or environment variable.

I went with `FORCE_COLOR` because I think 99.9% of the time if you want to force colors, then you also want animation/update. If you're forcing colors, then you're using a modern terminal, which should support animation/update. Let me know if that makes sense to you or if you think differently!

Lastly, while I was making changes here I also noticed that the fallback renderer can be non-silent even when the main renderer is silent. So if you passed the quiet option and the fallback renderer was chosen, then it wouldn't be quiet. I've fixed that as well.

Closes #693