### PR TITLE
fix: avoid overkilling execa and child processes asynchronously on error

### DIFF
--- a/lib/resolveTaskFn.js
+++ b/lib/resolveTaskFn.js
@@ -63,7 +63,7 @@ const interruptExecutionOnError = (ctx, execaChildProcess) => {
       clearInterval(loopIntervalId)
 
       const ids = await pidTree(execaChildProcess.pid)
-      ids.forEach(process.kill)
+      ids.forEach((id) => process.kill(id))
 
       // The execa process is killed separately in order
       // to get the `KILLED` status.

--- a/lib/resolveTaskFn.js
+++ b/lib/resolveTaskFn.js
@@ -56,8 +56,12 @@ const handleOutput = (command, result, ctx, isError = false) => {
  * checks the context.
  */
 const interruptExecutionOnError = (ctx, execaChildProcess) => {
+  let loopIntervalId
+
   async function loop() {
     if (ctx.errors.size > 0) {
+      clearInterval(loopIntervalId)
+
       const ids = await pidTree(execaChildProcess.pid)
       ids.forEach(process.kill)
 
@@ -67,7 +71,7 @@ const interruptExecutionOnError = (ctx, execaChildProcess) => {
     }
   }
 
-  const loopIntervalId = setInterval(loop, ERROR_CHECK_INTERVAL)
+  loopIntervalId = setInterval(loop, ERROR_CHECK_INTERVAL)
 
   return () => {
     clearInterval(loopIntervalId)


### PR DESCRIPTION
The recently merged #1117 (and the 12.3.6 release itself) introduced a quite dangerous defect in the clean-up logic for failed multi-process linter runs.

I've made an attempt to fix those, but unfortunately I'm not sure I can quickly come up with a suitable test coverage for the fixes provided.
Reason being is that I'm not sure how to incorporate such low-level checks into integration-like output matchers I saw in the existing suites.
Maybe you do not even cover such stuff typically? 


## 1. Unexpected arguments (fixed by 1c0e6c08ef9362b593ae056a9d85bbad9cd25a79)
The first quite simple issue is just missed code bug. We have 

```js
ids.forEach(process.kill)
```

which actually runs as 

```js
ids.forEach((id, index) => process.kill(id, index))
```

Maybe it was doing fine during testing, but in my environment on Windows machine it caused the whole thing to halt with `Error: kill ENOSYS`. 

I've researched it a bit at first:
Naturally similar issues were appearing in different other Node utility libraries. The cause was that a `singal` (second argument) passed to the `process.kill` was carrying an unexpected (by Windows) value , so maintainers usually had to switch from `SIGHUP` to `SIGINT` or something similar.

However, our situation is quite different and plain `process.kill(id)` would definitely suffuce our needs.

## 2. Unwanted asynchronousness (fixed by a2b2ae8662941efe1eecf7f83090f1cabe85c523)
The whole `interruptExecutionOnError` function is based solely on a false expectation of that `loop` function lifetime will be less than the `ERROR_CHECK_INTERVAL`.

Guess what. My work-related laptop is bloated with an immense amount of "endpoint protection" stuff.
To say it short: due to installed "protection" from my employer `await pidTree(id)` lookup takes almost 2 full seconds on average. That is usually 8-10 invocations of the `loop` function.

The implications of it is that on some invocation of `await pidTree(execaPid)` it will be already late -- `execa` will be dead in the water already and it will again counterblast the clean-up execution with an uncaught error.

I was thinking through different ways to fix it: 
- 🚫 a lot of inner try-catches (just messy overall);
- 🚫 checking whether `execa` is still alive on each error-passing `loop` invocation  (unnecessary invocations of a few `await pidTree` until finally one of them resolved and processes are finally killed (with some error-catches of overkills));
- 🚫 introduction of a "deadman semaphore" variable -- kinda the same as previous, but we set it to "dead=true" immediately on the first error-catching invocation of the `loop` function (unnecessary interval triggers still);
- ✅ finally I came to just a simple interval clearing on the first error-catching `loop`.
- ❔ The last idea came to my mind only now [as I'm writing this], but in fact we may also properly use promises instead of interval, which should've been considered **dangerous** for any async function in the first place.  so you can consider this approach in the future. The idea resides around `while (running) { await delay(interval) await invoke() }` but still should be implemented carefully.

I hope this approach do not contradict with other logic around. Otherwise we may try to fallback to other options, until it fits the environment.

## PS
_All in all I was actually surprised there are no ultimate fail-safe wrapping around the linters run. Yes, we indeed try to restore last stash on fail, but those bugs above was halting the execution of whole tool._
_I also saw some issues in the repository. The causes might be different, but the result is the same: if there's an uncaught error during the last phases, we can fail restoring the repository state. Even more: sometimes `index.lock` (git lockfile) were still in the `.git` folder after a failed run._

_Although I probably can understand, that actully this is not very high priority issue, because user can simply restore the stash on their own. Guess, it wouldn't actually break anything._
