### PR TITLE
perf: go back to using `git add` when staging changes from tasks

### DIFF
--- a/.changeset/bumpy-nights-clap.md
+++ b/.changeset/bumpy-nights-clap.md
@@ -1,0 +1,5 @@
+---
+'lint-staged': patch
+---
+
+Fix performance regression of _lint-staged_ v17 by going back to using `git add` to stage task modifications. This was changed to `git update-index --again` in v17 for less manual work, but unfortunately the `update-index` command gets slower in very large Git repos.

--- a/lib/gitWorkflow.js
+++ b/lib/gitWorkflow.js
@@ -1,4 +1,5 @@
 import crypto from 'node:crypto'
+import fs from 'node:fs/promises'
 import path from 'node:path'
 
 import { createDebug } from './debug.js'
@@ -80,13 +81,23 @@ export class GitWorkflow {
   /**
    * @param {Object} opts
    */
-  constructor({ allowEmpty, diff, diffFilter, failOnChanges, gitConfigDir, topLevelDir }) {
+  constructor({
+    allowEmpty,
+    diff,
+    diffFilter,
+    failOnChanges,
+    gitConfigDir,
+    matchedFileChunks,
+    topLevelDir,
+  }) {
     this.execGit = (args, options = {}) => execGit(args, { ...options, cwd: topLevelDir })
     this.allowEmpty = allowEmpty
     this.diff = diff
     this.diffFilter = diffFilter
     this.gitConfigDir = gitConfigDir
     this.failOnChanges = !!failOnChanges
+    /** @type {import('./getStagedFiles.js').StagedFile[][]} */
+    this.matchedFileChunks = matchedFileChunks
     this.topLevelDir = topLevelDir
 
     /**
@@ -299,30 +310,46 @@ export class GitWorkflow {
       ? normalizePath(process.env.GIT_INDEX_FILE)
       : process.env.GIT_INDEX_FILE
 
-    debugLog('Updating active Git index again: %s', activeIndexFile)
-    await this.execGit(['update-index', '--again'])
-    debugLog('Done updating Git index again: %s', activeIndexFile)
-
-    if (activeIndexFile?.endsWith('.lock')) {
-      const defaultIndexLock = normalizePath(
-        await this.execGit(['rev-parse', '--path-format=absolute', '--git-path', 'index.lock'])
+    /** Needs to be run serially because of locking Git operation */
+    for (const files of this.matchedFileChunks) {
+      const accessCheckedFiles = await Promise.allSettled(
+        files.map(async (f) => {
+          if (f.status === 'D') {
+            await fs.access(f.filepath)
+            return f.filepath // File is no longer deleted and can be added
+          } else {
+            return f.filepath
+          }
+        })
       )
 
-      /**
-       * If the active index file is a non-default lockfile, we are committing with a pathspec
-       * without having explicitly run `git add`. In this case we need to also update the
-       * default index, otherwise there will be leftover diff after committing
-       */
-      if (activeIndexFile !== defaultIndexLock) {
-        debugLog('Updating default Git index lock again: %s', defaultIndexLock)
+      const addableFiles = accessCheckedFiles.flatMap((r) =>
+        r.status === 'fulfilled' ? [r.value] : []
+      )
 
-        await this.execGit(['update-index', '--again'], {
-          env: {
-            GIT_INDEX_FILE: defaultIndexLock,
-          },
-        })
+      debugLog('Updating active Git index: %s', activeIndexFile)
+      await this.execGit(['add', '--', ...addableFiles])
+      debugLog('Done updating Git index: %s', activeIndexFile)
 
-        debugLog('Done updating default Git index lock again: %s', defaultIndexLock)
+      if (activeIndexFile?.endsWith('.lock')) {
+        const defaultIndexLock = normalizePath(
+          await this.execGit(['rev-parse', '--path-format=absolute', '--git-path', 'index.lock'])
+        )
+
+        /**
+         * If the active index file is a non-default lockfile, we are committing with a pathspec
+         * without having explicitly run `git add`. In this case we need to also update the
+         * default index, otherwise there will be leftover diff after committing
+         */
+        if (activeIndexFile !== defaultIndexLock) {
+          debugLog('Updating default Git index again: %s', defaultIndexLock)
+          await this.execGit(['add', '--', ...addableFiles], {
+            env: {
+              GIT_INDEX_FILE: defaultIndexLock,
+            },
+          })
+          debugLog('Done updating default Git index lock: %s', defaultIndexLock)
+        }
       }
     }
 

--- a/lib/runAll.js
+++ b/lib/runAll.js
@@ -302,12 +302,23 @@ export const runAll = async (
     return ctx
   }
 
+  // Chunk matched files for better Windows compatibility
+  /** @type {import('./getStagedFiles.js').StagedFile[][]} */
+  const matchedFileChunks = chunkFiles({
+    // matched files are relative to `cwd`, not `topLevelDir`, when `relative` is used
+    baseDir: cwd,
+    files: Array.from(matchedFiles),
+    maxArgLength,
+    relative: false,
+  })
+
   const git = new GitWorkflow({
     allowEmpty,
     diff,
     diffFilter,
     failOnChanges,
     gitConfigDir,
+    matchedFileChunks,
     topLevelDir,
   })
 
@@ -328,7 +339,7 @@ export const runAll = async (
         skip: () => listrTasks.every((task) => task.skip()),
       },
       {
-        title: 'Updating Git index again...',
+        title: 'Staging changes from tasks...',
         task: (ctx) => git.updateIndex(ctx),
         skip: updateIndexSkipped,
       },

--- a/test/integration/gitWorkFlow.test.js
+++ b/test/integration/gitWorkFlow.test.js
@@ -204,6 +204,7 @@ describe('gitWorkflow', () => {
         const gitWorkflow = new GitWorkflow({
           topLevelDir: cwd,
           gitConfigDir: path.join(cwd, './.git'),
+          matchedFileChunks: [[]],
         })
         const ctx = getInitialState()
 
@@ -228,6 +229,7 @@ describe('gitWorkflow', () => {
         const gitWorkflow = new GitWorkflow({
           topLevelDir: cwd,
           gitConfigDir: path.join(cwd, './.git'),
+          matchedFileChunks: [[]],
         })
         const ctx = getInitialState()
 
@@ -245,6 +247,7 @@ describe('gitWorkflow', () => {
         const gitWorkflow = new GitWorkflow({
           topLevelDir: cwd,
           gitConfigDir: path.join(cwd, './.git'),
+          matchedFileChunks: [[]],
         })
 
         gitWorkflow.mergeHeadBuffer = true
@@ -268,6 +271,7 @@ describe('gitWorkflow', () => {
         const gitWorkflow = new GitWorkflow({
           topLevelDir: cwd,
           gitConfigDir: path.join(cwd, './.git'),
+          matchedFileChunks: [[]],
         })
 
         const ctx = getInitialState()

--- a/test/integration/partially-staged-changes.test.js
+++ b/test/integration/partially-staged-changes.test.js
@@ -25,7 +25,7 @@ describe('lint-staged', () => {
       const output = await gitCommit()
 
       expect(output).toMatch('Hiding unstaged changes to partially staged files...')
-      expect(output).toMatch('Updating Git index again...')
+      expect(output).toMatch('Staging changes from tasks...')
       expect(output).toMatch('Restoring unstaged changes...')
 
       // Nothing is wrong, so a new commit is created and file is pretty

--- a/test/unit/runAll.spec.js
+++ b/test/unit/runAll.spec.js
@@ -188,7 +188,7 @@ describe('runAll', () => {
 
     await expect(runAll({})).rejects.toThrow('lint-staged failed')
 
-    expect(console.printHistory()).toMatch(/"data":"SKIPPED".*Updating Git index again/)
+    expect(console.printHistory()).toMatch(/"data":"SKIPPED".*Staging changes from tasks/)
   })
 
   it('should skip tasks and restore state if terminated', async ({ expect }) => {


### PR DESCRIPTION
Fix performance regression of _lint-staged_ v17 by going back to using `git add` to stage task modifications. This was changed to `git update-index --again` in v17 for less manual work, but unfortunately the `update-index` command gets slower in very large Git repos.
