### PR TITLE
fix: ignore "package.json" as config file when it's invalid JSON

### DIFF
--- a/lib/loadConfig.js
+++ b/lib/loadConfig.js
@@ -9,12 +9,14 @@ import { resolveConfig } from './resolveConfig.js'
 
 const debugLog = debug('lint-staged:loadConfig')
 
+const PACKAGE_JSON = 'package.json'
+
 /**
  * The list of files `lint-staged` will read configuration
  * from, in the declared order.
  */
 export const searchPlaces = [
-  'package.json',
+  PACKAGE_JSON,
   '.lintstagedrc',
   '.lintstagedrc.json',
   '.lintstagedrc.yaml',
@@ -27,7 +29,18 @@ export const searchPlaces = [
   'lint-staged.config.cjs',
 ]
 
-const jsonParse = (path, content) => JSON.parse(content)
+const jsonParse = (path, content) => {
+  try {
+    return JSON.parse(content)
+  } catch (error) {
+    if (path.endsWith(PACKAGE_JSON)) {
+      debugLog('Ignoring invalid package file `%s` with content:\n%s', path, content)
+      return undefined
+    }
+
+    throw error
+  }
+}
 
 const yamlParse = (path, content) => YAML.parse(content)
 

--- a/test/unit/loadConfig.spec.js
+++ b/test/unit/loadConfig.spec.js
@@ -1,3 +1,4 @@
+import fs from 'node:fs/promises'
 import path from 'node:path'
 
 import makeConsoleMock from 'consolemock'
@@ -176,5 +177,33 @@ describe('loadConfig', () => {
     const result = await loadConfig({ configPath: 'fake-config-file.yml' }, logger)
 
     expect(result).toMatchInlineSnapshot(`{}`)
+  })
+
+  it('should return empty object ".lintstagedrc.json" file is invalid', async () => {
+    expect.assertions(1)
+
+    const configFile = path.join(__dirname, '__mocks__', '.lintstagedrc.json')
+
+    await fs.writeFile(configFile, '{')
+
+    const result = await loadConfig({ configPath: configFile }, logger)
+
+    expect(result).toMatchInlineSnapshot(`{}`)
+
+    await fs.rm(configFile)
+  })
+
+  it('should return null config when package.json file is invalid', async () => {
+    expect.assertions(1)
+
+    const configFile = path.join(__dirname, '__mocks__', 'package.json')
+
+    await fs.writeFile(configFile, '{')
+
+    const { config } = await loadConfig({ configPath: configFile }, logger)
+
+    expect(config).toBeNull()
+
+    await fs.rm(configFile)
   })
 })


### PR DESCRIPTION
This PR hides the JSON parser error when trying to load _lint-staged_ config from an invalid package.json file:

```
% node bin/lint-staged.js
SyntaxError: Unexpected end of JSON input
    at JSON.parse (<anonymous>)
    at jsonParse (file:///Users/iiro/git/lint-staged/lib/loadConfig.js:30:43)
    at Object.load (/Users/iiro/git/lint-staged/node_modules/lilconfig/dist/index.js:148:35)
    at async loadConfig (file:///Users/iiro/git/lint-staged/lib/loadConfig.js:65:20)
    at async Promise.all (index 1)
    at async searchConfigs (file:///Users/iiro/git/lint-staged/lib/searchConfigs.js:84:3)
    at async runAll (file:///Users/iiro/git/lint-staged/lib/runAll.js:129:24)
    at async lintStaged (file:///Users/iiro/git/lint-staged/lib/index.js:108:17)
✔ Preparing lint-staged...
✔ Running tasks for staged files...
✔ Applying modifications from tasks...
✔ Cleaning up temporary files...
```

Instead a debug log entry will be emitted (in this case an empty file):

```
  lint-staged:loadConfig Ignoring invalid package file `/Users/iiro/git/lint-staged/test/package.json` with content:
  lint-staged:loadConfig  +0ms
  lint-staged:loadConfig Successfully loaded config from `/Users/iiro/git/lint-staged/test/package.json`:
  lint-staged:loadConfig null +0ms
```