### PR TITLE
ci: use personal access token with semantic-release so that it can trigger publish workflow

### DIFF
--- a/.changeset/odd-kids-ask.md
+++ b/.changeset/odd-kids-ask.md
@@ -1,0 +1,5 @@
+---
+'lint-staged': patch
+---
+
+Adjust GitHub Actions workflow so that automatic publishing works with signed commits.

--- a/.github/workflows/default-branch-push.yml
+++ b/.github/workflows/default-branch-push.yml
@@ -26,12 +26,6 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # https://github.com/actions/checkout/releases/tag/v6.0.2
-        with:
-          # Fine-grained access token to allow triggering of new workflows when 🦋 Changeset pushes a git tag
-          # Required permissions:
-          # - Contents (read/write)
-          # - Pull Requests (read/write)
-          token: ${{ secrets.CHANGESET_RELEASE_TOKEN }}
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # https://github.com/actions/setup-node/releases/tag/v6.4.0
         with:
@@ -60,5 +54,9 @@ jobs:
           commitMode: github-api # Sign commits and tags
           commit: 'chore(changeset): release'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Fine-grained access token to allow triggering of new workflows when 🦋 Changeset pushes a git tag
+          # Required permissions:
+          # - Contents (read/write)
+          # - Pull Requests (read/write)
+          GITHUB_TOKEN: ${{ secrets.CHANGESET_RELEASE_TOKEN }}
           HUSKY: '0' # disabled because pre-push hook checks for changesets which have now been removed


### PR DESCRIPTION
I had to manually recreate the [v17.0.0](https://github.com/lint-staged/lint-staged/releases/tag/v17.0.0) release by deleting the Git tag and pushing it locally. This is probably because I switched the Changesets action to use the `github-api`, and the actions can't create new actions unless a PAT is used.