### PR TITLE
fix: adjust Windows file handle fix

### DIFF
--- a/bin/lint-staged.js
+++ b/bin/lint-staged.js
@@ -132,5 +132,7 @@ try {
 } catch {
   process.exitCode = 1
 } finally {
-  await ttyHandle?.close()
+  if (ttyHandle) {
+    fs.closeSync(ttyHandle)
+  }
 }

--- a/lib/forceTty.js
+++ b/lib/forceTty.js
@@ -1,12 +1,16 @@
-import { constants } from 'node:fs'
-import fs from 'node:fs/promises'
+import fs from 'node:fs'
 import tty from 'node:tty'
 
-const getHandle = async () => {
+const getTtyFd = () => {
   if (process.platform === 'win32') {
-    return await fs.open('CONOUT$', constants.O_WRONLY | constants.O_EXCL, 0o666)
+    // We need to call the underlying C++ bindings directly to open the special
+    // path 'CONOUT$', because otherwise the `fs` library in JS will interpret
+    // that as a filesystem path like '.\CONOUT$'.
+    const cfs = process.binding('fs');
+    const path = 'CONOUT$';
+    return cfs.open(path, fs.constants.O_RDWR | fs.constants.O_EXCL, 0o666, undefined, { path })
   } else {
-    return await fs.open('/dev/tty', constants.O_WRONLY + constants.O_NOCTTY)
+    return fs.openSync('/dev/tty', fs.constants.O_WRONLY | fs.constants.O_NOCTTY)
   }
 }
 
@@ -15,31 +19,25 @@ const getHandle = async () => {
  * When invoking lint-staged through Git hooks, the shell might not
  * be a TTY, but we still want to enable spinners in a "non-hacky" way.
  *
- * @returns {Promise<fs.FileHandle | null>} the `FileHandle` pointing to the TTY, or `null` when failed.
+ * @returns {Promise<number | null>} the numeric file descriptor pointing to the TTY, or `null` when failed.
  */
 export const forceTty = async () => {
   /** No need to do anything if stdout is already a TTY. */
   if (process.stdout.isTTY) return null
 
   try {
-    const handle = await getHandle()
-
-    console.log('forceTTY handle:')
-    console.log(handle)
+    const ttyFd = await getTtyFd()
 
     /**
-     * Probably not realistic that the TTY handle is not a TTY,
+     * Probably not realistic that the TTY fd is not a TTY,
      * but close the handle just in case.
      */
-    if (!tty.isatty(handle.fd)) {
-      await handle.close()
+    if (!tty.isatty(ttyFd)) {
+      fs.closeSync(ttyFd)
       return null
     }
 
-    const stdout = new tty.WriteStream(handle.fd)
-
-    console.log('forceTTY stdout:')
-    console.log(stdout)
+    const stdout = new tty.WriteStream(ttyFd)
 
     /** Override `process.stdout` */
     Object.defineProperty(process, 'stdout', {
@@ -48,10 +46,9 @@ export const forceTty = async () => {
       get: () => stdout,
     })
 
-    return handle
+    return ttyFd
   } catch (error) {
-    console.error('forceTTY error:')
-    console.error(error)
+    console.error('forceTTY error:', error)
     return null
   }
 }

--- a/lib/forceTty.js
+++ b/lib/forceTty.js
@@ -27,6 +27,7 @@ export const forceTty = async () => {
 
   try {
     const ttyFd = await getTtyFd()
+    console.log('DEBUG - ttyFd is', ttyFd);
 
     /**
      * Probably not realistic that the TTY fd is not a TTY,
@@ -48,7 +49,6 @@ export const forceTty = async () => {
 
     return ttyFd
   } catch (error) {
-    console.error('forceTTY error:', error)
     return null
   }
 }

--- a/lib/forceTty.js
+++ b/lib/forceTty.js
@@ -6,8 +6,8 @@ const getTtyFd = () => {
     // We need to call the underlying C++ bindings directly to open the special
     // path 'CONOUT$', because otherwise the `fs` library in JS will interpret
     // that as a filesystem path like '.\CONOUT$'.
-    const cfs = process.binding('fs');
-    const path = 'CONOUT$';
+    const cfs = process.binding('fs')
+    const path = 'CONOUT$'
     return cfs.open(path, fs.constants.O_RDWR | fs.constants.O_EXCL, 0o666, undefined, { path })
   } else {
     return fs.openSync('/dev/tty', fs.constants.O_WRONLY | fs.constants.O_NOCTTY)


### PR DESCRIPTION
The essential issue here is that Windows treats `conout$` / `CONOUT$` as a special string, but when we pass that to `fs.open`, the JS layer in Node treats that as a filesystem path instead of passing on the string unmodified to the `CreateFileW` API. (On Windows I believe that [this is the place](https://github.com/nodejs/node/blob/v16.x/deps/uv/src/win/fs.c#L612) where the C++ calls `CreateFileW`).

Hence we are using the C++ bindings directly in Windows instead of the higher-level `fs.open` API.

I attempted to continue using the `node:fs/promises` APIs, but I found that this uses an internal class `FileHandle` which is not exported (see [here](https://github.com/nodejs/node/blob/v16.x/lib/internal/fs/promises.js#L450)). 

I ended up emulating `fs.openSync` from the non-promise API which calls into the C++ layer in a [relatively direct way](https://github.com/nodejs/node/blob/v16.x/lib/fs.js#L576). 

I think I could also emulate the non-promise `fs.open` with callbacks, but it looks like it would involve a few more steps like a `new FSReqCallback()`.