### PR TITLE
chore: fix typos in example comments for environment variables

### DIFF
--- a/lib/colors.js
+++ b/lib/colors.js
@@ -2,14 +2,14 @@ import nodeTty from 'node:tty'
 
 /**
  * @example NO_COLOR
- * @exmaple NO_COLOR=1
- * @exmaple NO_COLOR=true
+ * @example NO_COLOR=1
+ * @example NO_COLOR=true
  */
 const TRUTHRY_ENV_VAR_VALUES = ['', '1', 'true']
 
 /**
- * @exmaple FORCE_COLOR=0
- * @exmaple FORCE_COLOR=false
+ * @example FORCE_COLOR=0
+ * @example FORCE_COLOR=false
  */
 const FALSY_ENV_VAR_VALUES = ['0', 'false']
 


### PR DESCRIPTION
The JSDoc present on `colors.js` contained typos for the enum constants.

**Please check all these boxes before opening a Pull Request**

- [X] I have opened a GitHub issue beforehand and have agreed with the maintainer of this project
- [ ] I have written unit, integration and e2e tests that cover the logic in this Pull Request
- [ ] I have updated the [README.md](../README.md) file to reflect the changes in this Pull Request
- [X] I have used the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification in my commit messages
- [ ] I have created a [Changeset](https://github.com/changesets/changesets) file for generating a changelog entry
