### PR TITLE
test: make test runs robust against a non-"master" defaultBranch

### DIFF
--- a/test/integration/__utils__/withGitIntegration.js
+++ b/test/integration/__utils__/withGitIntegration.js
@@ -79,7 +79,7 @@ export const withGitIntegration =
     const utils = getGitUtils(cwd)
 
     // Init repository with initial commit
-    await utils.execGit('init')
+    await utils.execGit(['init', '--initial-branch=master'])
 
     if (isWindowsActions()) {
       await utils.execGit(['config', 'core.autocrlf', 'input'])


### PR DESCRIPTION
## Summary

This is a tiny fix related to my contribution at #1270 .

When running the tests locally they were failing because my `init.defaultBranch` is set to `main` (was a requirement for some other work). Some of the tests make assumption about the branch name, and will fail if it's not `master`. 

This tiny change makes the test runs more robust by specifying the initial branch name explicitly. This will also shield against any future changes in the default value of the property. This may very well happen, see git docs:
![image](https://user-images.githubusercontent.com/543372/223688714-bf9c6acc-ab46-4cd4-9a4f-0c8c5fda4e27.png)
