### PR TITLE
Add: tsc example with staged files

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,20 @@ export default {
 
 </details>
 
+### Example: Run `tsc` on changes to TypeScript files with staged filename arguments
+
+<details>
+  <summary>Click to expand</summary>
+
+```js
+// lint-staged.config.js
+export default {
+  '**/*.ts?(x)': (filenames) => `tsc --noEmit ${filenames.join(' ')}`,
+}
+```
+
+</details>
+
 ### Example: Run ESLint on entire repo if more than 10 staged files
 
 <details>


### PR DESCRIPTION
This PR
: added another example of how to run `tsc` with the files from the staged area.

As a TypeScript user, it was little confusing for me to know how to run tsc with specific filenames from `lint-staged`.
So, how about adding another example for whom might be confused like I was?