### PR TITLE
feat: expose cli entrance

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "bin": "./bin/lint-staged.js",
   "exports": {
     ".": "./lib/index.js",
+    "./bin": "./bin/lint-staged.js",
     "./package.json": "./package.json"
   },
   "files": [


### PR DESCRIPTION
Expose cli entrance will be convenient for developers who want to integrate `lint-stage` cli.