### PR TITLE
feat: Support using diff instead of staged files

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Options:
   -r, --relative                     pass relative filepaths to tasks (default: false)
   -x, --shell [path]                 skip parsing of tasks for better shell support (default:
                                      false)
+  --diff <gitref>                    run on the files changed on this branch since it forked
+                                     from <gitref> instead of the staged files (default: null)
   -v, --verbose                      show task output even when tasks succeed; by default only
                                      failed output is shown (default: false)
   -h, --help                         display help for command
@@ -91,6 +93,7 @@ Options:
 - **`--quiet`**: Supress all CLI output, except from tasks.
 - **`--relative`**: Pass filepaths relative to `process.cwd()` (where `lint-staged` runs) to tasks. Default is `false`.
 - **`--shell`**: By default linter commands will be parsed for speed and security. This has the side-effect that regular shell scripts might not work as expected. You can skip parsing of commands with this option. To use a specific shell, use a path like `--shell "/bin/bash"`.
+- **`--diff [string]`**: This uses the changed files between the current branch and the specified Git ref (e.g., `origin/master`).
 - **`--verbose`**: Show task output even when tasks succeed. By default only failed output is shown.
 
 ## Configuration

--- a/bin/lint-staged.js
+++ b/bin/lint-staged.js
@@ -44,6 +44,11 @@ cmdline
   .option('-r, --relative', 'pass relative filepaths to tasks', false)
   .option('-x, --shell [path]', 'skip parsing of tasks for better shell support', false)
   .option(
+    '--diff <gitref>',
+    'Run on files changed on this branch since it forked from <gitref>',
+    null
+  )
+  .option(
     '-v, --verbose',
     'show task output even when tasks succeed; by default only failed output is shown',
     false
@@ -87,6 +92,7 @@ const options = {
   relative: !!cmdlineOptions.relative,
   shell: cmdlineOptions.shell /* Either a boolean or a string pointing to the shell */,
   verbose: !!cmdlineOptions.verbose,
+  diffRef: cmdlineOptions.diff,
 }
 
 debug('Options parsed from command-line:', options)

--- a/lib/getDiffFiles.js
+++ b/lib/getDiffFiles.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const execGit = require('./execGit')
+
+module.exports = async function getDiffFiles(commit, options) {
+  try {
+    // Docs for --diff-filter option: https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---diff-filterACDMRTUXB82308203
+    // Docs for -z option: https://git-scm.com/docs/git-diff#Documentation/git-diff.txt--z
+    const lines = await execGit(
+      ['diff', '--diff-filter=ACMR', '--name-only', '-z', commit + '...'],
+      options
+    )
+    // With `-z`, git prints `fileA\u0000fileB\u0000fileC\u0000` so we need to remove the last occurrence of `\u0000` before splitting
+    // eslint-disable-next-line no-control-regex
+    return lines ? lines.replace(/\u0000$/, '').split('\u0000') : []
+  } catch {
+    return null
+  }
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -61,6 +61,7 @@ const loadConfig = (configPath) => {
  * @param {boolean|string} [options.shell] - Skip parsing of tasks for better shell support
  * @param {boolean} [options.stash] - Enable the backup stash, and revert in case of errors
  * @param {boolean} [options.verbose] - Show task output even when tasks succeed; by default only failed output is shown
+ * @param {string|null} [options.diffRef] - Check using files changed since the current branch forked from this ref instead of the staged files
  * @param {Logger} [logger]
  *
  * @returns {Promise<boolean>} Promise of whether the linting passed or failed
@@ -79,6 +80,7 @@ const lintStaged = async (
     shell = false,
     stash = true,
     verbose = false,
+    diffRef = null,
   } = {},
   logger = console
 ) => {
@@ -129,6 +131,7 @@ const lintStaged = async (
         shell,
         stash,
         verbose,
+        diffRef,
       },
       logger
     )

--- a/lib/runAll.js
+++ b/lib/runAll.js
@@ -10,6 +10,7 @@ const execGit = require('./execGit')
 const generateTasks = require('./generateTasks')
 const getRenderer = require('./getRenderer')
 const getStagedFiles = require('./getStagedFiles')
+const getDiffFiles = require('./getDiffFiles')
 const GitWorkflow = require('./gitWorkflow')
 const makeCmdTasks = require('./makeCmdTasks')
 const {
@@ -51,6 +52,7 @@ const createError = (ctx) => Object.assign(new Error('lint-staged failed'), { ct
  * @param {boolean} [options.shell] - Skip parsing of tasks for better shell support
  * @param {boolean} [options.stash] - Enable the backup stash, and revert in case of errors
  * @param {boolean} [options.verbose] - Show task output even when tasks succeed; by default only failed output is shown
+ * @param {string|null} [options.diffRef] - Check files which have been changed in merge-base diff since this Git ref
  * @param {Logger} logger
  * @returns {Promise}
  */
@@ -67,12 +69,13 @@ const runAll = async (
     shell = false,
     stash = true,
     verbose = false,
+    diffRef = null,
   },
   logger = console
 ) => {
   debugLog('Running all linter scripts')
 
-  const ctx = getInitialState({ quiet })
+  const ctx = getInitialState({ quiet, diffRef })
 
   const { gitDir, gitConfigDir } = await resolveGitRepo(cwd)
   if (!gitDir) {
@@ -93,13 +96,21 @@ const runAll = async (
     logger.warn(skippingBackup(hasInitialCommit))
   }
 
-  const files = await getStagedFiles({ cwd: gitDir })
+  const getFiles = (options) => {
+    if (ctx.diffRef) {
+      return getDiffFiles(ctx.diffRef, options)
+    } else {
+      return getStagedFiles(options)
+    }
+  }
+
+  const files = await getFiles({ cwd: gitDir })
   if (!files) {
     if (!quiet) ctx.output.push(FAILED_GET_STAGED_FILES)
     ctx.errors.add(GetStagedFilesError)
     throw createError(ctx, GetStagedFilesError)
   }
-  debugLog('Loaded list of staged files in git:\n%O', files)
+  debugLog('Loaded list of files in git:\n%O', files)
 
   // If there are no files avoid executing any lint-staged logic
   if (files.length === 0) {

--- a/lib/runAll.js
+++ b/lib/runAll.js
@@ -91,8 +91,9 @@ const runAll = async (
     .catch(() => false)
 
   // Lint-staged should create a backup stash only when there's an initial commit
-  ctx.shouldBackup = hasInitialCommit && stash
-  if (!ctx.shouldBackup) {
+  // and we're not running a branch diff
+  ctx.shouldBackup = hasInitialCommit && stash && !ctx.diffRef
+  if (!ctx.shouldBackup && !ctx.diffRef) {
     logger.warn(skippingBackup(hasInitialCommit))
   }
 
@@ -218,6 +219,14 @@ const runAll = async (
 
   const git = new GitWorkflow({ allowEmpty, gitConfigDir, gitDir, matchedFileChunks })
 
+  if (!ctx.diffRef) {
+    listrTasks.push({
+      title: 'Applying modifications...',
+      task: (ctx) => git.applyModifications(ctx),
+      skip: applyModificationsSkipped,
+    })
+  }
+
   const runner = new Listr(
     [
       {
@@ -230,11 +239,6 @@ const runAll = async (
         enabled: hasPartiallyStagedFiles,
       },
       ...listrTasks,
-      {
-        title: 'Applying modifications...',
-        task: (ctx) => git.applyModifications(ctx),
-        skip: applyModificationsSkipped,
-      },
       {
         title: 'Restoring unstaged changes to partially staged files...',
         task: (ctx) => git.restoreUnstagedChanges(ctx),

--- a/lib/state.js
+++ b/lib/state.js
@@ -9,12 +9,13 @@ const {
   RestoreUnstagedChangesError,
 } = require('./symbols')
 
-const getInitialState = ({ quiet = false } = {}) => ({
+const getInitialState = ({ quiet = false, diffRef = null } = {}) => ({
   hasPartiallyStagedFiles: null,
   shouldBackup: null,
   errors: new Set([]),
   output: [],
   quiet,
+  diffRef,
 })
 
 const hasPartiallyStagedFiles = (ctx) => ctx.hasPartiallyStagedFiles

--- a/test/getDiffFiles.spec.js
+++ b/test/getDiffFiles.spec.js
@@ -1,0 +1,26 @@
+import getDiffFiles from '../lib/getDiffFiles'
+import execGit from '../lib/execGit'
+
+jest.mock('../lib/execGit')
+
+describe('getDiffFiles', () => {
+  it('should return array of file names', async () => {
+    execGit.mockImplementationOnce(async () => 'foo.js\u0000bar.js\u0000')
+    const staged = await getDiffFiles()
+    expect(staged).toEqual(['foo.js', 'bar.js'])
+  })
+
+  it('should return empty array when no staged files', async () => {
+    execGit.mockImplementationOnce(async () => '')
+    const staged = await getDiffFiles()
+    expect(staged).toEqual([])
+  })
+
+  it('should return null in case of error', async () => {
+    execGit.mockImplementationOnce(async () => {
+      throw new Error('fatal: not a git repository (or any of the parent directories): .git')
+    })
+    const staged = await getDiffFiles()
+    expect(staged).toEqual(null)
+  })
+})

--- a/test/gitWorkflow.spec.js
+++ b/test/gitWorkflow.spec.js
@@ -67,6 +67,7 @@ describe('gitWorkflow', () => {
       )
       expect(ctx).toMatchInlineSnapshot(`
         Object {
+          "diffRef": null,
           "errors": Set {
             Symbol(GitError),
           },
@@ -91,6 +92,7 @@ describe('gitWorkflow', () => {
       )
       expect(ctx).toMatchInlineSnapshot(`
         Object {
+          "diffRef": null,
           "errors": Set {
             Symbol(GetBackupStashError),
             Symbol(GitError),
@@ -153,6 +155,7 @@ describe('gitWorkflow', () => {
       )
       expect(ctx).toMatchInlineSnapshot(`
         Object {
+          "diffRef": null,
           "errors": Set {
             Symbol(GitError),
             Symbol(HideUnstagedChangesError),
@@ -194,6 +197,7 @@ describe('gitWorkflow', () => {
       )
       expect(ctx).toMatchInlineSnapshot(`
         Object {
+          "diffRef": null,
           "errors": Set {
             Symbol(GitError),
             Symbol(RestoreMergeStatusError),

--- a/test/index2.spec.js
+++ b/test/index2.spec.js
@@ -25,6 +25,7 @@ describe('lintStaged', () => {
     expect(Listr.mock.calls[0][1]).toMatchInlineSnapshot(`
       Object {
         "ctx": Object {
+          "diffRef": null,
           "errors": Set {},
           "hasPartiallyStagedFiles": null,
           "output": Array [],
@@ -51,6 +52,7 @@ describe('lintStaged', () => {
     expect(Listr.mock.calls[0][1]).toMatchInlineSnapshot(`
       Object {
         "ctx": Object {
+          "diffRef": null,
           "errors": Set {},
           "hasPartiallyStagedFiles": null,
           "output": Array [],

--- a/test/resolveTaskFn.spec.js
+++ b/test/resolveTaskFn.spec.js
@@ -237,6 +237,7 @@ describe('resolveTaskFn', () => {
     await expect(taskFn(context)).resolves.toMatchInlineSnapshot(`undefined`)
     expect(context).toMatchInlineSnapshot(`
       Object {
+        "diffRef": null,
         "errors": Set {},
         "hasPartiallyStagedFiles": null,
         "output": Array [],
@@ -263,6 +264,7 @@ describe('resolveTaskFn', () => {
     await expect(taskFn(context)).resolves.toMatchInlineSnapshot(`undefined`)
     expect(context).toMatchInlineSnapshot(`
       Object {
+        "diffRef": null,
         "errors": Set {},
         "hasPartiallyStagedFiles": null,
         "output": Array [
@@ -293,6 +295,7 @@ describe('resolveTaskFn', () => {
     await expect(taskFn(context)).rejects.toThrowErrorMatchingInlineSnapshot(`"mock cmd [1]"`)
     expect(context).toMatchInlineSnapshot(`
       Object {
+        "diffRef": null,
         "errors": Set {
           Symbol(TaskError),
         },
@@ -323,6 +326,7 @@ describe('resolveTaskFn', () => {
     await expect(taskFn(context)).rejects.toThrowErrorMatchingInlineSnapshot(`"mock cmd [1]"`)
     expect(context).toMatchInlineSnapshot(`
       Object {
+        "diffRef": null,
         "errors": Set {
           Symbol(TaskError),
         },

--- a/test/runAll.spec.js
+++ b/test/runAll.spec.js
@@ -40,6 +40,7 @@ describe('runAll', () => {
     expect.assertions(1)
     await expect(runAll({ config: {} })).resolves.toMatchInlineSnapshot(`
             Object {
+              "diffRef": null,
               "errors": Set {},
               "hasPartiallyStagedFiles": null,
               "output": Array [
@@ -55,6 +56,22 @@ describe('runAll', () => {
     expect.assertions(1)
     await expect(runAll({ config: {}, quiet: true })).resolves.toMatchInlineSnapshot(`
             Object {
+              "diffRef": null,
+              "errors": Set {},
+              "hasPartiallyStagedFiles": null,
+              "output": Array [],
+              "quiet": true,
+              "shouldBackup": true,
+            }
+          `)
+  })
+
+  it('should not print output in diff mode when no changes and quiet', async () => {
+    expect.assertions(1)
+    await expect(runAll({ config: {}, quiet: true, diffRef: 'HEAD' })).resolves
+      .toMatchInlineSnapshot(`
+            Object {
+              "diffRef": "HEAD",
               "errors": Set {},
               "hasPartiallyStagedFiles": null,
               "output": Array [],


### PR DESCRIPTION
This makes using lint-staged from CI straightforward: pass `--diff origin/master` when running in CI to check the files which have changed since the current branch forked from `origin/master`.

Including this feature in `lint-staged` allows the same config to be used for both Git hooks and CI checking.

The current alternative involves doing a `git reset --soft`, which would work but puts the checkout in a strange state (i.e., the HEAD commit is no longer the branch tip). If any other CI checks happen to be running in parallel with `lint-staged`, it seems risky to be changing the repo state like that.