### PR TITLE
docs: blog.johnnyreilly.com -> johnnyreilly.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This project contains a script that will run arbitrary shell tasks with a list o
 - [Running Jest Tests Before Each Git Commit - Ben McCormick, 2017](https://benmccormick.org/2017/02/26/running-jest-tests-before-each-git-commit/)
 - [AgentConf presentation - Andrey Okonetchnikov, 2018](https://www.youtube.com/watch?v=-mhY7e-EsC4)
 - [SurviveJS interview - Juho Vepsäläinen and Andrey Okonetchnikov, 2018](https://survivejs.com/blog/lint-staged-interview/)
-- [Prettier your CSharp with `dotnet-format` and `lint-staged`](https://blog.johnnyreilly.com/2020/12/22/prettier-your-csharp-with-dotnet-format-and-lint-staged)
+- [Prettier your CSharp with `dotnet-format` and `lint-staged`](https://johnnyreilly.com/2020/12/22/prettier-your-csharp-with-dotnet-format-and-lint-staged)
 
 > If you've written one, please submit a PR with the link to it!
 


### PR DESCRIPTION
Hello!

Thanks for your amazing work!  My blog has moved from blog.johnnyreilly.com to johnnyreilly.com; this PR updates the link to reflect that. (There's a 301 in place but it's good to cover all bases)

https://github.com/johnnyreilly/blog.johnnyreilly.com/pull/393