### PR TITLE
Use index-based stash references

### DIFF
--- a/lib/gitWorkflow.js
+++ b/lib/gitWorkflow.js
@@ -104,16 +104,7 @@ export class GitWorkflow {
       throw new Error('lint-staged automatic backup is missing!')
     }
 
-    /**
-     * https://github.com/okonet/lint-staged/issues/1121
-     * Detect MSYS in login shell mode and escape braces
-     * to prevent interpolation
-     */
-    if (!!process.env.MSYSTEM && !!process.env.LOGINSHELL) {
-      return `refs/stash@\\{${index}\\}`
-    }
-
-    return `refs/stash@{${index}}`
+    return String(index)
   }
 
   /**

--- a/test/unit/getBackupStash.spec.js
+++ b/test/unit/getBackupStash.spec.js
@@ -47,47 +47,7 @@ describe('gitWorkflow', () => {
         ].join('\n')
       )
 
-      await expect(gitWorkflow.getBackupStash(ctx)).resolves.toEqual('refs/stash@{1}')
-    })
-
-    it('should return unescaped ref to the backup stash when using MSYS2 without login shell', async () => {
-      const gitWorkflow = new GitWorkflow(options)
-      const ctx = getInitialState()
-
-      process.env.MSYSTEM = 'MSYS'
-
-      execGit.mockResolvedValueOnce(
-        [
-          'stash@{0}: some random stuff',
-          `stash@{1}: ${STASH}`,
-          'stash@{2}: other random stuff',
-        ].join('\n')
-      )
-
-      await expect(gitWorkflow.getBackupStash(ctx)).resolves.toEqual('refs/stash@{1}')
-
-      delete process.env.MSYSTEM
-    })
-
-    it('should return escaped ref to the backup stash when using MSYS2 with login shell', async () => {
-      const gitWorkflow = new GitWorkflow(options)
-      const ctx = getInitialState()
-
-      process.env.MSYSTEM = 'MSYS'
-      process.env.LOGINSHELL = 'bash'
-
-      execGit.mockResolvedValueOnce(
-        [
-          'stash@{0}: some random stuff',
-          `stash@{1}: ${STASH}`,
-          'stash@{2}: other random stuff',
-        ].join('\n')
-      )
-
-      await expect(gitWorkflow.getBackupStash(ctx)).resolves.toEqual('refs/stash@\\{1\\}')
-
-      delete process.env.MSYSTEM
-      delete process.env.LOGINSHELL
+      await expect(gitWorkflow.getBackupStash(ctx)).resolves.toEqual('1')
     })
   })
 })


### PR DESCRIPTION
Following the discussion in #1267 I'm making this PR here to make the suggested change. Please see the issue for more details.

This also means we can remove the MSYS workaround, and the corresponding test.