### PR TITLE
fix: prefer to spawn from closest `node_modules/.bin`

### DIFF
--- a/.changeset/big-shrimps-bake.md
+++ b/.changeset/big-shrimps-bake.md
@@ -1,0 +1,5 @@
+---
+'lint-staged': patch
+---
+
+Prefer to spawn binaries from closest `node_modules/.bin` before global locations in `PATH`. This matches the behavior of `npm` and previous versions of _lint-staged_, before switching to `tinyexec` in `v16.3.0`.

--- a/lib/getSpawnedTask.js
+++ b/lib/getSpawnedTask.js
@@ -1,3 +1,5 @@
+import path from 'node:path'
+
 import { parseArgsStringToArgv } from 'string-argv'
 import { exec } from 'tinyexec'
 
@@ -10,6 +12,24 @@ import { getInitialState } from './state.js'
 import { TaskError } from './symbols.js'
 
 const debugLog = createDebug('lint-staged:getSpawnedTask')
+
+export const getTaskEnv = ({ color, cwd = process.cwd(), env = process.env }) => {
+  const nodeModulesBinPaths = []
+
+  let current = cwd
+  let previous
+  do {
+    nodeModulesBinPaths.push(path.resolve(current, 'node_modules', '.bin'))
+    previous = current
+    current = path.dirname(current)
+  } while (current !== previous) // stop at root
+
+  const taskEnv = color ? { FORCE_COLOR: 'true' } : { NO_COLOR: 'true' }
+
+  taskEnv.PATH = nodeModulesBinPaths.join(':') + (env.PATH ? `:${env.PATH}` : '')
+
+  return taskEnv
+}
 
 /**
  * Handle task console output.
@@ -90,7 +110,7 @@ export const getSpawnedTask = ({
       // Only use topLevelDir as CWD if we are using the git binary
       // e.g `npm` should run tasks in the actual CWD
       cwd: /^git(\.exe)?/i.test(cmd) ? topLevelDir : cwd,
-      env: color ? { FORCE_COLOR: 'true' } : { NO_COLOR: 'true' },
+      env: getTaskEnv({ color, cwd }),
       stdio: ['ignore'],
     },
   }

--- a/test/unit/getSpawnedTask.spec.js
+++ b/test/unit/getSpawnedTask.spec.js
@@ -1,3 +1,5 @@
+import path from 'node:path'
+
 import { exec } from 'tinyexec'
 import { beforeEach, describe, it, vi } from 'vitest'
 
@@ -14,7 +16,7 @@ vi.mock('tinyexec', () => ({
   }),
 }))
 
-const { getSpawnedTask } = await import('../../lib/getSpawnedTask.js')
+const { getSpawnedTask, getTaskEnv } = await import('../../lib/getSpawnedTask.js')
 
 vi.useFakeTimers()
 
@@ -31,25 +33,6 @@ describe('getSpawnedTask', () => {
     vi.clearAllMocks()
   })
 
-  it('should pass FORCE_COLOR var to task when color supported', async ({ expect }) => {
-    expect.assertions(2)
-    const taskFn = getSpawnedTask({
-      ...defaultOpts,
-      command: 'node --arg=true ./myscript.js',
-      color: true,
-    })
-
-    await taskFn()
-    expect(exec).toHaveBeenCalledTimes(1)
-    expect(exec).toHaveBeenLastCalledWith('node', ['--arg=true', './myscript.js', 'test.js'], {
-      nodeOptions: {
-        cwd: process.cwd(),
-        stdio: ['ignore'],
-        env: { FORCE_COLOR: 'true' },
-      },
-    })
-  })
-
   it('should support non npm scripts', async ({ expect }) => {
     expect.assertions(2)
     const taskFn = getSpawnedTask({
@@ -63,7 +46,7 @@ describe('getSpawnedTask', () => {
       nodeOptions: {
         cwd: process.cwd(),
         stdio: ['ignore'],
-        env: { NO_COLOR: 'true' },
+        env: expect.objectContaining({ NO_COLOR: 'true' }),
       },
     })
   })
@@ -78,13 +61,11 @@ describe('getSpawnedTask', () => {
 
     await taskFn()
     expect(exec).toHaveBeenCalledTimes(1)
-    expect(exec).toHaveBeenLastCalledWith('node', ['--arg=true', './myscript.js', 'test.js'], {
-      nodeOptions: {
-        cwd: process.cwd(),
-        stdio: ['ignore'],
-        env: { NO_COLOR: 'true' },
-      },
-    })
+    expect(exec).toHaveBeenLastCalledWith(
+      'node',
+      ['--arg=true', './myscript.js', 'test.js'],
+      expect.any(Object)
+    )
   })
 
   it('should pass `topLevelDir` as `cwd` to `spawn()` topLevelDir !== process.cwd for git commands', async ({
@@ -100,11 +81,9 @@ describe('getSpawnedTask', () => {
     await taskFn()
     expect(exec).toHaveBeenCalledTimes(1)
     expect(exec).toHaveBeenLastCalledWith('git', ['diff', 'test.js'], {
-      nodeOptions: {
+      nodeOptions: expect.objectContaining({
         cwd: '../',
-        stdio: ['ignore'],
-        env: { NO_COLOR: 'true' },
-      },
+      }),
     })
   })
 
@@ -117,11 +96,9 @@ describe('getSpawnedTask', () => {
     await taskFn()
     expect(exec).toHaveBeenCalledTimes(1)
     expect(exec).toHaveBeenLastCalledWith('jest', ['test.js'], {
-      nodeOptions: {
+      nodeOptions: expect.objectContaining({
         cwd: process.cwd(),
-        stdio: ['ignore'],
-        env: { NO_COLOR: 'true' },
-      },
+      }),
     })
   })
 
@@ -339,5 +316,56 @@ describe('getSpawnedTask', () => {
     await expect(() => taskFn()).rejects.toThrow('node [FAILED]')
 
     expect(abortController.signal.aborted).toBe(false)
+  })
+})
+
+describe('getTaskEnv', () => {
+  it('should add FORCE_COLOR=true to env when color enablef', ({ expect }) => {
+    const env = getTaskEnv({ color: true })
+    expect(env).toHaveProperty('FORCE_COLOR', 'true')
+    expect(env).not.toHaveProperty('NO_COLOR')
+  })
+
+  it('should add NO_COLOR=true to env when color disabled', ({ expect }) => {
+    const env = getTaskEnv({ color: false })
+    expect(env).toHaveProperty('NO_COLOR', 'true')
+    expect(env).not.toHaveProperty('FORCE_COLOR')
+  })
+
+  it('should prepend all node_modules/.bin to PATH', ({ expect }) => {
+    const PATH = path.join(path.sep, 'usr', 'local', 'bin')
+
+    const env = getTaskEnv({
+      env: { PATH },
+      cwd: path.join(path.sep, 'one', 'two', 'three'),
+    })
+
+    expect(env).toHaveProperty(
+      'PATH',
+      [
+        path.join(path.sep, 'one', 'two', 'three', 'node_modules', '.bin'),
+        path.join(path.sep, 'one', 'two', 'node_modules', '.bin'),
+        path.join(path.sep, 'one', 'node_modules', '.bin'),
+        path.join(path.sep, 'node_modules', '.bin'),
+        PATH,
+      ].join(':')
+    )
+  })
+
+  it('should format previously missing PATH correctly', ({ expect }) => {
+    const env = getTaskEnv({
+      env: {},
+      cwd: path.join(path.sep, 'one', 'two', 'three'),
+    })
+
+    expect(env).toHaveProperty(
+      'PATH',
+      [
+        path.join(path.sep, 'one', 'two', 'three', 'node_modules', '.bin'),
+        path.join(path.sep, 'one', 'two', 'node_modules', '.bin'),
+        path.join(path.sep, 'one', 'node_modules', '.bin'),
+        path.join(path.sep, 'node_modules', '.bin'),
+      ].join(':')
+    )
   })
 })

--- a/test/unit/getSpawnedTasks.spec.js
+++ b/test/unit/getSpawnedTasks.spec.js
@@ -65,24 +65,12 @@ describe('getSpawnedTasks', () => {
     expect(taskPromise).toBeInstanceOf(Promise)
     await taskPromise
     expect(exec).toHaveBeenCalledTimes(1)
-    expect(exec).toHaveBeenLastCalledWith('test', ['test.js'], {
-      nodeOptions: {
-        cwd: process.cwd(),
-        stdio: ['ignore'],
-        env: { NO_COLOR: 'true' },
-      },
-    })
+    expect(exec).toHaveBeenLastCalledWith('test', ['test.js'], expect.any(Object))
     taskPromise = linter2.task()
     expect(taskPromise).toBeInstanceOf(Promise)
     await taskPromise
     expect(exec).toHaveBeenCalledTimes(2)
-    expect(exec).toHaveBeenLastCalledWith('test2', ['test.js'], {
-      nodeOptions: {
-        cwd: process.cwd(),
-        stdio: ['ignore'],
-        env: { NO_COLOR: 'true' },
-      },
-    })
+    expect(exec).toHaveBeenLastCalledWith('test2', ['test.js'], expect.any(Object))
   })
 
   it('should work with function task returning a string', async ({ expect }) => {


### PR DESCRIPTION
Behavior of preferring local node_modules to globally installed ones was flipped in `v16.3.0` with the change from `nano-spawn` to `tinyexec`. This PR restores it by manually prefixing `PATH`. Marked as draft for a while because this could also be directly implemented in `tinyexec` (ref. https://github.com/tinylibs/tinyexec/issues/86)