### PR TITLE
Minor Version Bump

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,6 @@ on:
     # Run on pushes to specific branches
     branches:
       - master
-      - next
       - beta
       - alpha
     # Do not run on tags


### PR DESCRIPTION
This PR bumps a minor version, making it possible to publish a new npm version under the `latest` tag. From this PR `semantic-release` inadvertently released patch versions to `next` without adding the `-next` postfix.

It also disables `semantic-release` from running for the `next` branch, until the issue is solved.