### PR TITLE
docs: fix the missing comma in the README.md code

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,7 +594,7 @@ const success = await lintStaged({
   maxArgLength: null,
   quiet: false,
   relative: false,
-  shell: false
+  shell: false,
   stash: true,
   verbose: false
 })


### PR DESCRIPTION
I found a comma missing in the README code.