### PR TITLE
fix: fix stash still true when diff is not undefined

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -75,7 +75,8 @@ const lintStaged = async (
     quiet = false,
     relative = false,
     shell = false,
-    stash = true,
+    // Stashing should be disabled by default when the `diff` option is used
+    stash = diff === undefined,
     verbose = false,
   } = {},
   logger = console


### PR DESCRIPTION
fix: fix stash still true when diff is not undefined